### PR TITLE
ci: add dev to push.branches in contract/core/panel

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,7 +1,7 @@
 name: contract
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths: ["theia-core/**", "theia-panel/**", "schemas/**", "examples/**"]
   pull_request:
     paths: ["theia-core/**", "theia-panel/**", "schemas/**", "examples/**"]

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,7 +1,7 @@
 name: core
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths: ["theia-core/**", "schemas/**", ".github/workflows/core.yml"]
   pull_request:
     paths: ["theia-core/**", "schemas/**", ".github/workflows/core.yml"]

--- a/.github/workflows/panel.yml
+++ b/.github/workflows/panel.yml
@@ -1,7 +1,7 @@
 name: panel
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
     paths: ["theia-panel/**", "schemas/**", ".github/workflows/panel.yml"]
   pull_request:
     paths: ["theia-panel/**", "schemas/**", ".github/workflows/panel.yml"]


### PR DESCRIPTION
## Summary
- Adds `dev` alongside `main` in `push.branches` for `contract.yml`, `core.yml`, and `panel.yml`.
- PR triggers are untouched (no branch filter), so PRs targeting `dev` or `main` continue to run CI.

## Why
Part of the main + dev branching setup:
- `main` = stable tip (what Hermes pins to)
- `dev` = integration branch (features PR into here)

Without this change, direct pushes to `dev` (merge-backs from main, hotfixes, release prep) would silently skip CI.

## Test plan
- [x] Workflow YAML lints locally (single-line branch list edit)
- [ ] PR runs `contract`/`core`/`panel` via `pull_request:` trigger — should all pass since no source code changed
- [ ] After merge, push a no-op commit to `dev` and confirm CI fires