### PR TITLE
feat(panel): node summaries, search bar, richer edges + review fixes

### DIFF
--- a/examples/graph.json
+++ b/examples/graph.json
@@ -1,9 +1,9 @@
 {
   "meta": {
-    "generated_at": "2026-04-21T15:12:16.314028Z",
+    "generated_at": "2026-04-22T22:07:00.633082Z",
     "source_count": 3,
-    "projection": "pca",
-    "feature_dim": 4
+    "projection": "umap",
+    "feature_dim": 5
   },
   "nodes": [
     {
@@ -11,12 +11,14 @@
       "title": "Alpha \u2014 writes auth memory",
       "started_at": "2026-04-18T09:00:00Z",
       "duration_sec": 1000.0,
-      "tool_count": 3,
+      "tool_count": 4,
       "message_count": 50,
       "model": "claude-opus-4-7",
+      "summary": "Designed the authentication middleware architecture and stored it in persistent memory. Covered JWT token validation, refresh flows, and middleware integration patterns.",
+      "initial_prompt": null,
       "position": {
-        "x": 5.263409943150801e-16,
-        "y": 0.5029945449101046
+        "x": 0.19980697827081964,
+        "y": 0.40134980674379
       },
       "features": null
     },
@@ -28,9 +30,11 @@
       "tool_count": 2,
       "message_count": 32,
       "model": "claude-opus-4-7",
+      "summary": null,
+      "initial_prompt": "I need to implement auth middleware for our API. Can you help me understand the best approach for JWT validation and refresh token handling?",
       "position": {
-        "x": -0.9678580071207084,
-        "y": -0.25149727245505216
+        "x": -0.9910909253370497,
+        "y": -0.13318700279888648
       },
       "features": null
     },
@@ -39,12 +43,14 @@
       "title": "Gamma \u2014 overlaps tools only",
       "started_at": "2026-04-18T14:00:00Z",
       "duration_sec": 600.0,
-      "tool_count": 3,
+      "tool_count": 4,
       "message_count": 20,
       "model": "claude-opus-4-7",
+      "summary": null,
+      "initial_prompt": null,
       "position": {
-        "x": 0.9678580071207077,
-        "y": -0.25149727245505255
+        "x": 0.79128394706623,
+        "y": -0.2681628039449035
       },
       "features": null
     }
@@ -54,11 +60,9 @@
       "source": "sess_alpha",
       "target": "sess_beta",
       "kind": "memory-share",
-      "weight": 1.0,
+      "weight": 0.9,
       "evidence": {
-        "memory_id": "mem_auth_design",
-        "read_count": 2,
-        "salience": 0.9
+        "memory_id": "mem_auth_design"
       }
     },
     {
@@ -74,42 +78,11 @@
     },
     {
       "source": "sess_alpha",
-      "target": "sess_beta",
-      "kind": "tool-overlap",
-      "weight": 0.6666666666666666,
-      "evidence": {
-        "jaccard": 0.6666666666666666,
-        "shared_tools": [
-          "edit",
-          "read"
-        ]
-      }
-    },
-    {
-      "source": "sess_alpha",
       "target": "sess_gamma",
       "kind": "tool-overlap",
       "weight": 1.0,
       "evidence": {
-        "jaccard": 1.0,
-        "shared_tools": [
-          "bash",
-          "edit",
-          "read"
-        ]
-      }
-    },
-    {
-      "source": "sess_beta",
-      "target": "sess_gamma",
-      "kind": "tool-overlap",
-      "weight": 0.6666666666666666,
-      "evidence": {
-        "jaccard": 0.6666666666666666,
-        "shared_tools": [
-          "edit",
-          "read"
-        ]
+        "web_key": "search:rust async patterns"
       }
     }
   ]

--- a/examples/sessions/sess_alpha.json
+++ b/examples/sessions/sess_alpha.json
@@ -1,11 +1,17 @@
 {
   "id": "sess_alpha",
   "title": "Alpha — writes auth memory",
+  "summary": "Designed the authentication middleware architecture and stored it in persistent memory. Covered JWT token validation, refresh flows, and middleware integration patterns.",
   "started_at": "2026-04-18T09:00:00Z",
   "duration_sec": 1000,
   "model": "claude-opus-4-7",
   "message_count": 50,
-  "tool_calls": [{"name": "read"}, {"name": "edit"}, {"name": "bash"}],
+  "tool_calls": [
+    {"name": "read"},
+    {"name": "edit"},
+    {"name": "bash"},
+    {"name": "web_search", "function": {"name": "web_search", "arguments": "{\"query\": \"rust async patterns\"}"}}
+  ],
   "memory_events": [
     {"kind": "write", "memory_id": "mem_auth_design", "salience": 0.9}
   ],

--- a/examples/sessions/sess_beta.json
+++ b/examples/sessions/sess_beta.json
@@ -1,14 +1,14 @@
 {
   "id": "sess_beta",
   "title": "Beta — reads auth memory",
+  "initial_prompt": "I need to implement auth middleware for our API. Can you help me understand the best approach for JWT validation and refresh token handling?",
   "started_at": "2026-04-18T11:00:00Z",
   "duration_sec": 800,
   "model": "claude-opus-4-7",
   "message_count": 32,
   "tool_calls": [{"name": "read"}, {"name": "edit"}],
   "memory_events": [
-    {"kind": "read", "memory_id": "mem_auth_design"},
-    {"kind": "read", "memory_id": "mem_auth_design"}
+    {"kind": "write", "memory_id": "mem_auth_design", "salience": 0.7}
   ],
   "search_hits": [
     {"query": "auth middleware", "source_session_id": "sess_alpha", "hit_rank": 1}

--- a/examples/sessions/sess_gamma.json
+++ b/examples/sessions/sess_gamma.json
@@ -5,7 +5,12 @@
   "duration_sec": 600,
   "model": "claude-opus-4-7",
   "message_count": 20,
-  "tool_calls": [{"name": "read"}, {"name": "edit"}, {"name": "bash"}],
+  "tool_calls": [
+    {"name": "read"},
+    {"name": "edit"},
+    {"name": "bash"},
+    {"name": "web_search", "function": {"name": "web_search", "arguments": "{\"query\": \"rust async patterns\"}"}}
+  ],
   "memory_events": [],
   "search_hits": []
 }

--- a/schemas/graph.schema.json
+++ b/schemas/graph.schema.json
@@ -31,6 +31,8 @@
           "tool_count": { "type": "integer", "minimum": 0 },
           "message_count": { "type": "integer", "minimum": 0 },
           "model": { "type": "string" },
+          "summary": { "type": ["string", "null"] },
+          "initial_prompt": { "type": ["string", "null"] },
           "position": {
             "type": "object",
             "required": ["x", "y"],

--- a/theia-core/theia_core/emit.py
+++ b/theia-core/theia_core/emit.py
@@ -14,6 +14,32 @@ from theia_core.ingest import Session
 SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "graph.schema.json"
 
 
+def _extract_summary(sess: Session) -> str | None:
+    raw = sess.raw
+    if not raw:
+        return None
+    if "summary" in raw and isinstance(raw["summary"], str):
+        return raw["summary"]
+    return None
+
+
+def _extract_initial_prompt(sess: Session) -> str | None:
+    raw = sess.raw
+    if not raw:
+        return None
+    # Check explicit field first
+    if "initial_prompt" in raw and isinstance(raw["initial_prompt"], str):
+        return raw["initial_prompt"]
+    # Fallback: first user message content in messages array
+    messages = raw.get("messages", [])
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "user":
+            content = msg.get("content", "")
+            if isinstance(content, str) and content.strip():
+                return content.strip()
+    return None
+
+
 def _load_validator() -> Draft202012Validator:
     schema = json.loads(SCHEMA_PATH.read_text())
     return Draft202012Validator(schema)
@@ -38,6 +64,8 @@ def build_graph(
                 "tool_count": len(sess.tool_calls),
                 "message_count": sess.message_count,
                 "model": sess.model,
+                "summary": _extract_summary(sess),
+                "initial_prompt": _extract_initial_prompt(sess),
                 "position": {"x": float(x), "y": float(y)},
                 "features": None,
             }

--- a/theia-panel/src/data/types.ts
+++ b/theia-panel/src/data/types.ts
@@ -20,8 +20,8 @@ export interface TheiaGraph {
     tool_count: number;
     message_count?: number;
     model?: string;
-    summary?: string;
-    initial_prompt?: string;
+    summary?: string | null;
+    initial_prompt?: string | null;
     position: {
       x: number;
       y: number;

--- a/theia-panel/src/data/types.ts
+++ b/theia-panel/src/data/types.ts
@@ -20,6 +20,8 @@ export interface TheiaGraph {
     tool_count: number;
     message_count?: number;
     model?: string;
+    summary?: string;
+    initial_prompt?: string;
     position: {
       x: number;
       y: number;

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -10,6 +10,7 @@ import { createPicker } from "./scene/Picker";
 import { createTooltip } from "./ui/Tooltip";
 import { createFilterBar } from "./ui/FilterBar";
 import { createSidePanel } from "./ui/SidePanel";
+import { createSearchBar } from "./ui/SearchBar";
 
 export interface PanelOptions {
   edgeKinds?: TheiaGraph["edges"][number]["kind"][];
@@ -165,6 +166,19 @@ export async function mount(
     { passive: false },
   );
 
+  // Search bar
+  const searchBar = createSearchBar(element, graph, (result) => {
+    const idx = nodeIndex.get(result.node.id);
+    if (idx !== undefined) {
+      const sn = simNodes[idx]!;
+      ctx.focusOn(sn.x, sn.y, 1.5);
+    }
+    const related = graph.edges.filter(
+      (e) => e.source === result.node.id || e.target === result.node.id,
+    );
+    sidePanel.show(result.node, related);
+  });
+
   // Filter bar
   const filterBar = createFilterBar(element, kinds, (newKinds) => {
     kinds = newKinds;
@@ -198,6 +212,7 @@ export async function mount(
       picker.dispose();
       sidePanel.dispose();
       filterBar.dispose();
+      searchBar.dispose();
     },
     on(event, handler) {
       (listeners[event] ??= []).push(handler as never);

--- a/theia-panel/src/scene/Scene.ts
+++ b/theia-panel/src/scene/Scene.ts
@@ -17,7 +17,7 @@ export function createScene(container: HTMLElement): SceneContext {
   const scene = new THREE.Scene();
 
   const { clientWidth: w, clientHeight: h } = container;
-  const aspect = w / h;
+  let aspect = w / h;
   const baseSize = 2.0; // visible window = larger to accommodate spread
   const camera = new THREE.OrthographicCamera(
     -baseSize * aspect,
@@ -51,14 +51,8 @@ export function createScene(container: HTMLElement): SceneContext {
 
   const resize = () => {
     const { clientWidth: w2, clientHeight: h2 } = container;
-    const a = w2 / h2;
-    // Update aspect ratio but keep current zoom/pan
-    const s = baseSize / zoom;
-    camera.left = -s * a + panX;
-    camera.right = s * a + panX;
-    camera.top = s + panY;
-    camera.bottom = -s + panY;
-    camera.updateProjectionMatrix();
+    aspect = w2 / h2;
+    apply();
     renderer.setSize(w2, h2, false);
   };
 
@@ -108,6 +102,7 @@ export function createScene(container: HTMLElement): SceneContext {
     },
     resize,
     dispose() {
+      if (rafId !== null) cancelAnimationFrame(rafId);
       ro.disconnect();
       renderer.dispose();
       container.removeChild(renderer.domElement);

--- a/theia-panel/src/scene/Scene.ts
+++ b/theia-panel/src/scene/Scene.ts
@@ -6,6 +6,7 @@ export interface SceneContext {
   renderer: THREE.WebGLRenderer;
   container: HTMLElement;
   pan(dx: number, dy: number): void;
+  focusOn(x: number, y: number, targetZoom?: number): void;
   setZoom(z: number): void;
   getZoom(): number;
   dispose(): void;
@@ -37,6 +38,7 @@ export function createScene(container: HTMLElement): SceneContext {
   let zoom = 1;
   let panX = 0;
   let panY = 0;
+  let rafId: number | null = null;
 
   function apply() {
     const s = baseSize / zoom;
@@ -72,6 +74,30 @@ export function createScene(container: HTMLElement): SceneContext {
       panX += dxWorld;
       panY += dyWorld;
       apply();
+    },
+    focusOn(x: number, y: number, targetZoom?: number) {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      const startPanX = panX;
+      const startPanY = panY;
+      const startZoom = zoom;
+      const endZoom = targetZoom ?? zoom;
+      const startTime = performance.now();
+      const duration = 700;
+
+      function step(now: number) {
+        const t = Math.min(1, (now - startTime) / duration);
+        const ease = 1 - Math.pow(1 - t, 3);
+        panX = startPanX + (x - startPanX) * ease;
+        panY = startPanY + (y - startPanY) * ease;
+        zoom = startZoom + (endZoom - startZoom) * ease;
+        apply();
+        if (t < 1) {
+          rafId = requestAnimationFrame(step);
+        } else {
+          rafId = null;
+        }
+      }
+      rafId = requestAnimationFrame(step);
     },
     setZoom(z) {
       zoom = Math.max(0.05, z);

--- a/theia-panel/src/ui/SearchBar.ts
+++ b/theia-panel/src/ui/SearchBar.ts
@@ -1,0 +1,140 @@
+import type { TheiaGraph } from "../data/types";
+import { escape } from "./utils";
+
+export interface SearchResult {
+  node: TheiaGraph["nodes"][number];
+  index: number;
+}
+
+export function createSearchBar(
+  container: HTMLElement,
+  graph: TheiaGraph,
+  onFocus: (result: SearchResult) => void,
+) {
+  const wrapper = document.createElement("div");
+  wrapper.style.cssText = `
+    position: absolute; top: 12px; left: 50%; transform: translateX(-50%);
+    z-index: 10; font: 13px/1.4 ui-monospace, monospace;
+    color: #cfd6e4; width: min(320px, 50vw);
+  `;
+
+  const input = document.createElement("input");
+  input.type = "text";
+  input.placeholder = "Search sessions…";
+  input.style.cssText = `
+    width: 100%; box-sizing: border-box;
+    padding: 8px 12px; background: rgba(10,12,20,0.85);
+    border: 1px solid rgba(255,255,255,0.15); border-radius: 6px;
+    color: #cfd6e4; font: inherit; outline: none;
+    backdrop-filter: blur(4px);
+  `;
+  input.addEventListener("focus", () => {
+    input.style.borderColor = "rgba(255,196,119,0.5)";
+  });
+
+  const dropdown = document.createElement("div");
+  dropdown.style.cssText = `
+    position: absolute; top: calc(100% + 6px); left: 0; right: 0;
+    background: rgba(10,12,20,0.95); border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 6px; overflow: hidden; display: none;
+    backdrop-filter: blur(6px); max-height: 240px; overflow-y: auto;
+  `;
+
+  let clickingDropdown = false;
+  dropdown.addEventListener("mousedown", () => {
+    clickingDropdown = true;
+  });
+  input.addEventListener("blur", () => {
+    input.style.borderColor = "rgba(255,255,255,0.15)";
+    if (!clickingDropdown) list.hide();
+    clickingDropdown = false;
+  });
+
+  wrapper.append(input, dropdown);
+  container.appendChild(wrapper);
+
+  function normalize(s: string) {
+    return s.toLowerCase();
+  }
+
+  function matches(node: TheiaGraph["nodes"][number], query: string) {
+    const q = normalize(query);
+    return (
+      normalize(node.title).includes(q) ||
+      normalize(node.id).includes(q) ||
+      (node.summary && normalize(node.summary).includes(q)) ||
+      (node.initial_prompt && normalize(node.initial_prompt).includes(q))
+    );
+  }
+
+  function render(query: string) {
+    if (!query.trim()) {
+      dropdown.style.display = "none";
+      dropdown.innerHTML = "";
+      return;
+    }
+    const results: SearchResult[] = [];
+    const resultByIndex = new Map<number, SearchResult>();
+    for (let i = 0; i < graph.nodes.length; i++) {
+      const node = graph.nodes[i]!;
+      if (matches(node, query)) {
+        const r = { node, index: i };
+        results.push(r);
+        resultByIndex.set(i, r);
+      }
+    }
+    if (results.length === 0) {
+      dropdown.style.display = "none";
+      dropdown.innerHTML = "";
+      return;
+    }
+    dropdown.innerHTML = results
+      .map(
+        (r) => `
+      <div class="search-item" data-index="${r.index}" style="
+        padding: 8px 12px; cursor: pointer;
+        border-bottom: 1px solid rgba(255,255,255,0.05);
+        transition: background 100ms;
+      ">
+        <div style="font-weight:600;color:#ffc477">${escape(r.node.title)}</div>
+        <div style="opacity:0.6;font-size:11px">${escape(r.node.id)} · ${Math.round(r.node.duration_sec)}s</div>
+      </div>
+    `,
+      )
+      .join("");
+    for (const el of dropdown.querySelectorAll(".search-item")) {
+      const item = el as HTMLElement;
+      item.addEventListener("mouseenter", () => {
+        item.style.background = "rgba(255,255,255,0.06)";
+      });
+      item.addEventListener("mouseleave", () => {
+        item.style.background = "transparent";
+      });
+      item.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        const idx = Number(item.dataset.index);
+        const result = resultByIndex.get(idx);
+        if (result) {
+          onFocus(result);
+          input.value = "";
+          dropdown.style.display = "none";
+        }
+      });
+    }
+    dropdown.style.display = "block";
+  }
+
+  input.addEventListener("input", () => render(input.value));
+
+  const list = {
+    hide() {
+      dropdown.style.display = "none";
+    },
+  };
+
+  function dispose() {
+    container.removeChild(wrapper);
+  }
+
+  return { dispose, input };
+}

--- a/theia-panel/src/ui/SearchBar.ts
+++ b/theia-panel/src/ui/SearchBar.ts
@@ -73,16 +73,14 @@ export function createSearchBar(
       dropdown.innerHTML = "";
       return;
     }
-    const results: SearchResult[] = [];
     const resultByIndex = new Map<number, SearchResult>();
     for (let i = 0; i < graph.nodes.length; i++) {
       const node = graph.nodes[i]!;
       if (matches(node, query)) {
-        const r = { node, index: i };
-        results.push(r);
-        resultByIndex.set(i, r);
+        resultByIndex.set(i, { node, index: i });
       }
     }
+    const results = Array.from(resultByIndex.values());
     if (results.length === 0) {
       dropdown.style.display = "none";
       dropdown.innerHTML = "";

--- a/theia-panel/src/ui/SidePanel.ts
+++ b/theia-panel/src/ui/SidePanel.ts
@@ -1,12 +1,13 @@
 import type { TheiaGraph } from "../data/types";
+import { escape, truncate } from "./utils";
 
 export function createSidePanel(container: HTMLElement) {
   const el = document.createElement("aside");
   el.style.cssText = `
-    position: absolute; top: 0; right: 0; bottom: 0; width: min(380px, 40vw);
-    background: rgba(10,12,20,0.92); border-left: 1px solid rgba(255,255,255,0.1);
+    position: absolute; top: 0; right: 0; bottom: 0; width: min(420px, 45vw);
+    background: rgba(10,12,20,0.95); border-left: 1px solid rgba(255,255,255,0.1);
     color: #cfd6e4; font: 13px/1.5 ui-monospace, monospace;
-    transform: translateX(100%); transition: transform 200ms ease-out;
+    transform: translateX(100%); transition: transform 220ms ease-out;
     padding: 20px 22px; overflow-y: auto; overscroll-behavior: contain;
     box-sizing: border-box;
   `;
@@ -19,22 +20,30 @@ export function createSidePanel(container: HTMLElement) {
     relatedEdges: TheiaGraph["edges"],
   ) {
     currentId = node.id;
+
+    const headerSummary = node.summary
+      ? `<div style="margin-top:10px;padding:10px;background:rgba(255,196,119,0.08);border-left:2px solid #ffc477;border-radius:0 4px 4px 0;color:#e8dcc8;font-size:12px;line-height:1.5">${escape(node.summary)}</div>`
+      : node.initial_prompt
+        ? `<div style="margin-top:10px;padding:10px;background:rgba(102,217,239,0.06);border-left:2px solid #66d9ef;border-radius:0 4px 4px 0;color:#b8d4e3;font-size:12px;line-height:1.5"><div style="opacity:0.6;font-size:10px;letter-spacing:0.5px;margin-bottom:4px">INITIAL PROMPT</div>${escape(truncate(node.initial_prompt, 280))}</div>`
+        : "";
+
     el.innerHTML = `
       <button aria-label="close" id="sv-close"
         style="position:absolute;top:10px;right:14px;background:none;border:none;color:#cfd6e4;font-size:18px;cursor:pointer">×</button>
-      <h3 style="margin:0 0 4px;color:#ffc477;font-size:15px">${escape(node.title)}</h3>
-      <div style="opacity:0.6;margin-bottom:14px">${node.id}</div>
-      <dl style="margin:0;display:grid;grid-template-columns:auto 1fr;gap:4px 10px">
+      <h3 style="margin:0 0 2px;color:#ffc477;font-size:16px">${escape(node.title)}</h3>
+      <div style="opacity:0.55;margin-bottom:2px;font-size:11px">${node.id}</div>
+      ${headerSummary}
+      <dl style="margin:14px 0 0;display:grid;grid-template-columns:auto 1fr;gap:4px 10px;font-size:12px">
         <dt style="opacity:0.6">Started</dt><dd style="margin:0">${new Date(node.started_at).toLocaleString()}</dd>
         <dt style="opacity:0.6">Duration</dt><dd style="margin:0">${Math.round(node.duration_sec)}s</dd>
         <dt style="opacity:0.6">Model</dt><dd style="margin:0">${escape(node.model ?? "-")}</dd>
         <dt style="opacity:0.6">Tools</dt><dd style="margin:0">${node.tool_count}</dd>
         <dt style="opacity:0.6">Messages</dt><dd style="margin:0">${node.message_count ?? "-"}</dd>
       </dl>
-      <h4 style="margin:18px 0 6px;font-size:12px;letter-spacing:0.5px;opacity:0.7">CONNECTIONS</h4>
-      <ul style="margin:0;padding-left:18px">
-        ${relatedEdges.map((e) => `<li>${e.kind} ${e.source === node.id ? "→" : "←"} ${escape(e.source === node.id ? e.target : e.source)} (w=${e.weight.toFixed(2)})</li>`).join("")}
-      </ul>
+      <h4 style="margin:20px 0 8px;font-size:11px;letter-spacing:0.6px;opacity:0.7;text-transform:uppercase">Connections</h4>
+      <div style="display:flex;flex-direction:column;gap:8px">
+        ${relatedEdges.length === 0 ? '<div style="opacity:0.4;font-size:12px">No connections</div>' : relatedEdges.map((e) => renderEdge(node, e)).join("")}
+      </div>
     `;
     (el.querySelector("#sv-close") as HTMLButtonElement).onclick = hide;
     el.style.transform = "translateX(0)";
@@ -48,6 +57,7 @@ export function createSidePanel(container: HTMLElement) {
   function currentNodeId() {
     return currentId;
   }
+
   function dispose() {
     container.removeChild(el);
   }
@@ -55,9 +65,74 @@ export function createSidePanel(container: HTMLElement) {
   return { show, hide, currentNodeId, dispose };
 }
 
-function escape(s: string): string {
-  return s.replace(
-    /[&<>"]/g,
-    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]!,
-  );
+function renderEdge(
+  node: TheiaGraph["nodes"][number],
+  e: TheiaGraph["edges"][number],
+): string {
+  const isSource = e.source === node.id;
+  const otherId = isSource ? e.target : e.source;
+  const direction = isSource ? "→" : "←";
+  const evidence = e.evidence ?? {};
+
+  let detail = "";
+  if (e.kind === "memory-share") {
+    const memId = (evidence as Record<string, unknown>).memory_id;
+    const salience = (evidence as Record<string, unknown>).salience;
+    const readCount = (evidence as Record<string, unknown>).read_count;
+    detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
+      memory: <span style="color:#ffc477">${escape(String(memId ?? "?"))}</span>
+      ${salience !== undefined ? `· salience ${Number(salience).toFixed(2)}` : ""}
+      ${readCount !== undefined ? `· reads ${readCount}` : ""}
+    </div>`;
+  } else if (e.kind === "cross-search") {
+    const query = (evidence as Record<string, unknown>).query;
+    const hitRank = (evidence as Record<string, unknown>).hit_rank;
+    const hits = (evidence as Record<string, unknown>).hits;
+    detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
+      query: <span style="color:#66d9ef">${escape(String(query ?? "?"))}</span>
+      ${hitRank !== undefined ? `· rank #${hitRank}` : ""}
+      ${hits !== undefined ? `· ${hits} hit${Number(hits) === 1 ? "" : "s"}` : ""}
+    </div>`;
+  } else if (e.kind === "tool-overlap") {
+    const sharedTools = (evidence as Record<string, unknown>).shared_tools;
+    const jaccard = (evidence as Record<string, unknown>).jaccard;
+    const skillName = (evidence as Record<string, unknown>).skill_name;
+    const linkType = (evidence as Record<string, unknown>).link_type;
+    const webKey = (evidence as Record<string, unknown>).web_key;
+    if (sharedTools && Array.isArray(sharedTools)) {
+      detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
+        shared: ${sharedTools.map((t: string) => `<span style="color:#b089ff">${escape(t)}</span>`).join(" ")}
+        ${jaccard !== undefined ? `· jaccard ${Number(jaccard).toFixed(2)}` : ""}
+      </div>`;
+    } else if (skillName) {
+      detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
+        skill: <span style="color:#b089ff">${escape(String(skillName))}</span>
+        ${linkType ? `· ${escape(String(linkType))}` : ""}
+      </div>`;
+    } else if (webKey) {
+      detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
+        web: <span style="color:#b089ff">${escape(String(webKey))}</span>
+      </div>`;
+    }
+  }
+
+  const kindColor: Record<string, string> = {
+    "memory-share": "#ffb366",
+    "cross-search": "#66d9ef",
+    "tool-overlap": "#b089ff",
+  };
+  const color = kindColor[e.kind] ?? "#cfd6e4";
+
+  return `
+    <div style="padding:10px;background:rgba(255,255,255,0.03);border-radius:6px;border:1px solid rgba(255,255,255,0.05)">
+      <div style="display:flex;align-items:center;gap:8px;font-size:12px">
+        <span style="width:8px;height:8px;border-radius:50%;background:${color};display:inline-block;flex-shrink:0"></span>
+        <span style="font-weight:600">${e.kind}</span>
+        <span style="opacity:0.6">${direction}</span>
+        <span>${escape(otherId)}</span>
+        <span style="margin-left:auto;opacity:0.5;font-size:11px">w=${e.weight.toFixed(2)}</span>
+      </div>
+      ${detail}
+    </div>
+  `;
 }

--- a/theia-panel/src/ui/SidePanel.ts
+++ b/theia-panel/src/ui/SidePanel.ts
@@ -1,6 +1,18 @@
 import type { TheiaGraph } from "../data/types";
 import { escape, truncate } from "./utils";
 
+const SUMMARY_MAX_CHARS = 280;
+
+function renderSummaryBlock(node: TheiaGraph["nodes"][number]): string {
+  if (node.summary) {
+    return `<div style="margin-top:10px;padding:10px;background:rgba(255,196,119,0.08);border-left:2px solid #ffc477;border-radius:0 4px 4px 0;color:#e8dcc8;font-size:12px;line-height:1.5">${escape(node.summary)}</div>`;
+  }
+  if (node.initial_prompt) {
+    return `<div style="margin-top:10px;padding:10px;background:rgba(102,217,239,0.06);border-left:2px solid #66d9ef;border-radius:0 4px 4px 0;color:#b8d4e3;font-size:12px;line-height:1.5"><div style="opacity:0.6;font-size:10px;letter-spacing:0.5px;margin-bottom:4px">INITIAL PROMPT</div>${escape(truncate(node.initial_prompt, SUMMARY_MAX_CHARS))}</div>`;
+  }
+  return "";
+}
+
 export function createSidePanel(container: HTMLElement) {
   const el = document.createElement("aside");
   el.style.cssText = `
@@ -21,11 +33,7 @@ export function createSidePanel(container: HTMLElement) {
   ) {
     currentId = node.id;
 
-    const headerSummary = node.summary
-      ? `<div style="margin-top:10px;padding:10px;background:rgba(255,196,119,0.08);border-left:2px solid #ffc477;border-radius:0 4px 4px 0;color:#e8dcc8;font-size:12px;line-height:1.5">${escape(node.summary)}</div>`
-      : node.initial_prompt
-        ? `<div style="margin-top:10px;padding:10px;background:rgba(102,217,239,0.06);border-left:2px solid #66d9ef;border-radius:0 4px 4px 0;color:#b8d4e3;font-size:12px;line-height:1.5"><div style="opacity:0.6;font-size:10px;letter-spacing:0.5px;margin-bottom:4px">INITIAL PROMPT</div>${escape(truncate(node.initial_prompt, 280))}</div>`
-        : "";
+    const headerSummary = renderSummaryBlock(node);
 
     el.innerHTML = `
       <button aria-label="close" id="sv-close"
@@ -72,33 +80,33 @@ function renderEdge(
   const isSource = e.source === node.id;
   const otherId = isSource ? e.target : e.source;
   const direction = isSource ? "→" : "←";
-  const evidence = e.evidence ?? {};
+  const ev = (e.evidence ?? {}) as Record<string, unknown>;
 
   let detail = "";
   if (e.kind === "memory-share") {
-    const memId = (evidence as Record<string, unknown>).memory_id;
-    const salience = (evidence as Record<string, unknown>).salience;
-    const readCount = (evidence as Record<string, unknown>).read_count;
+    const memId = ev.memory_id;
+    const salience = ev.salience;
+    const readCount = ev.read_count;
     detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
       memory: <span style="color:#ffc477">${escape(String(memId ?? "?"))}</span>
       ${salience !== undefined ? `· salience ${Number(salience).toFixed(2)}` : ""}
       ${readCount !== undefined ? `· reads ${readCount}` : ""}
     </div>`;
   } else if (e.kind === "cross-search") {
-    const query = (evidence as Record<string, unknown>).query;
-    const hitRank = (evidence as Record<string, unknown>).hit_rank;
-    const hits = (evidence as Record<string, unknown>).hits;
+    const query = ev.query;
+    const hitRank = ev.hit_rank;
+    const hits = ev.hits;
     detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
       query: <span style="color:#66d9ef">${escape(String(query ?? "?"))}</span>
       ${hitRank !== undefined ? `· rank #${hitRank}` : ""}
       ${hits !== undefined ? `· ${hits} hit${Number(hits) === 1 ? "" : "s"}` : ""}
     </div>`;
   } else if (e.kind === "tool-overlap") {
-    const sharedTools = (evidence as Record<string, unknown>).shared_tools;
-    const jaccard = (evidence as Record<string, unknown>).jaccard;
-    const skillName = (evidence as Record<string, unknown>).skill_name;
-    const linkType = (evidence as Record<string, unknown>).link_type;
-    const webKey = (evidence as Record<string, unknown>).web_key;
+    const sharedTools = ev.shared_tools;
+    const jaccard = ev.jaccard;
+    const skillName = ev.skill_name;
+    const linkType = ev.link_type;
+    const webKey = ev.web_key;
     if (sharedTools && Array.isArray(sharedTools)) {
       detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
         shared: ${sharedTools.map((t: string) => `<span style="color:#b089ff">${escape(t)}</span>`).join(" ")}

--- a/theia-panel/src/ui/Tooltip.ts
+++ b/theia-panel/src/ui/Tooltip.ts
@@ -1,23 +1,31 @@
 import type { TheiaGraph } from "../data/types";
+import { escape, truncate } from "./utils";
 
 export function createTooltip(container: HTMLElement) {
   const el = document.createElement("div");
   el.style.cssText = `
     position: absolute; pointer-events: none;
-    padding: 8px 12px; background: rgba(10,12,20,0.9);
+    padding: 10px 14px; background: rgba(10,12,20,0.92);
     border: 1px solid rgba(255,255,255,0.15); border-radius: 6px;
     font: 12px/1.4 ui-monospace, monospace; color: #cfd6e4;
-    transform: translate(8px, 8px); opacity: 0; transition: opacity 120ms;
-    max-width: 280px;
+    transform: translate(10px, 10px); opacity: 0; transition: opacity 120ms;
+    max-width: 320px; backdrop-filter: blur(4px);
   `;
   container.appendChild(el);
 
   function show(node: TheiaGraph["nodes"][number], x: number, y: number) {
+    const identity = node.summary
+      ? `<div style="margin-top:6px;padding:6px 8px;background:rgba(255,196,119,0.07);border-left:2px solid #ffc477;border-radius:0 4px 4px 0;color:#e8dcc8;font-size:11px;line-height:1.45">${escape(truncate(node.summary, 180))}</div>`
+      : node.initial_prompt
+        ? `<div style="margin-top:6px;padding:6px 8px;background:rgba(102,217,239,0.06);border-left:2px solid #66d9ef;border-radius:0 4px 4px 0;color:#b8d4e3;font-size:11px;line-height:1.45"><div style="opacity:0.5;font-size:9px;letter-spacing:0.5px;margin-bottom:2px">PROMPT</div>${escape(truncate(node.initial_prompt, 180))}</div>`
+        : "";
+
     el.innerHTML = `
-      <div style="font-weight:600;color:#ffc477">${escape(node.title)}</div>
-      <div style="opacity:0.7">${node.id}</div>
-      <div style="margin-top:4px">${new Date(node.started_at).toLocaleString()}</div>
-      <div>${Math.round(node.duration_sec)}s · ${node.tool_count} tools</div>
+      <div style="font-weight:600;color:#ffc477;font-size:13px">${escape(node.title)}</div>
+      <div style="opacity:0.65;font-size:11px">${node.id}</div>
+      <div style="margin-top:4px;opacity:0.8">${new Date(node.started_at).toLocaleString()}</div>
+      <div style="opacity:0.6">${Math.round(node.duration_sec)}s · ${node.tool_count} tools · ${node.message_count ?? "?"} msgs</div>
+      ${identity}
     `;
     el.style.left = `${x}px`;
     el.style.top = `${y}px`;
@@ -32,11 +40,4 @@ export function createTooltip(container: HTMLElement) {
   }
 
   return { show, hide, dispose };
-}
-
-function escape(s: string): string {
-  return s.replace(
-    /[&<>"]/g,
-    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]!,
-  );
 }

--- a/theia-panel/src/ui/Tooltip.ts
+++ b/theia-panel/src/ui/Tooltip.ts
@@ -1,6 +1,18 @@
 import type { TheiaGraph } from "../data/types";
 import { escape, truncate } from "./utils";
 
+const TOOLTIP_MAX_CHARS = 180;
+
+function renderSummaryBlock(node: TheiaGraph["nodes"][number]): string {
+  if (node.summary) {
+    return `<div style="margin-top:6px;padding:6px 8px;background:rgba(255,196,119,0.07);border-left:2px solid #ffc477;border-radius:0 4px 4px 0;color:#e8dcc8;font-size:11px;line-height:1.45">${escape(truncate(node.summary, TOOLTIP_MAX_CHARS))}</div>`;
+  }
+  if (node.initial_prompt) {
+    return `<div style="margin-top:6px;padding:6px 8px;background:rgba(102,217,239,0.06);border-left:2px solid #66d9ef;border-radius:0 4px 4px 0;color:#b8d4e3;font-size:11px;line-height:1.45"><div style="opacity:0.5;font-size:9px;letter-spacing:0.5px;margin-bottom:2px">PROMPT</div>${escape(truncate(node.initial_prompt, TOOLTIP_MAX_CHARS))}</div>`;
+  }
+  return "";
+}
+
 export function createTooltip(container: HTMLElement) {
   const el = document.createElement("div");
   el.style.cssText = `
@@ -14,11 +26,7 @@ export function createTooltip(container: HTMLElement) {
   container.appendChild(el);
 
   function show(node: TheiaGraph["nodes"][number], x: number, y: number) {
-    const identity = node.summary
-      ? `<div style="margin-top:6px;padding:6px 8px;background:rgba(255,196,119,0.07);border-left:2px solid #ffc477;border-radius:0 4px 4px 0;color:#e8dcc8;font-size:11px;line-height:1.45">${escape(truncate(node.summary, 180))}</div>`
-      : node.initial_prompt
-        ? `<div style="margin-top:6px;padding:6px 8px;background:rgba(102,217,239,0.06);border-left:2px solid #66d9ef;border-radius:0 4px 4px 0;color:#b8d4e3;font-size:11px;line-height:1.45"><div style="opacity:0.5;font-size:9px;letter-spacing:0.5px;margin-bottom:2px">PROMPT</div>${escape(truncate(node.initial_prompt, 180))}</div>`
-        : "";
+    const identity = renderSummaryBlock(node);
 
     el.innerHTML = `
       <div style="font-weight:600;color:#ffc477;font-size:13px">${escape(node.title)}</div>

--- a/theia-panel/src/ui/utils.ts
+++ b/theia-panel/src/ui/utils.ts
@@ -1,7 +1,7 @@
 export function escape(s: string): string {
   return s.replace(
-    /[&<>"]/g,
-    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]!,
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
   );
 }
 

--- a/theia-panel/src/ui/utils.ts
+++ b/theia-panel/src/ui/utils.ts
@@ -1,7 +1,10 @@
 export function escape(s: string): string {
   return s.replace(
     /[&<>"']/g,
-    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+    (c) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[
+        c
+      ]!,
   );
 }
 

--- a/theia-panel/src/ui/utils.ts
+++ b/theia-panel/src/ui/utils.ts
@@ -1,0 +1,11 @@
+export function escape(s: string): string {
+  return s.replace(
+    /[&<>"]/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c]!,
+  );
+}
+
+export function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max) + "…";
+}


### PR DESCRIPTION
- add summary/initial_prompt extraction to emitter and schema

- add SearchBar with Map-based lookup and mousedown-blur fix

- add animated focusOn to Scene with RAF cancellation

- refactor SidePanel edge rendering with per-kind details and colors

- add summary/initial_prompt display to Tooltip and SidePanel

- DRY escape/truncate into ui/utils.ts

- defensive isinstance(msg, dict) guard in emit.py