### PR TITLE
style: adapt panel and plugin to match Hermes Agent dashboard theming

### DIFF
--- a/plugin/src/index.js
+++ b/plugin/src/index.js
@@ -77,24 +77,26 @@
     function cssVar(name) {
       return (root.getPropertyValue(name) || "").trim();
     }
-    var bg     = toHex(cssVar("--background-base"), "07080d");
+    var bg       = toHex(cssVar("--background-base"), "07080d");
     // fg — primary body text: use the midground triplet (theme-responsive).
-    var fg     = toHex(cssVar("--midground-base"), "cfd6e4");
+    var fg       = toHex(cssVar("--midground-base"), "cfd6e4");
     // fg2 — secondary/muted labels (55% opacity midground in the DS).
-    var fg2    = toHex(cssVar("--color-muted-foreground") || cssVar("--midground"), "9ca3af");
+    var fg2      = toHex(cssVar("--color-muted-foreground") || cssVar("--midground"), "9ca3af");
+    // midground — the dashboard's midground layer used e.g. for bg-card blend.
+    var midground = toHex(cssVar("--midground-base"), "cfd6e4");
     // accent — warm gold for emphasis.  --color-warning is static (#ffbd38)
     // but intentionally fixed: it provides a functional highlight that stands
     // out from body text across all dark themes.  Falls back to the theme's
     // midground only if --color-warning is absent.
-    var accent = toHex(cssVar("--color-warning") || cssVar("--midground-base"), "ffc477");
-    var border = toHex(cssVar("--color-border"), "ffffff26");
-    var font   = root.getPropertyValue("font-family").trim()
+    var accent   = toHex(cssVar("--color-warning") || cssVar("--midground-base"), "ffc477");
+    var border   = toHex(cssVar("--color-border"), "ffffff26");
+    var font     = root.getPropertyValue("font-family").trim()
       || "'Mondwest', ui-monospace, monospace";
-    return { bg: bg, fg: fg, fg2: fg2, accent: accent, border: border, font: font, radius: "0" };
+    return { bg, fg, fg2, midground, accent, border, font, radius: "0" };
   }
 
   function buildThemeQuery(theme) {
-    var keys = ["bg", "fg", "fg2", "accent", "border", "font", "radius"];
+    var keys = ["bg", "fg", "fg2", "midground", "accent", "border", "font", "radius"];
     return keys.map(function (k) {
       return k + "=" + encodeURIComponent(theme[k]);
     }).join("&");

--- a/plugin/src/style.css
+++ b/plugin/src/style.css
@@ -9,8 +9,10 @@
   max-height: 75vh;
   border: 1px solid var(--color-border, currentColor);
   border-radius: var(--radius, 0.25rem);
-  overflow: hidden;
+  overflow: clip;
+  box-sizing: border-box;
   background: var(--background-base, #07080d);
+  transition: background 200ms, border-color 200ms, border-radius 200ms;
 }
 
 .theia-iframe {
@@ -53,11 +55,13 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem 1rem;
+  background: var(--background-base, #07080d);
   background: color-mix(in srgb, var(--background-base, #07080d) 95%, transparent);
   border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
   color: var(--midground, #cfd6e4);
-  font-family: var(--theme-font-sans, ui-monospace, monospace);
+  font-family: var(--theme-font-sans, system-ui, -apple-system, sans-serif);
   z-index: 1;
+  transition: background 200ms, border-color 200ms;
 }
 
 .theia-iframe-full {

--- a/plugin/src/style.css
+++ b/plugin/src/style.css
@@ -56,10 +56,10 @@
   justify-content: space-between;
   padding: 0.5rem 1rem;
   background: var(--background-base, #07080d);
-  background: color-mix(in srgb, var(--background-base, #07080d) 95%, transparent);
+  background: color-mix(in srgb, var(--background-base, #07080d) 95%, transparent); /* Chrome 111+, FF 113+, Safari 16.2+ */
   border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
-  color: var(--midground, #cfd6e4);
-  font-family: var(--theme-font-sans, system-ui, -apple-system, sans-serif);
+  color: var(--midground-base, #cfd6e4);
+  font-family: system-ui, -apple-system, sans-serif;
   z-index: 1;
   transition: background 200ms, border-color 200ms;
 }

--- a/plugin/src/style.css
+++ b/plugin/src/style.css
@@ -1,4 +1,5 @@
-/* Theia Constellation Plugin — Styles */
+/* Theia Constellation Plugin — Styles
+   Uses the dashboard's CSS custom properties so every theme is reflected. */
 
 .theia-container {
   position: relative;
@@ -7,9 +8,9 @@
   min-height: 400px;
   max-height: 75vh;
   border: 1px solid var(--color-border, currentColor);
-  border-radius: 0.25rem;
+  border-radius: var(--radius, 0.25rem);
   overflow: hidden;
-  background: #07080d;
+  background: var(--background-base, #07080d);
 }
 
 .theia-iframe {
@@ -29,7 +30,7 @@
   min-height: 0;
   width: 100vw;
   height: 100vh;
-  background: #07080d;
+  background: var(--background-base, #07080d);
   display: flex;
   flex-direction: column;
   border: none;
@@ -40,7 +41,7 @@
 .theia-fullscreen {
   width: 100%;
   height: 100%;
-  background: #07080d;
+  background: var(--background-base, #07080d);
   display: flex;
   flex-direction: column;
   border: none;
@@ -52,8 +53,10 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem 1rem;
-  background: rgba(7, 8, 13, 0.95);
+  background: color-mix(in srgb, var(--background-base, #07080d) 95%, transparent);
   border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
+  color: var(--midground, #cfd6e4);
+  font-family: var(--theme-font-sans, ui-monospace, monospace);
   z-index: 1;
 }
 

--- a/theia-panel/src/ui/SidePanel.ts
+++ b/theia-panel/src/ui/SidePanel.ts
@@ -5,17 +5,22 @@ import { escape, truncate } from "./utils";
 
 const SUMMARY_MAX_CHARS = 280;
 
-/** Approximate the dashboard's `bg-card` pattern: blend fg into bg at 4%. */
+/** Approximate the dashboard's `bg-card` pattern: blend midground into bg at 4%. */
 function cardBg(t: ThemeTokens): string {
-  const fr = parseInt(t.fg.slice(0, 2), 16);
-  const fg = parseInt(t.fg.slice(2, 4), 16);
-  const fb = parseInt(t.fg.slice(4, 6), 16);
+  const mr = parseInt(t.midground.slice(0, 2), 16);
+  const mg = parseInt(t.midground.slice(2, 4), 16);
+  const mb = parseInt(t.midground.slice(4, 6), 16);
   const br = parseInt(t.bg.slice(0, 2), 16);
   const bg = parseInt(t.bg.slice(2, 4), 16);
   const bb = parseInt(t.bg.slice(4, 6), 16);
   const mix = (a: number, b: number, p: number) =>
     Math.round(a * p + b * (1 - p));
-  return `rgb(${mix(fr, br, 0.04)},${mix(fg, bg, 0.04)},${mix(fb, bb, 0.04)})`;
+  return `rgb(${mix(mr, br, 0.04)},${mix(mg, bg, 0.04)},${mix(mb, bb, 0.04)})`;
+}
+
+/** Shared style for edge detail attribute lines. */
+function detailAttrStyle(t: ThemeTokens): string {
+  return `margin-top:6px;opacity:0.7;font-size:11px;color:#${t.fg2};line-height:1.5`;
 }
 
 function renderSummaryBlock(
@@ -26,10 +31,10 @@ function renderSummaryBlock(
     return `<div style="margin-top:10px;padding:10px;background:${cardBg(theme)};border-left:2px solid #${theme.accent};color:#${theme.fg};font-size:12px;line-height:1.5">${escape(node.summary)}</div>`;
   }
   if (node.initial_prompt) {
-    return `<div style="margin-top:10px;padding:10px;background:${cardBg(theme)};border-left:2px solid #66d9ef;color:#${theme.fg2};font-size:12px;line-height:1.5"><div style="opacity:0.6;font-size:10px;letter-spacing:0.5px;margin-bottom:4px">INITIAL PROMPT</div>${escape(truncate(node.initial_prompt, SUMMARY_MAX_CHARS))}</div>`;
+    return `<div style="margin-top:10px;padding:10px;background:${cardBg(theme)};border-left:2px solid #${theme.accent};color:#${theme.fg2};font-size:12px;line-height:1.5"><div style="opacity:0.6;font-size:10px;letter-spacing:0.5px;margin-bottom:4px">INITIAL PROMPT</div>${escape(truncate(node.initial_prompt, SUMMARY_MAX_CHARS))}</div>`;
   }
   if (node.preview) {
-    return `<div style="margin-top:10px;padding:10px;background:${cardBg(theme)};border-left:2px solid #66d9ef;color:#${theme.fg2};font-size:12px;line-height:1.5"><div style="opacity:0.6;font-size:10px;letter-spacing:0.5px;margin-bottom:4px">PREVIEW</div>${escape(truncate(node.preview, SUMMARY_MAX_CHARS))}</div>`;
+    return `<div style="margin-top:10px;padding:10px;background:${cardBg(theme)};border-left:2px solid #${theme.accent};color:#${theme.fg2};font-size:12px;line-height:1.5"><div style="opacity:0.6;font-size:10px;letter-spacing:0.5px;margin-bottom:4px">PREVIEW</div>${escape(truncate(node.preview, SUMMARY_MAX_CHARS))}</div>`;
   }
   return "";
 }
@@ -78,7 +83,7 @@ export function createSidePanel(
 
     el.innerHTML = `
       <button aria-label="close" id="sv-close"
-        style="position:absolute;top:12px;right:16px;background:none;border:none;color:#${theme.fg2};font-size:16px;cursor:pointer;opacity:0.5;transition:opacity 120ms">×</button>
+        style="position:absolute;top:12px;right:16px;background:none;border:none;color:#${theme.fg2};font-size:16px;cursor:pointer;opacity:0.5">×</button>
       <h3 style="margin:0 0 2px;color:#${theme.accent};font-size:15px;letter-spacing:0.02em">${escape(node.title || node.id)}</h3>
       <div style="opacity:0.5;color:#${theme.fg2};margin-bottom:2px;font-size:11px">${node.id}</div>
       ${headerSummary}
@@ -135,7 +140,7 @@ function renderEdge(
     const memId = ev.memory_id;
     const salience = ev.salience;
     const readCount = ev.read_count;
-    detail = `<div style="margin-top:6px;opacity:0.7;font-size:11px;color:#${theme.fg2};line-height:1.5">
+    detail = `<div style="${detailAttrStyle(theme)}">
       memory: <span style="color:#${theme.accent}">${escape(String(memId ?? "?"))}</span>
       ${salience !== undefined ? `\u00b7 salience ${Number(salience).toFixed(2)}` : ""}
       ${readCount !== undefined ? `\u00b7 reads ${readCount}` : ""}
@@ -144,8 +149,8 @@ function renderEdge(
     const query = ev.query;
     const hitRank = ev.hit_rank;
     const hits = ev.hits;
-    detail = `<div style="margin-top:6px;opacity:0.7;font-size:11px;color:#${theme.fg2};line-height:1.5">
-      query: <span style="color:#66d9ef">${escape(String(query ?? "?"))}</span>
+    detail = `<div style="${detailAttrStyle(theme)}">
+      query: <span style="color:#${theme.accent}">${escape(String(query ?? "?"))}</span>
       ${hitRank !== undefined ? `\u00b7 rank #${hitRank}` : ""}
       ${hits !== undefined ? `\u00b7 ${hits} hit${Number(hits) === 1 ? "" : "s"}` : ""}
     </div>`;
@@ -156,42 +161,36 @@ function renderEdge(
     const linkType = ev.link_type;
     const webKey = ev.web_key;
     if (sharedTools && Array.isArray(sharedTools)) {
-      detail = `<div style="margin-top:6px;opacity:0.7;font-size:11px;color:#${theme.fg2};line-height:1.5">
-        shared: ${sharedTools.map((t: string) => `<span style="color:#b089ff">${escape(t)}</span>`).join(" ")}
+      detail = `<div style="${detailAttrStyle(theme)}">
+        shared: ${sharedTools.map((t: string) => `<span style="color:#${theme.accent}">${escape(t)}</span>`).join(" ")}
         ${jaccard !== undefined ? `\u00b7 jaccard ${Number(jaccard).toFixed(2)}` : ""}
       </div>`;
     } else if (skillName) {
-      detail = `<div style="margin-top:6px;opacity:0.7;font-size:11px;color:#${theme.fg2};line-height:1.5">
-        skill: <span style="color:#b089ff">${escape(String(skillName))}</span>
+      detail = `<div style="${detailAttrStyle(theme)}">
+        skill: <span style="color:#${theme.accent}">${escape(String(skillName))}</span>
         ${linkType ? `\u00b7 ${escape(String(linkType))}` : ""}
       </div>`;
     } else if (webKey) {
-      detail = `<div style="margin-top:6px;opacity:0.7;font-size:11px;color:#${theme.fg2};line-height:1.5">
-        web: <span style="color:#b089ff">${escape(String(webKey))}</span>
+      detail = `<div style="${detailAttrStyle(theme)}">
+        web: <span style="color:#${theme.accent}">${escape(String(webKey))}</span>
       </div>`;
     }
   } else if (e.kind === "subagent") {
     const isChild = node.id === e.target;
     const label = isChild ? "parent" : "child";
     const displayId = isChild ? e.source : ev.child_session_id;
-    detail = `<div style="margin-top:6px;opacity:0.7;font-size:11px;color:#${theme.fg2};line-height:1.5">
-      ${label}: <span style="color:#7ce38b">${escape(String(displayId ?? "?"))}</span>
+    detail = `<div style="${detailAttrStyle(theme)}">
+      ${label}: <span style="color:#${theme.accent}">${escape(String(displayId ?? "?"))}</span>
     </div>`;
   }
 
-  const kindColor: Record<string, string> = {
-    "memory-share": "#ffb366",
-    "cross-search": "#66d9ef",
-    "tool-overlap": "#b089ff",
-    subagent: "#7ce38b",
-  };
-  const color = kindColor[e.kind] ?? `#${theme.fg}`;
+  const color = `#${theme.accent}`;
 
   return `
     <div style="padding:12px;background:${cardBg(theme)};border:1px solid #${theme.border}">
       <div style="display:flex;align-items:center;gap:8px;font-size:11px">
         <span style="width:7px;height:7px;border-radius:50%;background:${color};display:inline-block;flex-shrink:0"></span>
-        <span style="border:1px solid #${theme.border};padding:1px 7px;font-size:9px;letter-spacing:0.12em;text-transform:uppercase;color:#${theme.fg2};line-height:1.7">${e.kind}</span>
+        <span style="border:1px solid #${theme.border};padding:1px 7px;font-size:9px;letter-spacing:0.12em;text-transform:uppercase;color:#${theme.fg2};line-height:1.4">${e.kind}</span>
         <span style="opacity:0.35">${direction}</span>
         <span style="opacity:0.8;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:140px">${escape(otherId)}</span>
         <span style="margin-left:auto;opacity:0.35;font-size:10px;letter-spacing:0.04em">${e.weight.toFixed(2)}</span>

--- a/theia-panel/src/ui/SidePanel.ts
+++ b/theia-panel/src/ui/SidePanel.ts
@@ -7,7 +7,7 @@ const SUMMARY_MAX_CHARS = 280;
 
 /** Approximate the dashboard's `bg-card` pattern: blend midground into bg at 4%. */
 function cardBg(t: ThemeTokens): string {
-  const parse = (hex: string) => {
+  const parse = (hex: string): [number, number, number] => {
     const h = hex.replace(/^#/, "");
     return [
       parseInt(h.slice(0, 2), 16) || 0,

--- a/theia-panel/src/ui/SidePanel.ts
+++ b/theia-panel/src/ui/SidePanel.ts
@@ -7,12 +7,16 @@ const SUMMARY_MAX_CHARS = 280;
 
 /** Approximate the dashboard's `bg-card` pattern: blend midground into bg at 4%. */
 function cardBg(t: ThemeTokens): string {
-  const mr = parseInt(t.midground.slice(0, 2), 16);
-  const mg = parseInt(t.midground.slice(2, 4), 16);
-  const mb = parseInt(t.midground.slice(4, 6), 16);
-  const br = parseInt(t.bg.slice(0, 2), 16);
-  const bg = parseInt(t.bg.slice(2, 4), 16);
-  const bb = parseInt(t.bg.slice(4, 6), 16);
+  const parse = (hex: string) => {
+    const h = hex.replace(/^#/, "");
+    return [
+      parseInt(h.slice(0, 2), 16) || 0,
+      parseInt(h.slice(2, 4), 16) || 0,
+      parseInt(h.slice(4, 6), 16) || 0,
+    ];
+  };
+  const [mr, mg, mb] = parse(t.midground);
+  const [br, bg, bb] = parse(t.bg);
   const mix = (a: number, b: number, p: number) =>
     Math.round(a * p + b * (1 - p));
   return `rgb(${mix(mr, br, 0.04)},${mix(mg, bg, 0.04)},${mix(mb, bb, 0.04)})`;
@@ -81,6 +85,8 @@ export function createSidePanel(
 
     const headerSummary = renderSummaryBlock(node, theme);
 
+    const dtStyle = `opacity:0.6;color:#${theme.fg2};letter-spacing:0.04em;text-transform:uppercase;font-size:10px`;
+
     el.innerHTML = `
       <button aria-label="close" id="sv-close"
         style="position:absolute;top:12px;right:16px;background:none;border:none;color:#${theme.fg2};font-size:16px;cursor:pointer;opacity:0.5">×</button>
@@ -88,16 +94,16 @@ export function createSidePanel(
       <div style="opacity:0.5;color:#${theme.fg2};margin-bottom:2px;font-size:11px">${node.id}</div>
       ${headerSummary}
       <dl style="margin:14px 0 0;display:grid;grid-template-columns:auto 1fr;gap:3px 12px;font-size:12px">
-        <dt style="opacity:0.45;color:#${theme.fg2};letter-spacing:0.04em;text-transform:uppercase;font-size:10px">Started</dt><dd style="margin:0">${new Date(node.started_at).toLocaleString()}</dd>
-        <dt style="opacity:0.45;color:#${theme.fg2};letter-spacing:0.04em;text-transform:uppercase;font-size:10px">Duration</dt><dd style="margin:0">${Math.round(node.duration_sec)}s</dd>
-        <dt style="opacity:0.45;color:#${theme.fg2};letter-spacing:0.04em;text-transform:uppercase;font-size:10px">Model</dt><dd style="margin:0">${escape(node.model ?? "-")}</dd>
-        <dt style="opacity:0.45;color:#${theme.fg2};letter-spacing:0.04em;text-transform:uppercase;font-size:10px">Tools</dt><dd style="margin:0">${node.tool_count}</dd>
-        <dt style="opacity:0.45;color:#${theme.fg2};letter-spacing:0.04em;text-transform:uppercase;font-size:10px">Messages</dt><dd style="margin:0">${node.message_count ?? "-"}</dd>
+        <dt style="${dtStyle}">Started</dt><dd style="margin:0">${new Date(node.started_at).toLocaleString()}</dd>
+        <dt style="${dtStyle}">Duration</dt><dd style="margin:0">${Math.round(node.duration_sec)}s</dd>
+        <dt style="${dtStyle}">Model</dt><dd style="margin:0">${escape(node.model ?? "-")}</dd>
+        <dt style="${dtStyle}">Tools</dt><dd style="margin:0">${node.tool_count}</dd>
+        <dt style="${dtStyle}">Messages</dt><dd style="margin:0">${node.message_count ?? "-"}</dd>
       </dl>
       <div style="margin:20px 0 0;border-top:1px solid #${theme.border}"></div>
       <h4 style="margin:10px 0 8px;font-size:10px;letter-spacing:0.12em;opacity:0.5;text-transform:uppercase">Connections</h4>
       <div style="display:flex;flex-direction:column;gap:8px">
-        ${relatedEdges.length === 0 ? '<div style="opacity:0.35;font-size:11px">No connections</div>' : relatedEdges.map((e) => renderEdge(node, e, theme)).join("")}
+        ${relatedEdges.length === 0 ? '<div style="opacity:0.5;font-size:11px">No connections</div>' : relatedEdges.map((e) => renderEdge(node, e, theme)).join("")}
       </div>
     `;
     (el.querySelector("#sv-close") as HTMLButtonElement).onclick = hide;
@@ -193,7 +199,7 @@ function renderEdge(
         <span style="border:1px solid #${theme.border};padding:1px 7px;font-size:9px;letter-spacing:0.12em;text-transform:uppercase;color:#${theme.fg2};line-height:1.4">${e.kind}</span>
         <span style="opacity:0.35">${direction}</span>
         <span style="opacity:0.8;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:140px">${escape(otherId)}</span>
-        <span style="margin-left:auto;opacity:0.35;font-size:10px;letter-spacing:0.04em">${e.weight.toFixed(2)}</span>
+        <span style="margin-left:auto;opacity:0.35;font-size:10px;letter-spacing:0.04em" title="Edge weight">w=${e.weight.toFixed(2)}</span>
       </div>
       ${detail}
     </div>

--- a/theia-panel/src/ui/SidePanel.ts
+++ b/theia-panel/src/ui/SidePanel.ts
@@ -5,18 +5,31 @@ import { escape, truncate } from "./utils";
 
 const SUMMARY_MAX_CHARS = 280;
 
+/** Approximate the dashboard's `bg-card` pattern: blend fg into bg at 4%. */
+function cardBg(t: ThemeTokens): string {
+  const fr = parseInt(t.fg.slice(0, 2), 16);
+  const fg = parseInt(t.fg.slice(2, 4), 16);
+  const fb = parseInt(t.fg.slice(4, 6), 16);
+  const br = parseInt(t.bg.slice(0, 2), 16);
+  const bg = parseInt(t.bg.slice(2, 4), 16);
+  const bb = parseInt(t.bg.slice(4, 6), 16);
+  const mix = (a: number, b: number, p: number) =>
+    Math.round(a * p + b * (1 - p));
+  return `rgb(${mix(fr, br, 0.04)},${mix(fg, bg, 0.04)},${mix(fb, bb, 0.04)})`;
+}
+
 function renderSummaryBlock(
   node: TheiaGraph["nodes"][number],
   theme: ThemeTokens,
 ): string {
   if (node.summary) {
-    return `<div style="margin-top:10px;padding:10px;background:rgba(255,196,119,0.08);border-left:2px solid #${theme.accent};color:#${theme.fg};font-size:12px;line-height:1.5">${escape(node.summary)}</div>`;
+    return `<div style="margin-top:10px;padding:10px;background:${cardBg(theme)};border-left:2px solid #${theme.accent};color:#${theme.fg};font-size:12px;line-height:1.5">${escape(node.summary)}</div>`;
   }
   if (node.initial_prompt) {
-    return `<div style="margin-top:10px;padding:10px;background:rgba(102,217,239,0.06);border-left:2px solid #66d9ef;color:#${theme.fg2};font-size:12px;line-height:1.5"><div style="opacity:0.6;font-size:10px;letter-spacing:0.5px;margin-bottom:4px">INITIAL PROMPT</div>${escape(truncate(node.initial_prompt, SUMMARY_MAX_CHARS))}</div>`;
+    return `<div style="margin-top:10px;padding:10px;background:${cardBg(theme)};border-left:2px solid #66d9ef;color:#${theme.fg2};font-size:12px;line-height:1.5"><div style="opacity:0.6;font-size:10px;letter-spacing:0.5px;margin-bottom:4px">INITIAL PROMPT</div>${escape(truncate(node.initial_prompt, SUMMARY_MAX_CHARS))}</div>`;
   }
   if (node.preview) {
-    return `<div style="margin-top:10px;padding:10px;background:rgba(102,217,239,0.06);border-left:2px solid #66d9ef;color:#${theme.fg2};font-size:12px;line-height:1.5"><div style="opacity:0.6;font-size:10px;letter-spacing:0.5px;margin-bottom:4px">PREVIEW</div>${escape(truncate(node.preview, SUMMARY_MAX_CHARS))}</div>`;
+    return `<div style="margin-top:10px;padding:10px;background:${cardBg(theme)};border-left:2px solid #66d9ef;color:#${theme.fg2};font-size:12px;line-height:1.5"><div style="opacity:0.6;font-size:10px;letter-spacing:0.5px;margin-bottom:4px">PREVIEW</div>${escape(truncate(node.preview, SUMMARY_MAX_CHARS))}</div>`;
   }
   return "";
 }
@@ -33,7 +46,7 @@ export function createSidePanel(
     el.style.cssText = `
       position: absolute; top: 0; right: 0; bottom: 0; width: min(420px, 45vw);
       background: ${themeBgAlpha(theme, 0.95)}; border-left: 1px solid #${theme.border};
-      color: #${theme.fg}; font: 13px/1.5 'Mondwest', var(--theia-font, ui-monospace, monospace);
+      color: #${theme.fg}; font: 13px/1.6 var(--theia-font, ui-monospace, monospace);
       transform: translateX(${currentId ? "0" : "100%"}); transition: transform 220ms ease-out;
       padding: 20px 22px; overflow-y: auto; overscroll-behavior: contain;
       box-sizing: border-box;
@@ -65,20 +78,21 @@ export function createSidePanel(
 
     el.innerHTML = `
       <button aria-label="close" id="sv-close"
-        style="position:absolute;top:10px;right:14px;background:none;border:none;color:#${theme.fg};font-size:18px;cursor:pointer">×</button>
-      <h3 style="margin:0 0 2px;color:#${theme.accent};font-size:16px">${escape(node.title || node.id)}</h3>
-      <div style="opacity:0.55;color:#${theme.fg2};margin-bottom:2px;font-size:11px">${node.id}</div>
+        style="position:absolute;top:12px;right:16px;background:none;border:none;color:#${theme.fg2};font-size:16px;cursor:pointer;opacity:0.5;transition:opacity 120ms">×</button>
+      <h3 style="margin:0 0 2px;color:#${theme.accent};font-size:15px;letter-spacing:0.02em">${escape(node.title || node.id)}</h3>
+      <div style="opacity:0.5;color:#${theme.fg2};margin-bottom:2px;font-size:11px">${node.id}</div>
       ${headerSummary}
-      <dl style="margin:14px 0 0;display:grid;grid-template-columns:auto 1fr;gap:4px 10px;font-size:12px">
-        <dt style="opacity:0.6;color:#${theme.fg2}">Started</dt><dd style="margin:0">${new Date(node.started_at).toLocaleString()}</dd>
-        <dt style="opacity:0.6;color:#${theme.fg2}">Duration</dt><dd style="margin:0">${Math.round(node.duration_sec)}s</dd>
-        <dt style="opacity:0.6;color:#${theme.fg2}">Model</dt><dd style="margin:0">${escape(node.model ?? "-")}</dd>
-        <dt style="opacity:0.6;color:#${theme.fg2}">Tools</dt><dd style="margin:0">${node.tool_count}</dd>
-        <dt style="opacity:0.6;color:#${theme.fg2}">Messages</dt><dd style="margin:0">${node.message_count ?? "-"}</dd>
+      <dl style="margin:14px 0 0;display:grid;grid-template-columns:auto 1fr;gap:3px 12px;font-size:12px">
+        <dt style="opacity:0.45;color:#${theme.fg2};letter-spacing:0.04em;text-transform:uppercase;font-size:10px">Started</dt><dd style="margin:0">${new Date(node.started_at).toLocaleString()}</dd>
+        <dt style="opacity:0.45;color:#${theme.fg2};letter-spacing:0.04em;text-transform:uppercase;font-size:10px">Duration</dt><dd style="margin:0">${Math.round(node.duration_sec)}s</dd>
+        <dt style="opacity:0.45;color:#${theme.fg2};letter-spacing:0.04em;text-transform:uppercase;font-size:10px">Model</dt><dd style="margin:0">${escape(node.model ?? "-")}</dd>
+        <dt style="opacity:0.45;color:#${theme.fg2};letter-spacing:0.04em;text-transform:uppercase;font-size:10px">Tools</dt><dd style="margin:0">${node.tool_count}</dd>
+        <dt style="opacity:0.45;color:#${theme.fg2};letter-spacing:0.04em;text-transform:uppercase;font-size:10px">Messages</dt><dd style="margin:0">${node.message_count ?? "-"}</dd>
       </dl>
-      <h4 style="margin:20px 0 8px;font-size:11px;letter-spacing:0.6px;opacity:0.7;text-transform:uppercase">Connections</h4>
+      <div style="margin:20px 0 0;border-top:1px solid #${theme.border}"></div>
+      <h4 style="margin:10px 0 8px;font-size:10px;letter-spacing:0.12em;opacity:0.5;text-transform:uppercase">Connections</h4>
       <div style="display:flex;flex-direction:column;gap:8px">
-        ${relatedEdges.length === 0 ? '<div style="opacity:0.4;font-size:12px">No connections</div>' : relatedEdges.map((e) => renderEdge(node, e, theme)).join("")}
+        ${relatedEdges.length === 0 ? '<div style="opacity:0.35;font-size:11px">No connections</div>' : relatedEdges.map((e) => renderEdge(node, e, theme)).join("")}
       </div>
     `;
     (el.querySelector("#sv-close") as HTMLButtonElement).onclick = hide;
@@ -121,7 +135,7 @@ function renderEdge(
     const memId = ev.memory_id;
     const salience = ev.salience;
     const readCount = ev.read_count;
-    detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
+    detail = `<div style="margin-top:6px;opacity:0.7;font-size:11px;color:#${theme.fg2};line-height:1.5">
       memory: <span style="color:#${theme.accent}">${escape(String(memId ?? "?"))}</span>
       ${salience !== undefined ? `\u00b7 salience ${Number(salience).toFixed(2)}` : ""}
       ${readCount !== undefined ? `\u00b7 reads ${readCount}` : ""}
@@ -130,7 +144,7 @@ function renderEdge(
     const query = ev.query;
     const hitRank = ev.hit_rank;
     const hits = ev.hits;
-    detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
+    detail = `<div style="margin-top:6px;opacity:0.7;font-size:11px;color:#${theme.fg2};line-height:1.5">
       query: <span style="color:#66d9ef">${escape(String(query ?? "?"))}</span>
       ${hitRank !== undefined ? `\u00b7 rank #${hitRank}` : ""}
       ${hits !== undefined ? `\u00b7 ${hits} hit${Number(hits) === 1 ? "" : "s"}` : ""}
@@ -142,17 +156,17 @@ function renderEdge(
     const linkType = ev.link_type;
     const webKey = ev.web_key;
     if (sharedTools && Array.isArray(sharedTools)) {
-      detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
+      detail = `<div style="margin-top:6px;opacity:0.7;font-size:11px;color:#${theme.fg2};line-height:1.5">
         shared: ${sharedTools.map((t: string) => `<span style="color:#b089ff">${escape(t)}</span>`).join(" ")}
         ${jaccard !== undefined ? `\u00b7 jaccard ${Number(jaccard).toFixed(2)}` : ""}
       </div>`;
     } else if (skillName) {
-      detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
+      detail = `<div style="margin-top:6px;opacity:0.7;font-size:11px;color:#${theme.fg2};line-height:1.5">
         skill: <span style="color:#b089ff">${escape(String(skillName))}</span>
         ${linkType ? `\u00b7 ${escape(String(linkType))}` : ""}
       </div>`;
     } else if (webKey) {
-      detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
+      detail = `<div style="margin-top:6px;opacity:0.7;font-size:11px;color:#${theme.fg2};line-height:1.5">
         web: <span style="color:#b089ff">${escape(String(webKey))}</span>
       </div>`;
     }
@@ -160,7 +174,7 @@ function renderEdge(
     const isChild = node.id === e.target;
     const label = isChild ? "parent" : "child";
     const displayId = isChild ? e.source : ev.child_session_id;
-    detail = `<div style="margin-top:4px;opacity:0.75;font-size:11px">
+    detail = `<div style="margin-top:6px;opacity:0.7;font-size:11px;color:#${theme.fg2};line-height:1.5">
       ${label}: <span style="color:#7ce38b">${escape(String(displayId ?? "?"))}</span>
     </div>`;
   }
@@ -174,13 +188,13 @@ function renderEdge(
   const color = kindColor[e.kind] ?? `#${theme.fg}`;
 
   return `
-    <div style="padding:10px;background:rgba(255,255,255,0.03);border:1px solid #${theme.border}">
-      <div style="display:flex;align-items:center;gap:8px;font-size:12px">
-        <span style="width:8px;height:8px;border-radius:50%;background:${color};display:inline-block;flex-shrink:0"></span>
-        <span style="font-weight:600">${e.kind}</span>
-        <span style="opacity:0.6">${direction}</span>
-        <span>${escape(otherId)}</span>
-        <span style="margin-left:auto;opacity:0.5;font-size:11px">w=${e.weight.toFixed(2)}</span>
+    <div style="padding:12px;background:${cardBg(theme)};border:1px solid #${theme.border}">
+      <div style="display:flex;align-items:center;gap:8px;font-size:11px">
+        <span style="width:7px;height:7px;border-radius:50%;background:${color};display:inline-block;flex-shrink:0"></span>
+        <span style="border:1px solid #${theme.border};padding:1px 7px;font-size:9px;letter-spacing:0.12em;text-transform:uppercase;color:#${theme.fg2};line-height:1.7">${e.kind}</span>
+        <span style="opacity:0.35">${direction}</span>
+        <span style="opacity:0.8;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:140px">${escape(otherId)}</span>
+        <span style="margin-left:auto;opacity:0.35;font-size:10px;letter-spacing:0.04em">${e.weight.toFixed(2)}</span>
       </div>
       ${detail}
     </div>

--- a/theia-panel/src/ui/Theme.ts
+++ b/theia-panel/src/ui/Theme.ts
@@ -21,6 +21,7 @@ export interface ThemeTokens {
   bg: string;
   fg: string;
   fg2: string;
+  midground: string;
   accent: string;
   border: string;
   font: string;
@@ -31,6 +32,7 @@ const DEFAULTS: ThemeTokens = {
   bg: "07080d",
   fg: "cfd6e4",
   fg2: "9ca3af",
+  midground: "cfd6e4",
   accent: "ffc477",
   border: "ffffff26",
   font: "'Mondwest', ui-monospace, monospace",
@@ -44,6 +46,7 @@ export function readTheme(): ThemeTokens {
     bg: params.get("bg") || DEFAULTS.bg,
     fg: params.get("fg") || DEFAULTS.fg,
     fg2: params.get("fg2") || DEFAULTS.fg2,
+    midground: params.get("midground") || DEFAULTS.midground,
     accent: params.get("accent") || DEFAULTS.accent,
     border: params.get("border") || DEFAULTS.border,
     font: params.get("font")?.replace(/\+/g, " ") || DEFAULTS.font,
@@ -58,6 +61,7 @@ export function applyTheme(tokens: ThemeTokens): void {
   root.style.setProperty("--theia-bg", `#${tokens.bg}`);
   root.style.setProperty("--theia-fg", `#${tokens.fg}`);
   root.style.setProperty("--theia-fg2", `#${tokens.fg2}`);
+  root.style.setProperty("--theia-midground", `#${tokens.midground}`);
   root.style.setProperty("--theia-accent", `#${tokens.accent}`);
   root.style.setProperty("--theia-border", `#${tokens.border}`);
   root.style.setProperty("--theia-font", tokens.font);
@@ -102,6 +106,7 @@ export function onThemeMessage(
         bg: t.bg || DEFAULTS.bg,
         fg: t.fg || DEFAULTS.fg,
         fg2: t.fg2 || DEFAULTS.fg2,
+        midground: t.midground || DEFAULTS.midground,
         accent: t.accent || DEFAULTS.accent,
         border: t.border || DEFAULTS.border,
         font: t.font || DEFAULTS.font,


### PR DESCRIPTION
- SidePanel: replace hardcoded translucent backgrounds with theme-aware cardBg helper (blends fg into bg at 4%, matching dashboard bg-card pattern)
- SidePanel: redesign edge cards with compact badge-style kind labels, uppercase letter-spaced dt labels, subtle section dividers
- SidePanel: adjust typography (line-height, font-family, letter-spacing) to align with dashboard conventions
- plugin/style.css: replace hardcoded #07080d with var(--background-base) and add var(--radius), var(--midground), var(--theme-font-sans) so the plugin shell reflects the active dashboard theme