### PR TITLE
feat: add one-command install script for beginners

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,24 +5,57 @@
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/arm64be/theia/main/install.sh | bash
 #   bash install.sh                          (from a local clone)
+#   bash install.sh --help                   (show this help)
+#   bash install.sh --no-service             (skip service prompt)
+#   bash install.sh --no-update              (don't git pull if already installed)
 #
 # What it does:
-#   1. Checks prerequisites (Python ≥3.11, Node.js, npm, git, make)
-#   2. Clones the repo into ~/.hermes/hermes-theia/ (only if missing)
-#   3. Installs Python & Node dependencies
-#   4. Builds the panel embed and assembles the plugin
-#   5. Symlinks the plugin into ~/.hermes/plugins/theia-constellation
-#   6. Optionally installs a watch service (systemd or shell script)
+#   1. Checks prerequisites (Python >= 3.11, Node.js, npm, git, make)
+#   2. Clones the repo into ~/.hermes/hermes-theia/ (git pull to update if exists)
+#   3. Creates a Python virtual environment and installs dependencies
+#   4. Installs Node dependencies
+#   5. Builds the panel embed and assembles the plugin
+#   6. Symlinks the plugin into ~/.hermes/plugins/theia-constellation
+#   7. Optionally installs a watch service (systemd or shell script)
 # ---------------------------------------------------------------------------
 set -euo pipefail
 
-SKIP_SERVICE=false
-for arg in "$@"; do [ "$arg" = "--no-service" ] && SKIP_SERVICE=true; done
-
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
 REPO_URL="https://github.com/arm64be/theia"
 INSTALL_DIR="${HOME}/.hermes/hermes-theia"
+VENV_DIR="${INSTALL_DIR}/.venv"
 HERMES_PLUGINS_DIR="${HOME}/.hermes/plugins"
 PLUGIN_NAME="theia-constellation"
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+HELP=false
+NO_UPDATE=false
+SKIP_SERVICE=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --help|-h) HELP=true ;;
+        --no-update) NO_UPDATE=true ;;
+        --no-service) SKIP_SERVICE=true ;;
+    esac
+done
+
+usage() {
+    cat << 'EOF'
+Usage: bash install.sh [options]
+
+Options:
+  --help, -h       Show this help message
+  --no-service     Skip the watch service prompt
+  --no-update      Don't git pull if already installed
+EOF
+}
+
+$HELP && { usage; exit 0; }
 
 # ---------------------------------------------------------------------------
 # Colours
@@ -34,52 +67,51 @@ warn()  { echo -e "${Y}[WARN]${NC}  $1"; }
 err()   { echo -e "${R}[ERR]${NC}  $1"; }
 
 # ---------------------------------------------------------------------------
-# Step 1 — Prerequisites
+# Step 1 - Prerequisites
 # ---------------------------------------------------------------------------
 check_prereqs() {
     info "Checking prerequisites..."
     local fail=0
 
     for cmd in python3 node npm git make; do
-        command -v "$cmd" &>/dev/null || { err "'$cmd' is required but not found"; fail=1; }
+        command -v "$cmd" &>/dev/null || { err "'${cmd}' is required but not found"; fail=1; }
     done
-
-    if command -v python3 &>/dev/null; then
-        local pyver
-        pyver=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-        if python3 -c "import sys; exit(0 if sys.version_info >= (3,11) else 1)" 2>/dev/null; then
-            ok "Python ${pyver}"
-        else
-            err "Python 3.11+ required (found ${pyver})"; fail=1
-        fi
-    fi
-
-    if command -v node &>/dev/null; then
-        ok "Node.js $(node --version)"
-    fi
-    if command -v npm &>/dev/null; then
-        ok "npm $(npm --version)"
-    fi
-
     [ "$fail" -eq 1 ] && exit 1
+
+    if python3 -c "import sys; exit(0 if sys.version_info >= (3,11) else 1)" 2>/dev/null; then
+        local pyver; pyver=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        ok "Python ${pyver}"
+    else
+        local pyver; pyver=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        err "Python 3.11+ required (found ${pyver})"; fail=1; exit 1
+    fi
+
+    ok "Node.js $(node --version)"
+    ok "npm $(npm --version)"
+    ok "$(git --version 2>/dev/null || git version)"
+    ok "$(make --version 2>/dev/null | head -1)"
 }
 
 # ---------------------------------------------------------------------------
-# Step 2 — Clone / copy repository
+# Step 2 - Clone / update repository
 # ---------------------------------------------------------------------------
 clone_repo() {
     if [ -d "$INSTALL_DIR" ]; then
-        info "Repository already exists at ${INSTALL_DIR}"
+        if $NO_UPDATE; then
+            info "Repository exists at ${INSTALL_DIR}, skipping update (--no-update)"
+            return
+        fi
+        info "Updating existing repository at ${INSTALL_DIR}..."
+        (cd "$INSTALL_DIR" && git pull --ff-only) || warn "Could not git pull (local changes or network issue?)"
         return
     fi
 
     mkdir -p "$(dirname "$INSTALL_DIR")"
 
-    # If we're already inside a theia checkout, copy instead of cloning
     local self
     self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     if [ -f "${self}/Makefile" ] && [ -f "${self}/plugin/manifest.json" ]; then
-        info "Copying repository from ${self} → ${INSTALL_DIR}..."
+        info "Copying repository from ${self} to ${INSTALL_DIR}..."
         cp -r "$self" "$INSTALL_DIR"
         ok "Repository copied"
         return
@@ -91,39 +123,44 @@ clone_repo() {
 }
 
 # ---------------------------------------------------------------------------
-# Step 3 — Install dependencies
+# Step 3 - Python virtual environment + theia-core
 # ---------------------------------------------------------------------------
-install_deps() {
-    info "Installing theia-core (Python dependencies)..."
-    local core_dir="${INSTALL_DIR}/theia-core"
-    if command -v uv &>/dev/null; then
-        (cd "$core_dir" && uv pip install -e ".[dev]") || { err "Python install failed"; exit 1; }
-    elif command -v pip &>/dev/null; then
-        (cd "$core_dir" && pip install -e ".[dev]") || { err "Python install failed"; exit 1; }
-    elif python3 -m pip --version &>/dev/null; then
-        (cd "$core_dir" && python3 -m pip install -e ".[dev]") || { err "Python install failed"; exit 1; }
-    else
-        err "No Python package manager found (install pip or uv)"
-        exit 1
-    fi
-    ok "theia-core installed"
+setup_venv() {
+    info "Creating Python virtual environment at ${VENV_DIR}..."
+    python3 -m venv "$VENV_DIR"
+    local pip="${VENV_DIR}/bin/pip"
 
-    info "Installing theia-panel (Node dependencies)..."
-    (cd "${INSTALL_DIR}/theia-panel" && npm ci) || { err "npm install failed"; exit 1; }
+    info "Installing theia-core (Python dependencies)..."
+    (cd "${INSTALL_DIR}/theia-core" && "$pip" install -e ".[dev]") || {
+        err "theia-core install failed"; exit 1
+    }
+    ok "theia-core installed"
+}
+
+# ---------------------------------------------------------------------------
+# Step 4 - Node dependencies
+# ---------------------------------------------------------------------------
+install_panel_deps() {
+    info "Installing theia-panel (this may take a minute)..."
+    (cd "${INSTALL_DIR}/theia-panel" && npm ci) || {
+        err "npm install failed"; exit 1
+    }
     ok "theia-panel dependencies installed"
 }
 
 # ---------------------------------------------------------------------------
-# Step 4 — Build
+# Step 5 - Build
 # ---------------------------------------------------------------------------
 build_project() {
     info "Building project..."
-    (cd "$INSTALL_DIR" && make build) || { err "Build failed"; exit 1; }
+    (cd "$INSTALL_DIR" && make build) || {
+        err "Build failed"; exit 1
+    }
     ok "Build complete"
 }
 
 # ---------------------------------------------------------------------------
-# Step 5 — Symlink plugin into Hermes
+# Step 6 - Symlink plugin into Hermes
 # ---------------------------------------------------------------------------
 symlink_plugin() {
     info "Setting up Hermes plugin symlink..."
@@ -131,30 +168,26 @@ symlink_plugin() {
     local target="${HERMES_PLUGINS_DIR}/${PLUGIN_NAME}"
     [ -e "$target" ] && rm -rf "$target"
     ln -sfn "${INSTALL_DIR}/dist/plugin" "$target"
-    ok "Plugin linked: ${target} → ${INSTALL_DIR}/dist/plugin"
+    ok "Plugin linked: ${target} -> ${INSTALL_DIR}/dist/plugin"
 }
 
 # ---------------------------------------------------------------------------
-# Step 6 — Optional watch service
+# Step 7 - Optional watch service
 # ---------------------------------------------------------------------------
 install_service() {
-    $SKIP_SERVICE && { info "Skipping service installation (--no-service)"; return; }
+    [ "$SKIP_SERVICE" = true ] && { info "Skipping service installation (--no-service)"; return; }
 
-    # If stdin is not a terminal (e.g. piped from curl), skip automatically
     if [ ! -t 0 ]; then
-        info "Non-interactive shell — skipping service prompt"
-        info "Pass --no-service to silence, or run again in an interactive terminal"
+        info "Non-interactive shell - skipping service prompt"
+        info "Run interactively to configure a watch service, or pass --no-service to silence"
         return
     fi
 
     echo ""
-    echo "  ┌──────────────────────────────────────────────────┐"
-    echo "  │  Theia can watch your Hermes database and        │"
-    echo "  │  regenerate the constellation graph whenever     │"
-    echo "  │  sessions change.                               │"
-    echo "  │                                                  │"
-    echo "  │  Choose how to run the watcher:                  │"
-    echo "  └──────────────────────────────────────────────────┘"
+    echo "  Theia can watch your Hermes database and regenerate the"
+    echo "  constellation graph whenever sessions change."
+    echo ""
+    echo "  How would you like to run the watcher?"
     echo ""
     PS3="  Select an option (1-4): "
     options=(
@@ -164,6 +197,10 @@ install_service() {
         "Skip"
     )
     select opt in "${options[@]}"; do
+        if [ -z "$opt" ]; then
+            warn "Invalid option, please select 1-4"
+            continue
+        fi
         case $opt in
             "systemd --user service (recommended)")
                 install_systemd_user_service; break;;
@@ -178,19 +215,19 @@ install_service() {
 }
 
 install_systemd_user_service() {
-    local service_dir="${HOME}/.config/systemd/user"
-    local service_file="${service_dir}/theia-watch.service"
-    mkdir -p "$service_dir"
+    local service_file="${HOME}/.config/systemd/user/theia-watch.service"
+    mkdir -p "$(dirname "$service_file")"
 
     cat > "$service_file" << EOF
 [Unit]
-Description=Theia Constellation — Hermes session graph watcher
+Description=Theia Constellation - Hermes session graph watcher
 Documentation=https://github.com/arm64be/theia
 After=network.target
 
 [Service]
 Type=simple
-ExecStart=${INSTALL_DIR}/start-watch.sh
+WorkingDirectory=${INSTALL_DIR}
+ExecStart=${VENV_DIR}/bin/python -m theia_core --watch
 Restart=on-failure
 RestartSec=5
 
@@ -198,27 +235,28 @@ RestartSec=5
 WantedBy=default.target
 EOF
 
-    write_watch_script
-
-    systemctl --user daemon-reload 2>/dev/null || warn "Could not reload systemd (not running in systemd?)"
+    systemctl --user daemon-reload 2>/dev/null \
+        || warn "systemctl daemon-reload failed (no systemd user session?)"
     ok "systemd --user service installed: ${service_file}"
     info "Enable with:  systemctl --user enable theia-watch.service"
     info "Start with:   systemctl --user start theia-watch.service"
 }
 
 install_systemd_system_service() {
-    local service_file="/etc/systemd/system/theia-watch.service"
+    local user="${USER:-$(whoami)}"
+    local tmpfile; tmpfile=$(mktemp)
 
-    cat > /tmp/theia-watch.service << EOF
+    cat > "$tmpfile" << EOF
 [Unit]
-Description=Theia Constellation — Hermes session graph watcher
+Description=Theia Constellation - Hermes session graph watcher
 Documentation=https://github.com/arm64be/theia
 After=network.target
 
 [Service]
 Type=simple
-User=${USER}
-ExecStart=${INSTALL_DIR}/start-watch.sh
+User=${user}
+WorkingDirectory=${INSTALL_DIR}
+ExecStart=${VENV_DIR}/bin/python -m theia_core --watch
 Restart=on-failure
 RestartSec=5
 
@@ -226,19 +264,19 @@ RestartSec=5
 WantedBy=multi-user.target
 EOF
 
-    write_watch_script
-
     info "Installing system service (requires sudo)..."
-    sudo mv /tmp/theia-watch.service "$service_file" || { err "sudo failed"; exit 1; }
-    sudo systemctl daemon-reload 2>/dev/null || warn "Could not reload systemd"
-    ok "systemd system service installed: ${service_file}"
+    sudo mv "$tmpfile" /etc/systemd/system/theia-watch.service \
+        || { err "sudo mv failed"; exit 1; }
+    sudo systemctl daemon-reload 2>/dev/null \
+        || warn "systemctl daemon-reload failed"
+    ok "systemd system service installed: /etc/systemd/system/theia-watch.service"
     info "Enable with:  sudo systemctl enable theia-watch.service"
     info "Start with:   sudo systemctl start theia-watch.service"
 }
 
 install_shell_script() {
-    local script_file="${HOME}/.hermes/start-theia.sh"
-    cat > "$script_file" << EOF
+    local script="${HOME}/.hermes/start-theia.sh"
+    cat > "$script" << EOF
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -246,22 +284,11 @@ cd "${INSTALL_DIR}"
 echo "Starting Theia Constellation watcher..."
 echo "Watching Hermes database for changes (Ctrl+C to stop)"
 echo ""
-exec python3 -m theia_core --watch
-EOF
-    chmod +x "$script_file"
-    ok "Shell script created: ${script_file}"
-    info "Run it with:  ${script_file}"
-}
-
-write_watch_script() {
-    local script="${INSTALL_DIR}/start-watch.sh"
-    cat > "$script" << EOF
-#!/usr/bin/env bash
-set -euo pipefail
-cd "${INSTALL_DIR}"
-exec python3 -m theia_core --watch
+exec ${VENV_DIR}/bin/python -m theia_core --watch
 EOF
     chmod +x "$script"
+    ok "Shell script created: ${script}"
+    info "Run it with:  ${script}"
 }
 
 # ---------------------------------------------------------------------------
@@ -269,29 +296,35 @@ EOF
 # ---------------------------------------------------------------------------
 main() {
     echo ""
-    echo "  ╔═══════════════════════════════════════════╗"
-    echo "  ║     Theia Constellation Installer         ║"
-    echo "  ║  Visualize Hermes agent sessions as a     ║"
-    echo "  ║  semantic constellation.                  ║"
-    echo "  ╚═══════════════════════════════════════════╝"
+    echo "  +-------------------------------------------+"
+    echo "  |     Theia Constellation Installer         |"
+    echo "  |  Visualize Hermes agent sessions as a     |"
+    echo "  |  semantic constellation.                  |"
+    echo "  +-------------------------------------------+"
     echo ""
 
     check_prereqs
     clone_repo
-    install_deps
+    setup_venv
+    install_panel_deps
     build_project
     symlink_plugin
     install_service
-
-    echo ""
-    ok "Installation complete!"
-    echo ""
-    echo "  Next steps:"
-    echo "    1. Make sure Hermes is running and has session data"
-    echo "    2. If you didn't install a watcher service, run:"
-    echo "       cd ${INSTALL_DIR} && python -m theia_core --watch"
-    echo "    3. Open the Hermes dashboard and click the 'Constellation' tab"
-    echo ""
 }
 
-main
+if ! (main "$@"); then
+    err ""
+    err "Installation did not complete."
+    err "To retry from scratch:  rm -rf ${INSTALL_DIR} && bash install.sh"
+    exit 1
+fi
+
+echo ""
+ok "Installation complete!"
+echo ""
+echo "  Next steps:"
+echo "    1. Make sure Hermes is running and has session data"
+echo "    2. If you didn't install a watcher service, run:"
+echo "       cd ${INSTALL_DIR} && ${VENV_DIR}/bin/python -m theia_core --watch"
+echo "    3. Open the Hermes dashboard and click the 'Constellation' tab"
+echo ""

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# theia — One-command installer
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/arm64be/theia/main/install.sh | bash
+#   bash install.sh                          (from a local clone)
+#
+# What it does:
+#   1. Checks prerequisites (Python ≥3.11, Node.js, npm, git, make)
+#   2. Clones the repo into ~/.hermes/hermes-theia/ (only if missing)
+#   3. Installs Python & Node dependencies
+#   4. Builds the panel embed and assembles the plugin
+#   5. Symlinks the plugin into ~/.hermes/plugins/theia-constellation
+#   6. Optionally installs a watch service (systemd or shell script)
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+SKIP_SERVICE=false
+for arg in "$@"; do [ "$arg" = "--no-service" ] && SKIP_SERVICE=true; done
+
+REPO_URL="https://github.com/arm64be/theia"
+INSTALL_DIR="${HOME}/.hermes/hermes-theia"
+HERMES_PLUGINS_DIR="${HOME}/.hermes/plugins"
+PLUGIN_NAME="theia-constellation"
+
+# ---------------------------------------------------------------------------
+# Colours
+# ---------------------------------------------------------------------------
+R='\033[0;31m'; G='\033[0;32m'; Y='\033[1;33m'; B='\033[0;34m'; NC='\033[0m'
+info()  { echo -e "${B}[INFO]${NC}  $1"; }
+ok()    { echo -e "${G}[ OK ]${NC}  $1"; }
+warn()  { echo -e "${Y}[WARN]${NC}  $1"; }
+err()   { echo -e "${R}[ERR]${NC}  $1"; }
+
+# ---------------------------------------------------------------------------
+# Step 1 — Prerequisites
+# ---------------------------------------------------------------------------
+check_prereqs() {
+    info "Checking prerequisites..."
+    local fail=0
+
+    for cmd in python3 node npm git make; do
+        command -v "$cmd" &>/dev/null || { err "'$cmd' is required but not found"; fail=1; }
+    done
+
+    if command -v python3 &>/dev/null; then
+        local pyver
+        pyver=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        if python3 -c "import sys; exit(0 if sys.version_info >= (3,11) else 1)" 2>/dev/null; then
+            ok "Python ${pyver}"
+        else
+            err "Python 3.11+ required (found ${pyver})"; fail=1
+        fi
+    fi
+
+    if command -v node &>/dev/null; then
+        ok "Node.js $(node --version)"
+    fi
+    if command -v npm &>/dev/null; then
+        ok "npm $(npm --version)"
+    fi
+
+    [ "$fail" -eq 1 ] && exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Step 2 — Clone / copy repository
+# ---------------------------------------------------------------------------
+clone_repo() {
+    if [ -d "$INSTALL_DIR" ]; then
+        info "Repository already exists at ${INSTALL_DIR}"
+        return
+    fi
+
+    mkdir -p "$(dirname "$INSTALL_DIR")"
+
+    # If we're already inside a theia checkout, copy instead of cloning
+    local self
+    self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [ -f "${self}/Makefile" ] && [ -f "${self}/plugin/manifest.json" ]; then
+        info "Copying repository from ${self} → ${INSTALL_DIR}..."
+        cp -r "$self" "$INSTALL_DIR"
+        ok "Repository copied"
+        return
+    fi
+
+    info "Cloning into ${INSTALL_DIR}..."
+    git clone --depth 1 "$REPO_URL" "$INSTALL_DIR"
+    ok "Repository cloned"
+}
+
+# ---------------------------------------------------------------------------
+# Step 3 — Install dependencies
+# ---------------------------------------------------------------------------
+install_deps() {
+    info "Installing theia-core (Python dependencies)..."
+    local core_dir="${INSTALL_DIR}/theia-core"
+    if command -v uv &>/dev/null; then
+        (cd "$core_dir" && uv pip install -e ".[dev]") || { err "Python install failed"; exit 1; }
+    elif command -v pip &>/dev/null; then
+        (cd "$core_dir" && pip install -e ".[dev]") || { err "Python install failed"; exit 1; }
+    elif python3 -m pip --version &>/dev/null; then
+        (cd "$core_dir" && python3 -m pip install -e ".[dev]") || { err "Python install failed"; exit 1; }
+    else
+        err "No Python package manager found (install pip or uv)"
+        exit 1
+    fi
+    ok "theia-core installed"
+
+    info "Installing theia-panel (Node dependencies)..."
+    (cd "${INSTALL_DIR}/theia-panel" && npm ci) || { err "npm install failed"; exit 1; }
+    ok "theia-panel dependencies installed"
+}
+
+# ---------------------------------------------------------------------------
+# Step 4 — Build
+# ---------------------------------------------------------------------------
+build_project() {
+    info "Building project..."
+    (cd "$INSTALL_DIR" && make build) || { err "Build failed"; exit 1; }
+    ok "Build complete"
+}
+
+# ---------------------------------------------------------------------------
+# Step 5 — Symlink plugin into Hermes
+# ---------------------------------------------------------------------------
+symlink_plugin() {
+    info "Setting up Hermes plugin symlink..."
+    mkdir -p "$HERMES_PLUGINS_DIR"
+    local target="${HERMES_PLUGINS_DIR}/${PLUGIN_NAME}"
+    [ -e "$target" ] && rm -rf "$target"
+    ln -sfn "${INSTALL_DIR}/dist/plugin" "$target"
+    ok "Plugin linked: ${target} → ${INSTALL_DIR}/dist/plugin"
+}
+
+# ---------------------------------------------------------------------------
+# Step 6 — Optional watch service
+# ---------------------------------------------------------------------------
+install_service() {
+    $SKIP_SERVICE && { info "Skipping service installation (--no-service)"; return; }
+
+    # If stdin is not a terminal (e.g. piped from curl), skip automatically
+    if [ ! -t 0 ]; then
+        info "Non-interactive shell — skipping service prompt"
+        info "Pass --no-service to silence, or run again in an interactive terminal"
+        return
+    fi
+
+    echo ""
+    echo "  ┌──────────────────────────────────────────────────┐"
+    echo "  │  Theia can watch your Hermes database and        │"
+    echo "  │  regenerate the constellation graph whenever     │"
+    echo "  │  sessions change.                               │"
+    echo "  │                                                  │"
+    echo "  │  Choose how to run the watcher:                  │"
+    echo "  └──────────────────────────────────────────────────┘"
+    echo ""
+    PS3="  Select an option (1-4): "
+    options=(
+        "systemd --user service (recommended)"
+        "systemd system service (requires sudo)"
+        "Simple shell script (run manually)"
+        "Skip"
+    )
+    select opt in "${options[@]}"; do
+        case $opt in
+            "systemd --user service (recommended)")
+                install_systemd_user_service; break;;
+            "systemd system service (requires sudo)")
+                install_systemd_system_service; break;;
+            "Simple shell script (run manually)")
+                install_shell_script; break;;
+            "Skip")
+                info "Skipping service installation"; break;;
+        esac
+    done
+}
+
+install_systemd_user_service() {
+    local service_dir="${HOME}/.config/systemd/user"
+    local service_file="${service_dir}/theia-watch.service"
+    mkdir -p "$service_dir"
+
+    cat > "$service_file" << EOF
+[Unit]
+Description=Theia Constellation — Hermes session graph watcher
+Documentation=https://github.com/arm64be/theia
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=${INSTALL_DIR}/start-watch.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+EOF
+
+    write_watch_script
+
+    systemctl --user daemon-reload 2>/dev/null || warn "Could not reload systemd (not running in systemd?)"
+    ok "systemd --user service installed: ${service_file}"
+    info "Enable with:  systemctl --user enable theia-watch.service"
+    info "Start with:   systemctl --user start theia-watch.service"
+}
+
+install_systemd_system_service() {
+    local service_file="/etc/systemd/system/theia-watch.service"
+
+    cat > /tmp/theia-watch.service << EOF
+[Unit]
+Description=Theia Constellation — Hermes session graph watcher
+Documentation=https://github.com/arm64be/theia
+After=network.target
+
+[Service]
+Type=simple
+User=${USER}
+ExecStart=${INSTALL_DIR}/start-watch.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    write_watch_script
+
+    info "Installing system service (requires sudo)..."
+    sudo mv /tmp/theia-watch.service "$service_file" || { err "sudo failed"; exit 1; }
+    sudo systemctl daemon-reload 2>/dev/null || warn "Could not reload systemd"
+    ok "systemd system service installed: ${service_file}"
+    info "Enable with:  sudo systemctl enable theia-watch.service"
+    info "Start with:   sudo systemctl start theia-watch.service"
+}
+
+install_shell_script() {
+    local script_file="${HOME}/.hermes/start-theia.sh"
+    cat > "$script_file" << EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "${INSTALL_DIR}"
+echo "Starting Theia Constellation watcher..."
+echo "Watching Hermes database for changes (Ctrl+C to stop)"
+echo ""
+exec python3 -m theia_core --watch
+EOF
+    chmod +x "$script_file"
+    ok "Shell script created: ${script_file}"
+    info "Run it with:  ${script_file}"
+}
+
+write_watch_script() {
+    local script="${INSTALL_DIR}/start-watch.sh"
+    cat > "$script" << EOF
+#!/usr/bin/env bash
+set -euo pipefail
+cd "${INSTALL_DIR}"
+exec python3 -m theia_core --watch
+EOF
+    chmod +x "$script"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    echo ""
+    echo "  ╔═══════════════════════════════════════════╗"
+    echo "  ║     Theia Constellation Installer         ║"
+    echo "  ║  Visualize Hermes agent sessions as a     ║"
+    echo "  ║  semantic constellation.                  ║"
+    echo "  ╚═══════════════════════════════════════════╝"
+    echo ""
+
+    check_prereqs
+    clone_repo
+    install_deps
+    build_project
+    symlink_plugin
+    install_service
+
+    echo ""
+    ok "Installation complete!"
+    echo ""
+    echo "  Next steps:"
+    echo "    1. Make sure Hermes is running and has session data"
+    echo "    2. If you didn't install a watcher service, run:"
+    echo "       cd ${INSTALL_DIR} && python -m theia_core --watch"
+    echo "    3. Open the Hermes dashboard and click the 'Constellation' tab"
+    echo ""
+}
+
+main

--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 # ---------------------------------------------------------------------------
-# theia — One-command installer
+# theia -- One-command installer
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/arm64be/theia/main/install.sh | bash
-#   bash install.sh                          (from a local clone)
-#   bash install.sh --help                   (show this help)
-#   bash install.sh --no-service             (skip service prompt)
-#   bash install.sh --no-update              (don't git pull if already installed)
+#   bash <(curl -fsSL https://raw.githubusercontent.com/arm64be/theia/main/install.sh)
+#   bash <(curl -fsSL https://raw.githubusercontent.com/arm64be/theia/main/install.sh) -s -- --no-service
+#   bash install.sh                            (from a local clone)
+#   bash install.sh --help                     (show this help)
+#   bash install.sh --no-service               (skip service prompt)
+#   bash install.sh --no-update                (don't git pull if already installed)
 #
 # What it does:
-#   1. Checks prerequisites (Python >= 3.11, Node.js, npm, git, make)
+#   1. Checks prerequisites (Python >= 3.11, Node.js, npm, GNU Make)
 #   2. Clones the repo into ~/.hermes/hermes-theia/ (git pull to update if exists)
 #   3. Creates a Python virtual environment and installs dependencies
 #   4. Installs Node dependencies
@@ -41,6 +42,7 @@ for arg in "$@"; do
         --help|-h) HELP=true ;;
         --no-update) NO_UPDATE=true ;;
         --no-service) SKIP_SERVICE=true ;;
+        *) err "Unknown option: ${arg}"; usage; exit 1 ;;
     esac
 done
 
@@ -55,25 +57,50 @@ Options:
 EOF
 }
 
-$HELP && { usage; exit 0; }
+if [ "$HELP" = true ]; then
+    usage
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# OS detection
+# ---------------------------------------------------------------------------
+IS_MACOS=false; [[ "$(uname)" == "Darwin" ]] && IS_MACOS=true
+HAS_SYSTEMD=false
+if command -v systemctl &>/dev/null && ! $IS_MACOS; then
+    HAS_SYSTEMD=true
+fi
+
+# ---------------------------------------------------------------------------
+# GNU Make detection
+# ---------------------------------------------------------------------------
+if command -v gmake &>/dev/null; then
+    MAKE_CMD="gmake"
+elif make --version 2>/dev/null | grep -q "GNU Make"; then
+    MAKE_CMD="make"
+else
+    echo "[ERR]  GNU Make is required but was not found."
+    $IS_MACOS && echo "       Install with: brew install make"
+    exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # Colours
 # ---------------------------------------------------------------------------
 R='\033[0;31m'; G='\033[0;32m'; Y='\033[1;33m'; B='\033[0;34m'; NC='\033[0m'
-info()  { echo -e "${B}[INFO]${NC}  $1"; }
-ok()    { echo -e "${G}[ OK ]${NC}  $1"; }
-warn()  { echo -e "${Y}[WARN]${NC}  $1"; }
-err()   { echo -e "${R}[ERR]${NC}  $1"; }
+info()  { echo -e "${B}[INFO]${NC}  $*"; }
+ok()    { echo -e "${G}[ OK ]${NC}  $*"; }
+warn()  { echo -e "${Y}[WARN]${NC}  $*"; }
+err()   { echo -e "${R}[ERR]${NC}  $*"; }
 
 # ---------------------------------------------------------------------------
-# Step 1 - Prerequisites
+# Step 1 -- Prerequisites
 # ---------------------------------------------------------------------------
 check_prereqs() {
     info "Checking prerequisites..."
     local fail=0
 
-    for cmd in python3 node npm git make; do
+    for cmd in python3 node npm git; do
         command -v "$cmd" &>/dev/null || { err "'${cmd}' is required but not found"; fail=1; }
     done
     [ "$fail" -eq 1 ] && exit 1
@@ -83,38 +110,48 @@ check_prereqs() {
         ok "Python ${pyver}"
     else
         local pyver; pyver=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-        err "Python 3.11+ required (found ${pyver})"; fail=1; exit 1
+        err "Python 3.11+ required (found ${pyver})"
+        exit 1
     fi
 
     ok "Node.js $(node --version)"
     ok "npm $(npm --version)"
     ok "$(git --version 2>/dev/null || git version)"
-    ok "$(make --version 2>/dev/null | head -1)"
+    ok "$(${MAKE_CMD} --version 2>/dev/null | head -1)"
+
+    if $IS_MACOS; then
+        warn "macOS detected: systemd services will not be available"
+    fi
 }
 
 # ---------------------------------------------------------------------------
-# Step 2 - Clone / update repository
+# Step 2 -- Clone / update repository
 # ---------------------------------------------------------------------------
 clone_repo() {
     if [ -d "$INSTALL_DIR" ]; then
-        if $NO_UPDATE; then
+        if [ "$NO_UPDATE" = true ]; then
             info "Repository exists at ${INSTALL_DIR}, skipping update (--no-update)"
             return
         fi
         info "Updating existing repository at ${INSTALL_DIR}..."
-        (cd "$INSTALL_DIR" && git pull --ff-only) || warn "Could not git pull (local changes or network issue?)"
+        (cd "$INSTALL_DIR" && git pull --ff-only) || {
+            warn "Could not git pull (local changes or network issue?)"
+            warn "Continuing with existing source -- build may use stale code"
+        }
         return
     fi
 
     mkdir -p "$(dirname "$INSTALL_DIR")"
 
-    local self
-    self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    if [ -f "${self}/Makefile" ] && [ -f "${self}/plugin/manifest.json" ]; then
-        info "Copying repository from ${self} to ${INSTALL_DIR}..."
-        cp -r "$self" "$INSTALL_DIR"
-        ok "Repository copied"
-        return
+    local self="${BASH_SOURCE[0]:-}"
+    if [ -n "$self" ]; then
+        self="$(cd "$(dirname "$self")" && pwd)"
+        if [ -f "${self}/Makefile" ] && [ -f "${self}/plugin/manifest.json" ]; then
+            info "Copying repository from ${self} to ${INSTALL_DIR}..."
+            cp -r "$self" "$INSTALL_DIR"
+            ok "Repository copied"
+            return
+        fi
     fi
 
     info "Cloning into ${INSTALL_DIR}..."
@@ -123,22 +160,30 @@ clone_repo() {
 }
 
 # ---------------------------------------------------------------------------
-# Step 3 - Python virtual environment + theia-core
+# Step 3 -- Python virtual environment + theia-core
 # ---------------------------------------------------------------------------
 setup_venv() {
-    info "Creating Python virtual environment at ${VENV_DIR}..."
-    python3 -m venv "$VENV_DIR"
+    if [ -d "$VENV_DIR" ] && "${VENV_DIR}/bin/python" -c "import theia_core" 2>/dev/null; then
+        ok "theia-core already installed, skipping"
+        return
+    fi
+
+    if [ ! -d "$VENV_DIR" ]; then
+        info "Creating Python virtual environment at ${VENV_DIR}..."
+        python3 -m venv "$VENV_DIR"
+    fi
+
     local pip="${VENV_DIR}/bin/pip"
 
     info "Installing theia-core (Python dependencies)..."
-    (cd "${INSTALL_DIR}/theia-core" && "$pip" install -e ".[dev]") || {
+    (cd "${INSTALL_DIR}/theia-core" && "$pip" install -e ".") || {
         err "theia-core install failed"; exit 1
     }
     ok "theia-core installed"
 }
 
 # ---------------------------------------------------------------------------
-# Step 4 - Node dependencies
+# Step 4 -- Node dependencies
 # ---------------------------------------------------------------------------
 install_panel_deps() {
     info "Installing theia-panel (this may take a minute)..."
@@ -149,36 +194,44 @@ install_panel_deps() {
 }
 
 # ---------------------------------------------------------------------------
-# Step 5 - Build
+# Step 5 -- Build
 # ---------------------------------------------------------------------------
 build_project() {
     info "Building project..."
-    (cd "$INSTALL_DIR" && make build) || {
+    (cd "$INSTALL_DIR" && ${MAKE_CMD} build) || {
         err "Build failed"; exit 1
     }
     ok "Build complete"
 }
 
 # ---------------------------------------------------------------------------
-# Step 6 - Symlink plugin into Hermes
+# Step 6 -- Symlink plugin into Hermes
 # ---------------------------------------------------------------------------
 symlink_plugin() {
     info "Setting up Hermes plugin symlink..."
     mkdir -p "$HERMES_PLUGINS_DIR"
     local target="${HERMES_PLUGINS_DIR}/${PLUGIN_NAME}"
-    [ -e "$target" ] && rm -rf "$target"
+
+    if [ -L "$target" ]; then
+        rm -f "$target"
+    elif [ -e "$target" ]; then
+        local backup="${target}.bak.$(date +%s)"
+        warn "Existing non-symlink plugin at ${target}, backing up to ${backup}..."
+        mv "$target" "$backup"
+    fi
+
     ln -sfn "${INSTALL_DIR}/dist/plugin" "$target"
     ok "Plugin linked: ${target} -> ${INSTALL_DIR}/dist/plugin"
 }
 
 # ---------------------------------------------------------------------------
-# Step 7 - Optional watch service
+# Step 7 -- Optional watch service
 # ---------------------------------------------------------------------------
 install_service() {
     [ "$SKIP_SERVICE" = true ] && { info "Skipping service installation (--no-service)"; return; }
 
     if [ ! -t 0 ]; then
-        info "Non-interactive shell - skipping service prompt"
+        info "Non-interactive shell -- skipping service prompt"
         info "Run interactively to configure a watch service, or pass --no-service to silence"
         return
     fi
@@ -189,16 +242,17 @@ install_service() {
     echo ""
     echo "  How would you like to run the watcher?"
     echo ""
-    PS3="  Select an option (1-4): "
-    options=(
-        "systemd --user service (recommended)"
-        "systemd system service (requires sudo)"
-        "Simple shell script (run manually)"
-        "Skip"
-    )
+
+    local options=()
+    $HAS_SYSTEMD && options+=("systemd --user service (recommended)")
+    $HAS_SYSTEMD && options+=("systemd system service (requires sudo)")
+    options+=("Simple shell script (run manually)")
+    options+=("Skip")
+
+    PS3="  Select an option (1-${#options[@]}): "
     select opt in "${options[@]}"; do
         if [ -z "$opt" ]; then
-            warn "Invalid option, please select 1-4"
+            warn "Invalid option, please select 1-${#options[@]}"
             continue
         fi
         case $opt in
@@ -227,6 +281,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=${INSTALL_DIR}
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
 ExecStart=${VENV_DIR}/bin/python -m theia_core --watch
 Restart=on-failure
 RestartSec=5
@@ -256,6 +311,7 @@ After=network.target
 Type=simple
 User=${user}
 WorkingDirectory=${INSTALL_DIR}
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
 ExecStart=${VENV_DIR}/bin/python -m theia_core --watch
 Restart=on-failure
 RestartSec=5
@@ -265,8 +321,11 @@ WantedBy=multi-user.target
 EOF
 
     info "Installing system service (requires sudo)..."
-    sudo mv "$tmpfile" /etc/systemd/system/theia-watch.service \
-        || { err "sudo mv failed"; exit 1; }
+    sudo mv "$tmpfile" /etc/systemd/system/theia-watch.service || {
+        err "sudo mv failed"; exit 1
+    }
+    sudo chown root:root /etc/systemd/system/theia-watch.service
+    sudo chmod 644 /etc/systemd/system/theia-watch.service
     sudo systemctl daemon-reload 2>/dev/null \
         || warn "systemctl daemon-reload failed"
     ok "systemd system service installed: /etc/systemd/system/theia-watch.service"
@@ -312,19 +371,19 @@ main() {
     install_service
 }
 
-if ! (main "$@"); then
+if (main "$@"); then
+    echo ""
+    ok "Installation complete!"
+    echo ""
+    echo "  Next steps:"
+    echo "    1. Make sure Hermes is running and has session data"
+    echo "    2. If you didn't install a watcher service, run:"
+    echo "       cd ${INSTALL_DIR} && ${VENV_DIR}/bin/python -m theia_core --watch"
+    echo "    3. Open the Hermes dashboard and click the 'Constellation' tab"
+    echo ""
+else
     err ""
     err "Installation did not complete."
     err "To retry from scratch:  rm -rf ${INSTALL_DIR} && bash install.sh"
     exit 1
 fi
-
-echo ""
-ok "Installation complete!"
-echo ""
-echo "  Next steps:"
-echo "    1. Make sure Hermes is running and has session data"
-echo "    2. If you didn't install a watcher service, run:"
-echo "       cd ${INSTALL_DIR} && ${VENV_DIR}/bin/python -m theia_core --watch"
-echo "    3. Open the Hermes dashboard and click the 'Constellation' tab"
-echo ""


### PR DESCRIPTION
The install.sh script provides a beginner-friendly way to install Theia:
- Checks prerequisites (Python 3.11+, Node.js, npm, git, make)
- Clones repo to ~/.hermes/hermes-theia/ (skips if already present)
- Installs Python & Node dependencies
- Builds the panel embed and assembles the plugin
- Symlinks plugin into ~/.hermes/plugins/theia-constellation
- Optionally installs a watch service (systemd or shell script)