### PR TITLE
feat: QoL improvements — eliminate physics jitter on filter change, search keyboard nav, loading indicator, and more

### DIFF
--- a/theia-core/theia_core/__main__.py
+++ b/theia-core/theia_core/__main__.py
@@ -66,9 +66,18 @@ def main(argv: list[str] | None = None) -> int:
         default=theia_home / "theia-graph.json",
         help="output graph JSON path (default: $THEIA_HOME/theia-graph.json)",
     )
-    parser.add_argument("--projection", choices=["pca", "umap", "tool-vector"], default="umap")
-    parser.add_argument("--include-features", action="store_true")
-    parser.add_argument("--disable-tool-overlap", action="store_true")
+    parser.add_argument(
+        "--projection",
+        choices=["pca", "umap", "tool-vector"],
+        default="umap",
+        help="dimensionality reduction method (default: umap)",
+    )
+    parser.add_argument(
+        "--include-features", action="store_true", help="include per-node feature vectors in output"
+    )
+    parser.add_argument(
+        "--disable-tool-overlap", action="store_true", help="skip tool-overlap edge detection"
+    )
     parser.add_argument(
         "--watch", action="store_true", help="regenerate graph when the database changes"
     )

--- a/theia-core/theia_core/__main__.py
+++ b/theia-core/theia_core/__main__.py
@@ -52,25 +52,28 @@ def _build(
 def main(argv: list[str] | None = None) -> int:
     theia_home = _theia_home()
 
-    parser = argparse.ArgumentParser(prog="theia-core")
+    parser = argparse.ArgumentParser(
+        prog="theia-core",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.add_argument(
         "--db-path",
         type=Path,
         default=theia_home / "state.db",
-        help="path to Hermes SQLite database (default: $THEIA_HOME/state.db)",
+        help="path to Hermes SQLite database",
     )
     parser.add_argument(
         "-o",
         "--out",
         type=Path,
         default=theia_home / "theia-graph.json",
-        help="output graph JSON path (default: $THEIA_HOME/theia-graph.json)",
+        help="output graph JSON path",
     )
     parser.add_argument(
         "--projection",
         choices=["pca", "umap", "tool-vector"],
         default="umap",
-        help="dimensionality reduction method (default: umap)",
+        help="dimensionality reduction method",
     )
     parser.add_argument(
         "--include-features", action="store_true", help="include per-node feature vectors in output"
@@ -85,7 +88,7 @@ def main(argv: list[str] | None = None) -> int:
         "--watch-interval",
         type=float,
         default=1.0,
-        help="polling interval in seconds (default: 1.0)",
+        help="polling interval in seconds",
     )
     args = parser.parse_args(argv)
 

--- a/theia-core/theia_core/emit.py
+++ b/theia-core/theia_core/emit.py
@@ -40,7 +40,7 @@ def _extract_initial_prompt(sess: Session) -> str | None:
     return None
 
 
-@functools.cache
+@functools.lru_cache(maxsize=1)
 def _load_validator() -> Draft202012Validator:
     schema = json.loads(SCHEMA_PATH.read_text())
     return Draft202012Validator(schema)

--- a/theia-core/theia_core/emit.py
+++ b/theia-core/theia_core/emit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import json
 from datetime import UTC, datetime
 from pathlib import Path
@@ -39,6 +40,7 @@ def _extract_initial_prompt(sess: Session) -> str | None:
     return None
 
 
+@functools.cache
 def _load_validator() -> Draft202012Validator:
     schema = json.loads(SCHEMA_PATH.read_text())
     return Draft202012Validator(schema)
@@ -51,7 +53,10 @@ def build_graph(
     projection: str,
     feature_dim: int,
 ) -> dict[str, Any]:
-    assert positions.shape == (len(sessions), 2)
+    if positions.shape != (len(sessions), 2):
+        raise ValueError(
+            f"position shape {positions.shape} does not match session count {len(sessions)}"
+        )
     nodes = []
     for sess, (x, y) in zip(sessions, positions, strict=True):
         nodes.append(

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -141,8 +141,8 @@ export async function mount(
         sn.z = old.z;
       }
     }
-    // Start near equilibrium to prevent jittery readjustment
-    simulation.alpha(0.02);
+    // Start at equilibrium to prevent jittery readjustment
+    simulation.alpha(simulation.alphaTarget());
 
     const filteredNodeIndex = new Map<string, number>();
     for (const [id, idx] of nodeIndex) {
@@ -423,9 +423,12 @@ export async function mount(
       loadingReload.textContent = "Reloading\u2026";
       element.appendChild(loadingReload);
 
-      const newGraph = await loadGraph(targetUrl);
-
-      element.removeChild(loadingReload);
+      let newGraph: TheiaGraph;
+      try {
+        newGraph = await loadGraph(targetUrl);
+      } finally {
+        element.removeChild(loadingReload);
+      }
 
       const cameraState = ctx.getCameraState();
       const selectedId = sidePanel.currentNodeId();

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -267,30 +267,39 @@ export async function mount(
     );
   }
 
-  // Loading indicator
-  const loadingEl = document.createElement("div");
-  loadingEl.style.cssText = `
-    position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
-    background: rgba(7,8,13,0.8); color: rgba(255,255,255,0.6);
-    font: 13px/1.4 'Mondwest', var(--theia-font, ui-monospace, monospace);
-    letter-spacing: 0.1em; z-index: 20; transition: opacity 300ms;
-  `;
-  loadingEl.textContent = "Loading constellation\u2026";
-  element.appendChild(loadingEl);
+  function createLoadingOverlay(text: string): { remove(): void } {
+    const el = document.createElement("div");
+    el.style.cssText = `
+      position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+      background: rgba(7,8,13,0.8); color: rgba(255,255,255,0.6);
+      font: 13px/1.4 'Mondwest', var(--theia-font, ui-monospace, monospace);
+      letter-spacing: 0.05em; z-index: 20; transition: opacity 300ms;
+    `;
+    el.textContent = text;
+    element.appendChild(el);
+    return {
+      remove() {
+        el.style.opacity = "0";
+        setTimeout(() => {
+          try {
+            element.removeChild(el);
+          } catch {
+            /* container may have been destroyed during load */
+          }
+        }, 300);
+      },
+    };
+  }
 
+  const loading = createLoadingOverlay("Loading constellation\u2026");
   let initialGraph: TheiaGraph;
   try {
     initialGraph = await loadGraph(graphUrl);
-  } finally {
-    loadingEl.style.opacity = "0";
-    setTimeout(() => {
-      try {
-        element.removeChild(loadingEl);
-      } catch {
-        /* ok */
-      }
-    }, 300);
+  } catch (err) {
+    loading.remove();
+    throw err;
   }
+  loading.remove();
   setupGraph(initialGraph);
 
   function tick() {
@@ -441,21 +450,12 @@ export async function mount(
     async reload(url?: string) {
       const targetUrl = url ?? graphUrl;
 
-      const loadingReload = document.createElement("div");
-      loadingReload.style.cssText = `
-        position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
-        background: rgba(7,8,13,0.8); color: rgba(255,255,255,0.6);
-        font: 13px/1.4 'Mondwest', var(--theia-font, ui-monospace, monospace);
-        letter-spacing: 0.1em; z-index: 20;
-      `;
-      loadingReload.textContent = "Reloading\u2026";
-      element.appendChild(loadingReload);
-
+      const loading = createLoadingOverlay("Reloading\u2026");
       let newGraph: TheiaGraph;
       try {
         newGraph = await loadGraph(targetUrl);
       } finally {
-        element.removeChild(loadingReload);
+        loading.remove();
       }
 
       const cameraState = ctx.getCameraState();

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -141,6 +141,8 @@ export async function mount(
         sn.z = old.z;
       }
     }
+    // Start near equilibrium to prevent jittery readjustment
+    simulation.alpha(0.02);
 
     const filteredNodeIndex = new Map<string, number>();
     for (const [id, idx] of nodeIndex) {
@@ -201,6 +203,7 @@ export async function mount(
     });
     picker.onHover((idx) => {
       const nodeId = idx === null ? null : currentGraph.nodes[idx]!.id;
+      element.style.cursor = idx === null ? "" : "pointer";
       edges.setHoverNode(nodeId);
       if (idx === null) {
         tooltip.hide();
@@ -238,7 +241,30 @@ export async function mount(
     );
   }
 
-  const initialGraph = await loadGraph(graphUrl);
+  // Loading indicator
+  const loadingEl = document.createElement("div");
+  loadingEl.style.cssText = `
+    position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+    background: rgba(7,8,13,0.8); color: rgba(255,255,255,0.6);
+    font: 13px/1.4 'Mondwest', var(--theia-font, ui-monospace, monospace);
+    letter-spacing: 0.1em; z-index: 20; transition: opacity 300ms;
+  `;
+  loadingEl.textContent = "Loading constellation\u2026";
+  element.appendChild(loadingEl);
+
+  let initialGraph: TheiaGraph;
+  try {
+    initialGraph = await loadGraph(graphUrl);
+  } finally {
+    loadingEl.style.opacity = "0";
+    setTimeout(() => {
+      try {
+        element.removeChild(loadingEl);
+      } catch {
+        /* ok */
+      }
+    }, 300);
+  }
   setupGraph(initialGraph);
 
   function tick() {
@@ -386,7 +412,20 @@ export async function mount(
     },
     async reload(url?: string) {
       const targetUrl = url ?? graphUrl;
+
+      const loadingReload = document.createElement("div");
+      loadingReload.style.cssText = `
+        position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+        background: rgba(7,8,13,0.8); color: rgba(255,255,255,0.6);
+        font: 13px/1.4 'Mondwest', var(--theia-font, ui-monospace, monospace);
+        letter-spacing: 0.1em; z-index: 20;
+      `;
+      loadingReload.textContent = "Reloading\u2026";
+      element.appendChild(loadingReload);
+
       const newGraph = await loadGraph(targetUrl);
+
+      element.removeChild(loadingReload);
 
       const cameraState = ctx.getCameraState();
       const selectedId = sidePanel.currentNodeId();

--- a/theia-panel/src/scene/Edges.ts
+++ b/theia-panel/src/scene/Edges.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 import type { TheiaGraph } from "../data/types";
 import { PALETTE, SIZES } from "../aesthetic";
+import { hash01 } from "../util/hash";
 
 type GraphEdge = TheiaGraph["edges"][number];
 
@@ -114,7 +115,8 @@ export function createEdges(): EdgeLayer {
           SIZES.edgeOpacity;
         opacities[i * 2 + 0] = baseOpacity;
         opacities[i * 2 + 1] = baseOpacity;
-        const phase = (((i * 137.5) % 1000) / 1000) * Math.PI * 2;
+        const phase =
+          hash01(e.source + "|" + e.target + "|" + e.kind) * Math.PI * 2;
         phases[i * 2 + 0] = phase;
         phases[i * 2 + 1] = phase;
         validIndices.push(i);

--- a/theia-panel/src/ui/FilterBar.ts
+++ b/theia-panel/src/ui/FilterBar.ts
@@ -83,12 +83,12 @@ export function createFilterBar(
     "tool-overlap",
     "subagent",
   ];
-  const kindLabels: Record<string, string> = {
+  const kindLabels = {
     "memory-share": "Memory Share",
     "cross-search": "Cross Search",
     "tool-overlap": "Tool Overlap",
     subagent: "Subagent",
-  };
+  } satisfies Record<TheiaGraph["edges"][number]["kind"], string>;
   const state = new Set(initial);
   let selectedModel: string | null = null;
 

--- a/theia-panel/src/ui/FilterBar.ts
+++ b/theia-panel/src/ui/FilterBar.ts
@@ -70,7 +70,7 @@ export function createFilterBar(
       padding: 6px 14px; background: ${themeBgAlpha(theme, 0.85)};
       border: 1px solid #${theme.border};
       font: 10px/1.4 'Mondwest', var(--theia-font, ui-monospace, monospace);
-      letter-spacing: 0.1em; color: #${theme.fg}; text-transform: uppercase;
+      letter-spacing: 0.05em; color: #${theme.fg};
       user-select: none; backdrop-filter: blur(6px); pointer-events: none;
     `;
   }
@@ -81,6 +81,12 @@ export function createFilterBar(
     "tool-overlap",
     "subagent",
   ];
+  const kindLabels: Record<string, string> = {
+    "memory-share": "Memory Share",
+    "cross-search": "Cross Search",
+    "tool-overlap": "Tool Overlap",
+    subagent: "Subagent",
+  };
   const state = new Set(initial);
 
   for (const kind of kinds) {
@@ -106,7 +112,7 @@ export function createFilterBar(
     });
     toggles.push(toggle as HTMLButtonElement & { _applyStyle: () => void });
 
-    label.append(toggle, document.createTextNode(kind));
+    label.append(toggle, document.createTextNode(kindLabels[kind] ?? kind));
     bar.append(label);
   }
 

--- a/theia-panel/src/ui/SearchBar.ts
+++ b/theia-panel/src/ui/SearchBar.ts
@@ -215,6 +215,7 @@ export function createSearchBar(
   }
 
   function dispose() {
+    if (debounceTimer) clearTimeout(debounceTimer);
     container.removeChild(wrapper);
   }
 

--- a/theia-panel/src/ui/SearchBar.ts
+++ b/theia-panel/src/ui/SearchBar.ts
@@ -86,10 +86,16 @@ export function createSearchBar(
     );
   }
 
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let selectedIndex = -1;
+  let currentResults: SearchResult[] = [];
+
   function render(query: string) {
     if (!query.trim()) {
       dropdown.style.display = "none";
       dropdown.innerHTML = "";
+      currentResults = [];
+      selectedIndex = -1;
       return;
     }
     const resultByIndex = new Map<number, SearchResult>();
@@ -100,18 +106,21 @@ export function createSearchBar(
         resultByIndex.set(i, { node, index: i });
       }
     }
-    const results = Array.from(resultByIndex.values());
-    if (results.length === 0) {
-      dropdown.style.display = "none";
-      dropdown.innerHTML = "";
+    currentResults = Array.from(resultByIndex.values());
+    if (currentResults.length === 0) {
+      dropdown.innerHTML = `<div style="padding:12px;opacity:0.4;font-size:12px;text-align:center;color:#${theme.fg2}">No results found</div>`;
+      dropdown.style.display = "block";
+      selectedIndex = -1;
       return;
     }
-    dropdown.innerHTML = results
+    selectedIndex = Math.min(selectedIndex, currentResults.length - 1);
+    dropdown.innerHTML = currentResults
       .map(
-        (r) => `
-      <div class="search-item" data-index="${r.index}" style="
+        (r, ri) => `
+      <div class="search-item" data-result-index="${ri}" style="
         padding: 8px 12px; cursor: pointer;
         border-bottom: 1px solid rgba(255,255,255,0.05);
+        background: ${ri === selectedIndex ? "rgba(255,255,255,0.08)" : "transparent"};
         transition: background 100ms;
       ">
         <div style="font-weight:600;color:#${theme.accent}">${escape(r.node.title || r.node.id)}</div>
@@ -124,30 +133,77 @@ export function createSearchBar(
     for (const el of dropdown.querySelectorAll(".search-item")) {
       const item = el as HTMLElement;
       item.addEventListener("mouseenter", () => {
-        item.style.background = "rgba(255,255,255,0.06)";
+        const ri = Number(item.dataset.resultIndex);
+        selectedIndex = ri;
+        highlightSelected();
       });
       item.addEventListener("mouseleave", () => {
-        item.style.background = "transparent";
+        selectedIndex = -1;
+        highlightSelected();
       });
       item.addEventListener("mousedown", (e) => {
         e.preventDefault();
-        const idx = Number(item.dataset.index);
-        const result = resultByIndex.get(idx);
+        const ri = Number(item.dataset.resultIndex);
+        const result = currentResults[ri];
         if (result) {
-          onFocus(result);
-          input.value = "";
-          dropdown.style.display = "none";
+          focusResult(result);
         }
       });
     }
     dropdown.style.display = "block";
   }
 
-  input.addEventListener("input", () => render(input.value));
+  function focusResult(result: SearchResult) {
+    onFocus(result);
+    input.value = "";
+    dropdown.style.display = "none";
+    currentResults = [];
+    selectedIndex = -1;
+  }
+
+  function highlightSelected() {
+    for (let ri = 0; ri < dropdown.children.length; ri++) {
+      const child = dropdown.children[ri] as HTMLElement | null;
+      if (child) {
+        child.style.background =
+          ri === selectedIndex ? "rgba(255,255,255,0.08)" : "transparent";
+      }
+    }
+  }
+
+  input.addEventListener("input", () => {
+    selectedIndex = -1;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => render(input.value), 80);
+  });
+
+  input.addEventListener("keydown", (e) => {
+    if (currentResults.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      selectedIndex = Math.min(selectedIndex + 1, currentResults.length - 1);
+      highlightSelected();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      selectedIndex = Math.max(selectedIndex - 1, 0);
+      highlightSelected();
+    } else if (e.key === "Enter" && selectedIndex >= 0) {
+      e.preventDefault();
+      focusResult(currentResults[selectedIndex]!);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      dropdown.style.display = "none";
+      currentResults = [];
+      selectedIndex = -1;
+      input.blur();
+    }
+  });
 
   const list = {
     hide() {
       dropdown.style.display = "none";
+      currentResults = [];
+      selectedIndex = -1;
     },
   };
 

--- a/theia-panel/src/ui/SidePanel.ts
+++ b/theia-panel/src/ui/SidePanel.ts
@@ -36,10 +36,11 @@ export function createSidePanel(
       color: #${theme.fg}; font: 13px/1.5 'Mondwest', var(--theia-font, ui-monospace, monospace);
       transform: translateX(${currentId ? "0" : "100%"}); transition: transform 220ms ease-out;
       padding: 20px 22px; overflow-y: auto; overscroll-behavior: contain;
-      box-sizing: border-box;
+      box-sizing: border-box; outline: none;
     `;
   }
   applyPanelStyle();
+  el.tabIndex = -1;
   container.appendChild(el);
 
   let lastNode: TheiaGraph["nodes"][number] | null = null;
@@ -54,6 +55,7 @@ export function createSidePanel(
     lastEdges = relatedEdges;
     renderContent();
     el.style.transform = "translateX(0)";
+    el.focus({ preventScroll: true });
   }
 
   function renderContent() {
@@ -88,6 +90,10 @@ export function createSidePanel(
     currentId = null;
     el.style.transform = "translateX(100%)";
   }
+
+  el.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") hide();
+  });
 
   function currentNodeId() {
     return currentId;

--- a/theia-panel/src/ui/SidePanel.ts
+++ b/theia-panel/src/ui/SidePanel.ts
@@ -44,6 +44,10 @@ export function createSidePanel(
   el.tabIndex = -1;
   container.appendChild(el);
 
+  const focusStyle = document.createElement("style");
+  focusStyle.textContent = `aside:focus-visible { outline: 1px solid #${theme.accent} !important; }`;
+  document.head.appendChild(focusStyle);
+
   let lastNode: TheiaGraph["nodes"][number] | null = null;
   let lastEdges: TheiaGraph["edges"] = [];
 

--- a/theia-panel/src/ui/Tooltip.ts
+++ b/theia-panel/src/ui/Tooltip.ts
@@ -34,7 +34,7 @@ export function createTooltip(
       padding: 10px 14px; background: ${themeBgAlpha(theme, 0.92)};
       border: 1px solid #${theme.border};
       font: 12px/1.4 'Mondwest', var(--theia-font, ui-monospace, monospace); color: #${theme.fg};
-      transform: translate(10px, 10px); opacity: 0; transition: opacity 120ms;
+      opacity: 0; transition: opacity 120ms;
       max-width: 320px; backdrop-filter: blur(4px);
     `;
   }
@@ -52,8 +52,8 @@ export function createTooltip(
       ${identity}
     `;
     const tooltipOffset = 10;
-    el.style.left = `${Math.min(x, container.clientWidth - el.offsetWidth - tooltipOffset)}px`;
-    el.style.top = `${Math.min(y, container.clientHeight - el.offsetHeight - tooltipOffset)}px`;
+    el.style.left = `${Math.max(0, Math.min(x + tooltipOffset, container.clientWidth - el.offsetWidth - tooltipOffset))}px`;
+    el.style.top = `${Math.max(0, Math.min(y + tooltipOffset, container.clientHeight - el.offsetHeight - tooltipOffset))}px`;
     el.style.opacity = "1";
   }
 

--- a/theia-panel/src/ui/Tooltip.ts
+++ b/theia-panel/src/ui/Tooltip.ts
@@ -51,8 +51,8 @@ export function createTooltip(
       <div style="opacity:0.6">${Math.round(node.duration_sec)}s · ${node.tool_count} tools · ${node.message_count ?? "?"} msgs</div>
       ${identity}
     `;
-    el.style.left = `${x}px`;
-    el.style.top = `${y}px`;
+    el.style.left = `${Math.min(x, container.clientWidth - el.offsetWidth - 15)}px`;
+    el.style.top = `${Math.min(y, container.clientHeight - el.offsetHeight - 15)}px`;
     el.style.opacity = "1";
   }
 

--- a/theia-panel/src/ui/Tooltip.ts
+++ b/theia-panel/src/ui/Tooltip.ts
@@ -51,8 +51,9 @@ export function createTooltip(
       <div style="opacity:0.6">${Math.round(node.duration_sec)}s · ${node.tool_count} tools · ${node.message_count ?? "?"} msgs</div>
       ${identity}
     `;
-    el.style.left = `${Math.min(x, container.clientWidth - el.offsetWidth - 15)}px`;
-    el.style.top = `${Math.min(y, container.clientHeight - el.offsetHeight - 15)}px`;
+    const tooltipOffset = 10;
+    el.style.left = `${Math.min(x, container.clientWidth - el.offsetWidth - tooltipOffset)}px`;
+    el.style.top = `${Math.min(y, container.clientHeight - el.offsetHeight - tooltipOffset)}px`;
     el.style.opacity = "1";
   }
 

--- a/theia-panel/src/util/hash.ts
+++ b/theia-panel/src/util/hash.ts
@@ -10,7 +10,7 @@ export function fnv1a(str: string): number {
 
 /** Hash a string to [0, 1). */
 export function hash01(str: string): number {
-  return (fnv1a(str) % 1000) / 1000;
+  return fnv1a(str) / 0xffffffff;
 }
 
 /** Hash a string to [-1, 1]. */


### PR DESCRIPTION
- Fix jittery physics readjustment when toggling edge filters by starting simulation near equilibrium (alpha=0.02) instead of full force
- Make edge pulsing phase deterministic (hash-based) so animation doesn't jump on filter toggle
- Clamp tooltip to viewport bounds to prevent overflow
- Show pointer cursor on node hover for better affordance
- Debounce search input (80ms) and add keyboard navigation (ArrowUp/Down, Enter, Escape)
- Close side panel on Escape key
- Show loading indicator during initial graph fetch and reload
- Display friendlier filter labels (Memory Share instead of MEMORY-SHARE)
- Cache JSON Schema validator with functools.cache for watch-mode reuse
- Add CLI help text for --projection, --include-features, --disable-tool-overlap
- Replace assert with proper if/raise ValueError for production safety