### PR TITLE
feat(theia-core): diagnostic logging for missing/orphan sessions (#17)

### DIFF
--- a/theia-core/theia_core/__main__.py
+++ b/theia-core/theia_core/__main__.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
+from collections import Counter
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -26,11 +28,21 @@ def _build(
     projection: str,
     include_features: bool,
     disable_tool_overlap: bool,
+    verbose: bool = False,
 ) -> dict[str, Any]:
     edges = detect_memory_share(sessions) + detect_cross_search(sessions)
     edges += detect_subagent(sessions)
     if not disable_tool_overlap:
         edges += detect_tool_overlap(sessions)
+
+    # The orphan-child warning is always shown — it's the canonical signal
+    # that a subagent's parent session is missing from the database.
+    _warn_orphan_children(sessions)
+    if verbose:
+        _report_subagent_topology(sessions)
+        edge_counts = Counter(e.kind for e in edges)
+        breakdown = ", ".join(f"{k}={n}" for k, n in sorted(edge_counts.items()))
+        print(f"detected {len(edges)} candidate edge(s): {breakdown}", file=sys.stderr)
 
     matrix, feature_names = build_feature_matrix(sessions)
     positions = project_to_2d(
@@ -47,6 +59,43 @@ def _build(
         for i, node in enumerate(graph["nodes"]):
             node["features"] = matrix[i].tolist()
     return graph
+
+
+def _warn_orphan_children(sessions: list[Any]) -> None:
+    """Always-on warning for child sessions whose parent isn't in the database.
+
+    This is the canonical signal that a subagent-spawning parent session was
+    never persisted to ``state.db`` — the missing parent prevents both its
+    node and any subagent edges from appearing in the constellation graph.
+    """
+    session_ids = {s.id for s in sessions}
+    orphans = [s for s in sessions if s.parent_id and s.parent_id not in session_ids]
+    if not orphans:
+        return
+    print(
+        f"warning: {len(orphans)} child session(s) reference a parent_session_id "
+        f"that is not in the database — subagent edges will be dropped:",
+        file=sys.stderr,
+    )
+    for s in orphans[:5]:
+        print(f"         {s.id} -> missing parent {s.parent_id}", file=sys.stderr)
+    if len(orphans) > 5:
+        print(f"         ...and {len(orphans) - 5} more", file=sys.stderr)
+
+
+def _report_subagent_topology(sessions: list[Any]) -> None:
+    """Print a verbose summary of parent/child session links."""
+    session_ids = {s.id for s in sessions}
+    children = [s for s in sessions if s.parent_id]
+    orphans = [s for s in children if s.parent_id not in session_ids]
+    parents_with_children = {s.parent_id for s in children if s.parent_id in session_ids}
+    print(
+        f"sessions={len(sessions)} "
+        f"parents_with_children={len(parents_with_children)} "
+        f"children={len(children)} "
+        f"orphan_children={len(orphans)}",
+        file=sys.stderr,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -82,6 +131,12 @@ def main(argv: list[str] | None = None) -> int:
         "--disable-tool-overlap", action="store_true", help="skip tool-overlap edge detection"
     )
     parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="print extra diagnostics (session/edge counts, orphan children, etc.)",
+    )
+    parser.add_argument(
         "--watch", action="store_true", help="regenerate graph when the database changes"
     )
     parser.add_argument(
@@ -102,6 +157,7 @@ def main(argv: list[str] | None = None) -> int:
             projection=args.projection,
             include_features=args.include_features,
             disable_tool_overlap=args.disable_tool_overlap,
+            verbose=args.verbose,
         )
         write_graph(graph, args.out)
         print(f"wrote {args.out} — {len(graph['nodes'])} nodes, {len(graph['edges'])} edges")

--- a/theia-core/theia_core/emit.py
+++ b/theia-core/theia_core/emit.py
@@ -101,9 +101,7 @@ def build_graph(
         )
         # Surface up to 5 examples so users can spot which sessions are missing.
         for e, missing in dropped[:5]:
-            missing_ids = ", ".join(
-                f"{label}={getattr(e, label)}" for label in missing
-            )
+            missing_ids = ", ".join(f"{label}={getattr(e, label)}" for label in missing)
             print(
                 f"         [{e.kind}] {e.source} -> {e.target}  missing: {missing_ids}",
                 file=sys.stderr,

--- a/theia-core/theia_core/emit.py
+++ b/theia-core/theia_core/emit.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import functools
 import json
+import sys
+from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -77,7 +79,38 @@ def build_graph(
             }
         )
     session_ids = {sess.id for sess in sessions}
-    valid_edges = [e for e in edges if e.source in session_ids and e.target in session_ids]
+    valid_edges: list[Edge] = []
+    dropped: list[tuple[Edge, list[str]]] = []
+    for e in edges:
+        missing = [
+            label
+            for label, sid in (("source", e.source), ("target", e.target))
+            if sid not in session_ids
+        ]
+        if missing:
+            dropped.append((e, missing))
+        else:
+            valid_edges.append(e)
+
+    if dropped:
+        by_kind: Counter[str] = Counter(e.kind for e, _ in dropped)
+        summary = ", ".join(f"{kind}={count}" for kind, count in sorted(by_kind.items()))
+        print(
+            f"warning: dropped {len(dropped)} edge(s) with unknown endpoints ({summary})",
+            file=sys.stderr,
+        )
+        # Surface up to 5 examples so users can spot which sessions are missing.
+        for e, missing in dropped[:5]:
+            missing_ids = ", ".join(
+                f"{label}={getattr(e, label)}" for label in missing
+            )
+            print(
+                f"         [{e.kind}] {e.source} -> {e.target}  missing: {missing_ids}",
+                file=sys.stderr,
+            )
+        if len(dropped) > 5:
+            print(f"         ...and {len(dropped) - 5} more", file=sys.stderr)
+
     return {
         "meta": {
             "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),


### PR DESCRIPTION
Closes #17 (diagnostic side — see "Why this isn't a fix" below).

## Context

Issue #17 reports that a session which spawned subagents — `20260424_113543_bfe810` — never appears in `theia-graph.json` (neither node nor edges). Reproduced the suspected code path against a comparable parent session in our local Hermes (`20260418_110417_32f9f8`, 2 subagent children) and confirmed it renders correctly: 236 nodes / 55 edges including all 8 expected `subagent` edges.

Audit of the relevant code paths:

| File | Behaviour |
|---|---|
| `theia-core/theia_core/ingest.py:181-274` | `load_sessions()` defaults to `include_children=True`; no SQL filter — every `sessions` row is loaded |
| `theia-core/theia_core/__main__.py:96` | Calls `load_sessions(args.db_path)` (no flag exposed) — children always included |
| `theia-core/theia_core/detect/subagent.py:7-22` | Edge created for each child whose `parent_id` is in the loaded set; orphans are silently skipped |
| `theia-core/theia_core/emit.py:79-80` | Filters edges by node membership — silent drop |

The "missing session" symptom can therefore only occur when the parent's row isn't in `state.db`. The dropping is silent at every layer, which is why the reporter has no way to tell whether it's a theia bug or an upstream Hermes persistence bug.

## What this PR changes

Surfaces the conditions that produce a silently-empty graph so future reports of #17 are self-diagnosing.

- **`emit.build_graph`** (`theia-core/theia_core/emit.py:79-112`): warn on stderr whenever an edge is dropped because either endpoint is unknown; lists up to 5 offenders grouped by kind. Defence-in-depth — current detectors already pre-filter, but this guards against future ones.
- **`__main__._warn_orphan_children`** (`theia-core/theia_core/__main__.py:64-83`): **always-on** warning naming each child session whose `parent_session_id` isn't in the DB. This is the canonical signal that a parent row is missing from `state.db` (= the reporter's scenario).
- **`__main__._report_subagent_topology`** (`theia-core/theia_core/__main__.py:86-99`): topology summary `sessions=N parents_with_children=K children=M orphan_children=O` plus per-kind edge tally.
- **New CLI flag** `-v` / `--verbose` (`theia-core/theia_core/__main__.py:117-122`): toggles the topology summary.

## Output samples

Healthy DB (no orphans — quiet, unchanged):
```
wrote /home/beheerder/.hermes/theia-graph.json — 236 nodes, 55 edges
```

Reporter's failure mode (synthetic DB where a child references a missing parent):
```
warning: 1 child session(s) reference a parent_session_id that is not in the database — subagent edges will be dropped:
         child_orphan -> missing parent ghost_parent
wrote /tmp/x.json — 3 nodes, 1 edges
```

`--verbose` additionally prints:
```
sessions=3 parents_with_children=1 children=2 orphan_children=1
detected 1 candidate edge(s): subagent=1
```

## Why this isn't a fix

If the reporter's parent row is genuinely missing from `state.db`, that's an upstream Hermes write-path issue (`hermes-agent/tools/delegate_tool.py`, `hermes-agent/run_agent.py`) — out of scope for theia. With this PR the next reproduction will show exactly which session ids Hermes failed to persist, after which we can either:

1. Confirm and file an upstream Hermes issue, or
2. Discover that the parent IS in the DB but theia is mishandling it — at which point we'll have actual data to debug.

## Test plan

- `pytest -q` in `theia-core/`: 28/28 passing.
- Ran `theia-core` against the real `~/.hermes/state.db` (236 sessions, 8 subagent links): output unchanged when no orphans exist.
- Ran against a hand-crafted SQLite DB with one orphan child: warning fires once, names the child + missing parent, exits 0 with a partial graph.

## Suggested follow-up on the issue

Ask the reporter to rerun on this branch and share:
1. The new warning output (if any).
2. `sqlite3 ~/.hermes/state.db "SELECT id, parent_session_id FROM sessions WHERE id = '20260424_113543_bfe810';"`

That tells us whether the row is missing (→ upstream Hermes) or present with surprising state (→ keep the theia investigation alive).