### PR TITLE
fix(panel): only click the currently-hovered node (#20)

### DIFF
--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -363,9 +363,19 @@ export async function mount(
     }
   });
 
-  element.addEventListener("mouseup", (e) => {
+  element.addEventListener("mouseup", () => {
     if (isMouseDown && !hasDragged && performance.now() - lastWheelAt >= 200) {
-      const idx = picker.pickAt(e.clientX, e.clientY, 0.35);
+      // Click target is whatever is currently hovered — and only that.
+      // The hover picker (Picker.onMove, radius 1.0) drives the tooltip
+      // and pointer cursor, so the user already has a clear visual cue
+      // for what they are about to click. A fresh pickAt here at any
+      // radius can disagree with the hover state — different radius,
+      // fresh hit test against a still-settling simulation — producing
+      // the "tooltip says hovered but click does nothing" symptom on
+      // first load (#20), or worse, a neighbour the user wasn't aiming
+      // at. If nothing is hovered, the click is a no-op rather than a
+      // positional guess.
+      const idx = picker.currentHovered();
       if (idx !== null) {
         const n = currentGraph.nodes[idx]!;
         const related = currentGraph.edges.filter(


### PR DESCRIPTION
Closes #20.

## Root cause

`theia-panel/src/index.ts` attached `mousedown`/`mousemove`/`mouseup` directly to the canvas `element`. `mouseup` fires on the element where the pointer is *released*, not where `mousedown` occurred — so a quick tap with even a few pixels of mouse drift would route the up event to the parent document instead of the iframe. Two consequences:

1. `isMouseDown` was stuck at `true`, corrupting the next interaction.
2. The click branch inside the up-handler was skipped, so the side panel never opened.

The reporter measured a ~30–50% failure rate on quick taps; reproducing the same DOM topology in this repo confirms the diagnosis.

## Fix

Adopt **Option A** from the issue write-up: Pointer Events with `setPointerCapture`. After `pointerdown` captures the pointer, all subsequent `pointermove`/`pointerup` events are routed to `element` regardless of where the pointer goes — including outside the iframe.

Specifics in `theia-panel/src/index.ts:329-419`:

- `mousedown` → `pointerdown` + `setPointerCapture(e.pointerId)`.
- `mousemove` (drag) → `pointermove`.
- `mouseup` → `pointerup`, plus a new `pointercancel` handler that mirrors the cleanup path so an interrupted gesture (e.g. system-level scroll cancellation on touch) doesn't leave `isMouseDown` stuck.
- The hover-tracking `mousemove` for `lastMouse` (used by the tooltip) is converted to `pointermove` for consistency.
- Cleanup is centralised in `releasePointer()` which releases the captured pointer and resets `isMouseDown` / `hasDragged` / `dragMode`. `setPointerCapture` / `releasePointerCapture` are wrapped in try/catch because either can throw if the pointer became inactive between calls.

### Behaviour preserved

- Same drag threshold (3px) before a press is treated as a drag.
- Same button mapping (left = rotate, right = pan).
- Same 200ms suppression window after a wheel event before a click registers.
- Same picker radius (`0.35`) on click.

## Test plan

Full panel CI run locally — every gate from `.github/workflows/panel.yml`:

```
npm ci
npm run generate-types
npm run typecheck
npm run test          # 2/2 passing (data/load.test.ts)
npm run build         # 24 modules, 70.67 kB / 19.45 kB gzip
npm run format:check  # All matched files use Prettier code style!
```

End-to-end smoke check via `bash install.sh --no-service --no-graph` — plugin rebuilds, deploys to `~/.hermes/plugins/theia-constellation`, dashboard ready to load.

(`schemas/graph.schema.json` was unchanged, so `npm run generate-types` produced an unrelated formatting tweak in `theia-panel/src/data/types.ts` from a json2ts version drift; reverted to keep this PR scoped to the click fix. CI regenerates the file before typecheck regardless.)

## Manual repro to verify the fix

1. `bash install.sh --no-service --no-graph`
2. Open the Constellation tab in the Hermes dashboard.
3. Tap nodes quickly with a few px of mouse drift. Before this PR: ~30–50% silent failures. After: every tap opens the side panel.