### PR TITLE
feat(core): add cron-chain edges to link cron-spawned sessions in constellation

### DIFF
--- a/schemas/graph.schema.json
+++ b/schemas/graph.schema.json
@@ -62,7 +62,7 @@
         "properties": {
           "source": { "type": "string" },
           "target": { "type": "string" },
-          "kind": { "enum": ["memory-share", "cross-search", "tool-overlap", "subagent"] },
+          "kind": { "enum": ["memory-share", "cross-search", "tool-overlap", "subagent", "cron-chain"] },
           "weight": { "type": "number", "minimum": 0, "maximum": 1 },
           "evidence": { "type": "object", "additionalProperties": true }
         }

--- a/theia-core/theia_core/__main__.py
+++ b/theia-core/theia_core/__main__.py
@@ -7,6 +7,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Any, Literal, cast
 
+from theia_core.detect.cron import detect_cron_chain
 from theia_core.detect.cross_search import detect_cross_search
 from theia_core.detect.memory_share import detect_memory_share
 from theia_core.detect.subagent import detect_subagent
@@ -34,6 +35,7 @@ def _build(
 ) -> dict[str, Any]:
     edges = detect_memory_share(sessions) + detect_cross_search(sessions)
     edges += detect_subagent(sessions)
+    edges += detect_cron_chain(sessions)
     if not disable_tool_overlap:
         edges += detect_tool_overlap(sessions)
 

--- a/theia-core/theia_core/detect/__init__.py
+++ b/theia-core/theia_core/detect/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-EdgeKind = Literal["memory-share", "cross-search", "tool-overlap", "subagent"]
+EdgeKind = Literal["memory-share", "cross-search", "tool-overlap", "subagent", "cron-chain"]
 
 
 @dataclass(frozen=True)

--- a/theia-core/theia_core/detect/cron.py
+++ b/theia-core/theia_core/detect/cron.py
@@ -21,7 +21,7 @@ def detect_cron_chain(sessions: list[Session]) -> list[Edge]:
     edges: list[Edge] = []
     for job_id, group in by_job.items():
         group.sort(key=lambda s: s.started_at)
-        for prev_sess, next_sess in zip(group, group[1:], strict=True):
+        for prev_sess, next_sess in zip(group, group[1:]):
             hours = (next_sess.started_at - prev_sess.started_at).total_seconds() / 3600
             weight = max(0.1, min(1.0, 1.0 / (1.0 + hours * 0.1)))
             edges.append(

--- a/theia-core/theia_core/detect/cron.py
+++ b/theia-core/theia_core/detect/cron.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+from theia_core.detect import Edge
+from theia_core.ingest import Session
+
+
+def detect_cron_chain(sessions: list[Session]) -> list[Edge]:
+    """Create edges between consecutive runs of the same cron job.
+
+    Sessions spawned by the same cron job are grouped by ``cron_job_id``,
+    sorted chronologically, and an edge is created between each consecutive
+    pair.  This lets users visually trace recurring task lineages.
+    """
+    by_job: dict[str, list[Session]] = defaultdict(list)
+    for sess in sessions:
+        if sess.cron_job_id:
+            by_job[sess.cron_job_id].append(sess)
+
+    edges: list[Edge] = []
+    for job_id, group in by_job.items():
+        group.sort(key=lambda s: s.started_at)
+        for prev_sess, next_sess in zip(group, group[1:], strict=True):
+            hours = (next_sess.started_at - prev_sess.started_at).total_seconds() / 3600
+            weight = max(0.1, min(1.0, 1.0 / (1.0 + hours * 0.1)))
+            edges.append(
+                Edge(
+                    source=prev_sess.id,
+                    target=next_sess.id,
+                    kind="cron-chain",
+                    weight=weight,
+                    evidence={
+                        "cron_job_id": job_id,
+                        "interval_hours": round(hours, 2),
+                    },
+                )
+            )
+    return edges

--- a/theia-core/theia_core/detect/cron.py
+++ b/theia-core/theia_core/detect/cron.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from itertools import pairwise
 
 from theia_core.detect import Edge
 from theia_core.ingest import Session
@@ -21,7 +22,7 @@ def detect_cron_chain(sessions: list[Session]) -> list[Edge]:
     edges: list[Edge] = []
     for job_id, group in by_job.items():
         group.sort(key=lambda s: s.started_at)
-        for prev_sess, next_sess in zip(group, group[1:]):
+        for prev_sess, next_sess in pairwise(group):
             hours = (next_sess.started_at - prev_sess.started_at).total_seconds() / 3600
             weight = max(0.1, min(1.0, 1.0 / (1.0 + hours * 0.1)))
             edges.append(

--- a/theia-core/theia_core/ingest.py
+++ b/theia-core/theia_core/ingest.py
@@ -44,6 +44,7 @@ class Session:
     preview: str = ""
     raw: dict[str, Any] = field(default_factory=dict)
     parent_id: str | None = None
+    cron_job_id: str | None = None
 
 
 def _parse_iso(s: str) -> datetime:
@@ -178,6 +179,20 @@ def _build_preview(messages: list[dict[str, Any]]) -> str:
     return ""
 
 
+def _extract_cron_job_id(session_id: str) -> str | None:
+    """Extract cron job ID from a cron-spawned session ID.
+
+    Cron session IDs follow the pattern ``cron_<job_id>_<timestamp>``,
+    e.g. ``cron_8974a4d0b3cc_20260330_171037``.
+    """
+    if not session_id.startswith("cron_"):
+        return None
+    parts = session_id.split("_", 2)
+    if len(parts) < 3:
+        return None
+    return parts[1]
+
+
 def load_sessions(db_path: Path, include_children: bool = True) -> list[Session]:
     """Load sessions from a Hermes SQLite database.
 
@@ -254,6 +269,8 @@ def load_sessions(db_path: Path, include_children: bool = True) -> list[Session]
             ended_at = _datetime_from_timestamp(row["ended_at"])
             duration_sec = max(0.0, (ended_at - started_at).total_seconds())
 
+            cron_job_id = _extract_cron_job_id(session_id)
+
             sessions.append(
                 Session(
                     id=session_id,
@@ -268,6 +285,7 @@ def load_sessions(db_path: Path, include_children: bool = True) -> list[Session]
                     preview=preview,
                     raw={"db_row": dict(row), "messages": messages},
                     parent_id=row["parent_session_id"],
+                    cron_job_id=cron_job_id,
                 )
             )
 

--- a/theia-panel/package.json
+++ b/theia-panel/package.json
@@ -7,7 +7,7 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "generate-types": "json2ts -i ../schemas/graph.schema.json -o src/data/types.ts --additionalProperties false",
+    "generate-types": "json2ts -i ../schemas/graph.schema.json -o src/data/types.ts --additionalProperties false && prettier --write src/data/types.ts",
     "format": "prettier --write src index.html",
     "format:check": "prettier --check src index.html"
   },

--- a/theia-panel/src/aesthetic.ts
+++ b/theia-panel/src/aesthetic.ts
@@ -8,6 +8,7 @@ export const PALETTE = {
   edgeSearch: 0x66d9ef, // cool cyan
   edgeOverlap: 0xb089ff, // muted violet
   edgeSubagent: 0x7ce38b, // soft green
+  edgeCronChain: 0xff6b6b, // coral red
 } as const;
 
 export const SIZES = {
@@ -19,5 +20,6 @@ export const SIZES = {
     "cross-search": 0.5,
     "tool-overlap": 0.12,
     subagent: 0.35,
+    "cron-chain": 0.45,
   },
 } as const;

--- a/theia-panel/src/data/types.ts
+++ b/theia-panel/src/data/types.ts
@@ -33,7 +33,7 @@ export interface TheiaGraph {
   edges: {
     source: string;
     target: string;
-    kind: "memory-share" | "cross-search" | "tool-overlap" | "subagent";
+    kind: "memory-share" | "cross-search" | "tool-overlap" | "subagent" | "cron-chain";
     weight: number;
     evidence?: Record<string, unknown>;
   }[];

--- a/theia-panel/src/data/types.ts
+++ b/theia-panel/src/data/types.ts
@@ -33,8 +33,15 @@ export interface TheiaGraph {
   edges: {
     source: string;
     target: string;
-    kind: "memory-share" | "cross-search" | "tool-overlap" | "subagent" | "cron-chain";
+    kind:
+      | "memory-share"
+      | "cross-search"
+      | "tool-overlap"
+      | "subagent"
+      | "cron-chain";
     weight: number;
-    evidence?: Record<string, unknown>;
+    evidence?: {
+      [k: string]: unknown;
+    };
   }[];
 }

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -132,7 +132,7 @@ export async function mount(
     modelFilter?: string | null,
   ): Set<string> {
     const kindVisible = new Set<string>();
-    if (enabledKinds.has("subagent")) {
+    if (enabledKinds.has("subagent") || enabledKinds.has("cron-chain")) {
       for (const node of graph.nodes) {
         kindVisible.add(node.id);
       }

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -132,7 +132,7 @@ export async function mount(
     modelFilter?: string | null,
   ): Set<string> {
     const kindVisible = new Set<string>();
-        if (enabledKinds.has("subagent")) {
+    if (enabledKinds.has("subagent")) {
       for (const node of graph.nodes) {
         kindVisible.add(node.id);
       }

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -132,7 +132,7 @@ export async function mount(
     modelFilter?: string | null,
   ): Set<string> {
     const kindVisible = new Set<string>();
-    if (enabledKinds.has("subagent") || enabledKinds.has("cron-chain")) {
+        if (enabledKinds.has("subagent")) {
       for (const node of graph.nodes) {
         kindVisible.add(node.id);
       }

--- a/theia-panel/src/physics/Simulation.ts
+++ b/theia-panel/src/physics/Simulation.ts
@@ -182,11 +182,13 @@ export function createSimulation(
     "cross-search": 0.25,
     "memory-share": 0.3,
     "tool-overlap": 0.04,
+    "cron-chain": 0.15,
   };
   const kindDistance: Record<string, number> = {
     "cross-search": 1.2,
     "memory-share": 0.9,
     "tool-overlap": 2.2,
+    "cron-chain": 1.6,
   };
 
   const linkForce = forceLink<PhysicsNode, PhysicsLink>(links)

--- a/theia-panel/src/scene/Edges.ts
+++ b/theia-panel/src/scene/Edges.ts
@@ -34,6 +34,7 @@ const PALETTE_MAP: Record<GraphEdge["kind"], number> = {
   "cross-search": PALETTE.edgeSearch,
   "tool-overlap": PALETTE.edgeOverlap,
   subagent: PALETTE.edgeSubagent,
+  "cron-chain": PALETTE.edgeCronChain,
 };
 
 export interface EdgeLayer {

--- a/theia-panel/src/ui/FilterBar.ts
+++ b/theia-panel/src/ui/FilterBar.ts
@@ -82,12 +82,14 @@ export function createFilterBar(
     "cross-search",
     "tool-overlap",
     "subagent",
+    "cron-chain",
   ];
   const kindLabels = {
     "memory-share": "Memory Share",
     "cross-search": "Cross Search",
     "tool-overlap": "Tool Overlap",
     subagent: "Subagent",
+    "cron-chain": "Cron Chain",
   } satisfies Record<TheiaGraph["edges"][number]["kind"], string>;
   const state = new Set(initial);
   let selectedModel: string | null = null;

--- a/theia-panel/src/ui/SidePanel.ts
+++ b/theia-panel/src/ui/SidePanel.ts
@@ -50,7 +50,7 @@ export function createSidePanel(
     onNavigate?: (nodeId: string) => void;
     onClose?: () => void;
     onFocusToggle?: (enabled: boolean) => void;
-  }
+  },
 ) {
   let theme = initialTheme;
   const el = document.createElement("aside");

--- a/theia-panel/src/ui/SidePanel.ts
+++ b/theia-panel/src/ui/SidePanel.ts
@@ -280,6 +280,13 @@ function renderEdge(
     detail = `<div style="${detailAttrStyle(theme)}">
       ${label}: <span style="color:#${theme.accent}">${escape(String(displayId ?? "?"))}</span>
     </div>`;
+  } else if (e.kind === "cron-chain") {
+    const jobId = ev.cron_job_id;
+    const intervalHours = ev.interval_hours;
+    detail = `<div style="${detailAttrStyle(theme)}">
+      cron job: <span style="color:#${theme.accent}">${escape(String(jobId ?? "?"))}</span>
+      ${intervalHours !== undefined ? `\u00b7 interval ${Number(intervalHours).toFixed(1)}h` : ""}
+    </div>`;
   }
 
   return `


### PR DESCRIPTION
## Summary

- Adds `cron-chain` edge type to link consecutive runs of the same cron job in the constellation graph
- New detector `theia-core/theia_core/detect/cron.py` groups sessions by `cron_job_id` and creates edges between runs
- Updates graph schema, frontend types, styling, filter bar toggle, and simulation physics

Closes #46