### PR TITLE
fix(api): derive dev panel URL from request host, add THEIA_DEV_HOST override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,10 @@ dev: dev-link ## Start dev environment (Vite hot-reload + plugin symlink)
 	@echo "    Panel:     http://localhost:$(DEV_PORT)"
 	@echo "    Dashboard: run 'THEIA_ENV=development hermes dashboard'"
 	@echo ""
-	THEIA_ENV=development cd theia-panel && npx vite --host 127.0.0.1 --port $(DEV_PORT)
+	THEIA_ENV=development cd theia-panel && npx vite --host 0.0.0.0 --port $(DEV_PORT)
 
 dev-panel: ## Start panel dev server only
-	cd theia-panel && npx vite --host 127.0.0.1 --port $(DEV_PORT)
+	cd theia-panel && npx vite --host 0.0.0.0 --port $(DEV_PORT)
 
 dev-link: ## Symlink plugin source into ~/.hermes/plugins for dev
 	@mkdir -p $(HERMES_PLUGINS)

--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,10 @@ dev: dev-link ## Start dev environment (Vite hot-reload + plugin symlink)
 	@echo "    Panel:     http://localhost:$(DEV_PORT)"
 	@echo "    Dashboard: run 'THEIA_ENV=development hermes dashboard'"
 	@echo ""
-	THEIA_ENV=development cd theia-panel && npx vite --host 0.0.0.0 --port $(DEV_PORT)
+	THEIA_ENV=development cd theia-panel && npx vite --host 127.0.0.1 --port $(DEV_PORT)
 
 dev-panel: ## Start panel dev server only
-	cd theia-panel && npx vite --host 0.0.0.0 --port $(DEV_PORT)
+	cd theia-panel && npx vite --host 127.0.0.1 --port $(DEV_PORT)
 
 dev-link: ## Symlink plugin source into ~/.hermes/plugins for dev
 	@mkdir -p $(HERMES_PLUGINS)

--- a/docs/build-pipeline.md
+++ b/docs/build-pipeline.md
@@ -82,7 +82,7 @@ The API validates the dev port before returning it:
 
 | Rule                      | Reason                                    |
 |---------------------------|-------------------------------------------|
-| Must be >= 1024           | Ports < 1024 are system-reserved          |
+| Must be >= 1024           | Ports < 1024 require root privileges on Linux/macOS |
 | Must not be 9119          | Well-known Hermes internal port            |
 
 If validation fails, `dev_panel_url` is set to `null` and

--- a/docs/build-pipeline.md
+++ b/docs/build-pipeline.md
@@ -66,12 +66,14 @@ a custom middleware. `index.html` calls
 
 When `THEIA_ENV=development`, the plugin API's `/config` endpoint returns a
 `dev_panel_url` that the dashboard uses to load the panel iframe. The URL is
-resolved in the following order:
+resolved from the `THEIA_DEV_HOST` environment variable, falling back to
+`localhost`:
 
 1. **`THEIA_DEV_HOST`** env var — explicit override (e.g. `THEIA_DEV_HOST=192.168.1.50`)
-2. **`X-Forwarded-Host`** request header — respects reverse-proxy setups
-3. **`Host`** request header — fallback to the incoming request host
-4. **`localhost`** — ultimate fallback
+2. **`localhost`** — fallback when `THEIA_DEV_HOST` is unset
+
+The API does **not** trust `X-Forwarded-Host` or `Host` request headers for
+host resolution, preventing origin-steering attacks.
 
 Port is controlled by **`THEIA_DEV_PORT`** (default `5173`). Both the host
 and port resolution apply to any environment where `THEIA_ENV=development`.
@@ -83,6 +85,7 @@ The API validates the dev port before returning it:
 | Rule                      | Reason                                    |
 |---------------------------|-------------------------------------------|
 | Must be >= 1024           | Ports < 1024 require root privileges on Linux/macOS |
+| Must be <= 65535          | Valid TCP port range                      |
 | Must not be 9119          | Well-known Hermes internal port            |
 
 If validation fails, `dev_panel_url` is set to `null` and

--- a/docs/build-pipeline.md
+++ b/docs/build-pipeline.md
@@ -62,6 +62,33 @@ During `vite` serve, the dev server reads `theia-graph.json` from
 a custom middleware. `index.html` calls
 `mount(document.getElementById("app"), "/theia-graph.json")`.
 
+### Dev URL resolution
+
+When `THEIA_ENV=development`, the plugin API's `/config` endpoint returns a
+`dev_panel_url` that the dashboard uses to load the panel iframe. The URL is
+resolved in the following order:
+
+1. **`THEIA_DEV_HOST`** env var — explicit override (e.g. `THEIA_DEV_HOST=192.168.1.50`)
+2. **`X-Forwarded-Host`** request header — respects reverse-proxy setups
+3. **`Host`** request header — fallback to the incoming request host
+4. **`localhost`** — ultimate fallback
+
+Port is controlled by **`THEIA_DEV_PORT`** (default `5173`). Both the host
+and port resolution apply to any environment where `THEIA_ENV=development`.
+
+### Port validation
+
+The API validates the dev port before returning it:
+
+| Rule                      | Reason                                    |
+|---------------------------|-------------------------------------------|
+| Must be >= 1024           | Ports < 1024 are system-reserved          |
+| Must not be 9119          | Well-known Hermes internal port            |
+
+If validation fails, `dev_panel_url` is set to `null` and
+`dev_panel_error` contains the reason. This prevents the dashboard from
+loading a misconfigured panel.
+
 ## 4. `theia-panel` library build
 
 ```bash

--- a/examples/dashboard.html
+++ b/examples/dashboard.html
@@ -358,7 +358,7 @@
           </div>
           <iframe
             id="theia-iframe"
-            src="http://localhost:5173/?graph=/graph.json"
+            src="about:blank"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope"
             loading="eager"
           ></iframe>
@@ -367,7 +367,18 @@
     </div>
 
     <script>
+      // ── Configuration ─────────────────────────────────────────────────────
+      // Dev panel URL — override via query param: ?panel=http://host:port
+      const DEFAULT_PANEL_URL = "http://localhost:5173";
+      const panelUrl =
+        new URLSearchParams(window.location.search).get("panel") ||
+        DEFAULT_PANEL_URL;
+      const panelOrigin = new URL(panelUrl).origin;
+
+      // ── Iframe setup ──────────────────────────────────────────────────────
       const iframe = document.getElementById("theia-iframe");
+      iframe.src = panelUrl + "/?graph=/graph.json";
+
       const loading = document.getElementById("iframe-loading");
 
       // Update iframe source display
@@ -394,7 +405,7 @@
 
       // Listen for postMessage from the theia panel
       window.addEventListener("message", (event) => {
-        if (event.origin !== "http://localhost:5173") return;
+        if (event.origin !== panelOrigin) return;
 
         if (event.data?.type === "node-click") {
           console.log("[dashboard] node clicked:", event.data.nodeId);

--- a/examples/dashboard.html
+++ b/examples/dashboard.html
@@ -370,9 +370,17 @@
       // ── Configuration ─────────────────────────────────────────────────────
       // Dev panel URL — override via query param: ?panel=http://host:port
       const DEFAULT_PANEL_URL = "http://localhost:5173";
-      const panelUrl =
+      let panelUrl =
         new URLSearchParams(window.location.search).get("panel") ||
         DEFAULT_PANEL_URL;
+      try {
+        const parsed = new URL(panelUrl);
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+          panelUrl = DEFAULT_PANEL_URL;
+        }
+      } catch {
+        panelUrl = DEFAULT_PANEL_URL;
+      }
       const panelOrigin = new URL(panelUrl).origin;
 
       // ── Iframe setup ──────────────────────────────────────────────────────

--- a/examples/dashboard.html
+++ b/examples/dashboard.html
@@ -373,19 +373,22 @@
       let panelUrl =
         new URLSearchParams(window.location.search).get("panel") ||
         DEFAULT_PANEL_URL;
+      let parsed;
       try {
-        const parsed = new URL(panelUrl);
+        parsed = new URL(panelUrl);
         if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
           panelUrl = DEFAULT_PANEL_URL;
+          parsed = new URL(panelUrl);
         }
       } catch {
         panelUrl = DEFAULT_PANEL_URL;
+        parsed = new URL(panelUrl);
       }
-      const panelOrigin = new URL(panelUrl).origin;
+      const panelOrigin = parsed.origin;
 
       // ── Iframe setup ──────────────────────────────────────────────────────
       const iframe = document.getElementById("theia-iframe");
-      iframe.src = panelUrl + "/?graph=/graph.json";
+      iframe.src = new URL("/?graph=/graph.json", panelUrl).href;
 
       const loading = document.getElementById("iframe-loading");
 

--- a/plugin/api/plugin_api.py
+++ b/plugin/api/plugin_api.py
@@ -35,7 +35,7 @@ log = logging.getLogger("theia-constellation")
 # ---------------------------------------------------------------------------
 
 THEIA_ENV = os.environ.get("THEIA_ENV", "production")
-THEIA_DEV_HOST = os.environ.get("THEIA_DEV_HOST", "")
+_THEIA_DEV_HOST_RAW = os.environ.get("THEIA_DEV_HOST", "")
 _THEIA_DEV_PORT_RAW = os.environ.get("THEIA_DEV_PORT", "5173")
 
 # ---------------------------------------------------------------------------
@@ -104,6 +104,22 @@ def _resolve_dev_url(host: str) -> str:
     return f"http://{formatted_host}:{_DEV_PORT}"
 
 
+# Validate THEIA_DEV_HOST at import time and cache result, mirroring port
+# validation.  This rejects empty hostnames (e.g. bare ":port" values) and
+# values that resolve to nothing after extraction.
+_THEIA_DEV_HOST: str | None = None
+_THEIA_DEV_HOST_ERROR: str | None = None
+
+_host_stripped = _THEIA_DEV_HOST_RAW.strip()
+if _host_stripped:
+    candidate = _extract_host(_host_stripped)
+    if not candidate:
+        _THEIA_DEV_HOST_ERROR = (
+            f"THEIA_DEV_HOST={_THEIA_DEV_HOST_RAW!r} resolved to empty hostname"
+        )
+    else:
+        _THEIA_DEV_HOST = _host_stripped
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -122,7 +138,7 @@ async def get_config(request: Request):
     config: dict = {"env": THEIA_ENV, "version": "0.1.0"}
 
     if THEIA_ENV == "development":
-        host = THEIA_DEV_HOST or "localhost"
+        host = _THEIA_DEV_HOST or "localhost"
 
         try:
             config["dev_panel_url"] = _resolve_dev_url(host)

--- a/plugin/api/plugin_api.py
+++ b/plugin/api/plugin_api.py
@@ -78,8 +78,12 @@ except ValueError as e:
 def _extract_host(host: str) -> str:
     """Extract hostname from a ``host[:port]`` string, handling IPv6."""
     host = host.strip()
+    if not host:
+        return "localhost"
     if host.startswith("["):
         host = host.split("]")[0][1:]
+        return host or "localhost"
+    if host.count(":") > 1:
         return host
     return host.split(":")[0]
 

--- a/plugin/api/plugin_api.py
+++ b/plugin/api/plugin_api.py
@@ -11,7 +11,10 @@ Environment modes:
   - development: Returns dev_panel_url pointing at Vite dev server
 
 Set THEIA_ENV to control the mode (default: "production").
+Set THEIA_DEV_HOST to override the Vite dev server host (default: derived
+  from incoming request headers).
 Set THEIA_DEV_PORT to control the Vite dev server port (default: 5173).
+Port validation rejects ports < 1024 and well-known Hermes ports (e.g. 9119).
 """
 
 from __future__ import annotations
@@ -19,7 +22,7 @@ from __future__ import annotations
 import logging
 import os
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 from .graph_data import load_graph
@@ -32,7 +35,40 @@ log = logging.getLogger("theia-constellation")
 # ---------------------------------------------------------------------------
 
 THEIA_ENV = os.environ.get("THEIA_ENV", "production")
+THEIA_DEV_HOST = os.environ.get("THEIA_DEV_HOST", "")
 THEIA_DEV_PORT = os.environ.get("THEIA_DEV_PORT", "5173")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BLOCKED_PORTS: set[int] = {9119}
+
+
+def _validate_port(port: str | int) -> int:
+    """Validate and return the port number.
+
+    Raises ``ValueError`` if the port is out of range or blocked.
+    """
+    try:
+        p = int(port)
+    except (ValueError, TypeError):
+        raise ValueError(f"Invalid port: {port!r}")
+
+    if p < 1024:
+        raise ValueError(f"Port {p} is reserved (must be >= 1024)")
+    if p in _BLOCKED_PORTS:
+        raise ValueError(f"Port {p} is blocked (well-known Hermes port)")
+
+    return p
+
+
+def _resolve_dev_url(host: str) -> str:
+    """Build dev panel URL from configuration or request host."""
+    port = _validate_port(THEIA_DEV_PORT)
+    resolved_host = THEIA_DEV_HOST or host
+    return f"http://{resolved_host}:{port}"
+
 
 # ---------------------------------------------------------------------------
 # Routes
@@ -40,16 +76,27 @@ THEIA_DEV_PORT = os.environ.get("THEIA_DEV_PORT", "5173")
 
 
 @router.get("/config")
-async def get_config():
+async def get_config(request: Request):
     """Return plugin configuration including environment info.
 
     In development mode, returns dev_panel_url so the frontend JS
     can proxy the iframe to the Vite dev server for hot-reload.
+    The host is derived from the incoming request headers
+    (``x-forwarded-host`` or ``host``), overridable via ``THEIA_DEV_HOST``.
     """
     config: dict = {"env": THEIA_ENV, "version": "0.1.0"}
 
     if THEIA_ENV == "development":
-        config["dev_panel_url"] = f"http://localhost:{THEIA_DEV_PORT}"
+        forwarded = request.headers.get("x-forwarded-host", "")
+        raw_host = request.headers.get("host", "localhost")
+        host = (forwarded or raw_host).split(":")[0]
+
+        try:
+            config["dev_panel_url"] = _resolve_dev_url(host)
+        except ValueError as e:
+            log.warning("Invalid dev port configuration: %s", e)
+            config["dev_panel_url"] = None
+            config["dev_panel_error"] = str(e)
 
     return config
 

--- a/plugin/api/plugin_api.py
+++ b/plugin/api/plugin_api.py
@@ -11,10 +11,10 @@ Environment modes:
   - development: Returns dev_panel_url pointing at Vite dev server
 
 Set THEIA_ENV to control the mode (default: "production").
-Set THEIA_DEV_HOST to override the Vite dev server host (default: derived
-  from incoming request headers).
+Set THEIA_DEV_HOST to override the Vite dev server host (default: localhost).
 Set THEIA_DEV_PORT to control the Vite dev server port (default: 5173).
-Port validation rejects ports < 1024 and well-known Hermes ports (e.g. 9119).
+Port validation rejects privileged ports (< 1024), ports > 65535, and
+well-known Hermes ports (e.g. 9119).
 """
 
 from __future__ import annotations
@@ -36,13 +36,16 @@ log = logging.getLogger("theia-constellation")
 
 THEIA_ENV = os.environ.get("THEIA_ENV", "production")
 THEIA_DEV_HOST = os.environ.get("THEIA_DEV_HOST", "")
-THEIA_DEV_PORT = os.environ.get("THEIA_DEV_PORT", "5173")
+_THEIA_DEV_PORT_RAW = os.environ.get("THEIA_DEV_PORT", "5173")
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-_BLOCKED_PORTS: set[int] = {9119}
+_BLOCKED_PORTS: frozenset[int] = frozenset({9119})
+
+_DEV_PORT: int | None = None
+_DEV_PORT_ERROR: str | None = None
 
 
 def _validate_port(port: str | int) -> int:
@@ -57,17 +60,44 @@ def _validate_port(port: str | int) -> int:
 
     if p < 1024:
         raise ValueError(f"Port {p} is reserved (must be >= 1024)")
+    if p > 65535:
+        raise ValueError(f"Port {p} is out of range (must be <= 65535)")
     if p in _BLOCKED_PORTS:
         raise ValueError(f"Port {p} is blocked (well-known Hermes port)")
 
     return p
 
 
+try:
+    _DEV_PORT = _validate_port(_THEIA_DEV_PORT_RAW)
+except ValueError as e:
+    _DEV_PORT_ERROR = str(e)
+    log.warning("Invalid THEIA_DEV_PORT configuration: %s", _DEV_PORT_ERROR)
+
+
+def _extract_host(host: str) -> str:
+    """Extract hostname from a ``host[:port]`` string, handling IPv6."""
+    host = host.strip()
+    if host.startswith("["):
+        host = host.split("]")[0][1:]
+        return host
+    return host.split(":")[0]
+
+
+def _format_host_for_url(host: str) -> str:
+    """Wrap IPv6 addresses in brackets for URL use."""
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
 def _resolve_dev_url(host: str) -> str:
     """Build dev panel URL from configuration or request host."""
-    port = _validate_port(THEIA_DEV_PORT)
-    resolved_host = THEIA_DEV_HOST or host
-    return f"http://{resolved_host}:{port}"
+    if _DEV_PORT_ERROR:
+        raise ValueError(_DEV_PORT_ERROR)
+    clean_host = _extract_host(host)
+    formatted_host = _format_host_for_url(clean_host)
+    return f"http://{formatted_host}:{_DEV_PORT}"
 
 
 # ---------------------------------------------------------------------------
@@ -81,20 +111,18 @@ async def get_config(request: Request):
 
     In development mode, returns dev_panel_url so the frontend JS
     can proxy the iframe to the Vite dev server for hot-reload.
-    The host is derived from the incoming request headers
-    (``x-forwarded-host`` or ``host``), overridable via ``THEIA_DEV_HOST``.
+    The host defaults to ``localhost`` and can be overridden via
+    ``THEIA_DEV_HOST``.  Request headers are never trusted for
+    host resolution.
     """
     config: dict = {"env": THEIA_ENV, "version": "0.1.0"}
 
     if THEIA_ENV == "development":
-        forwarded = request.headers.get("x-forwarded-host", "")
-        raw_host = request.headers.get("host", "localhost")
-        host = (forwarded or raw_host).split(":")[0]
+        host = THEIA_DEV_HOST or "localhost"
 
         try:
             config["dev_panel_url"] = _resolve_dev_url(host)
         except ValueError as e:
-            log.warning("Invalid dev port configuration: %s", e)
             config["dev_panel_url"] = None
             config["dev_panel_error"] = str(e)
 

--- a/plugin/api/tests/test_plugin_api.py
+++ b/plugin/api/tests/test_plugin_api.py
@@ -1,0 +1,101 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from api.plugin_api import (  # noqa: E402
+    _extract_host,
+    _format_host_for_url,
+    _validate_port,
+)
+
+
+class TestValidatePort:
+    @pytest.mark.parametrize(
+        ("port", "expected"),
+        [
+            (1024, 1024),
+            (65535, 65535),
+            ("5173", 5173),
+            ("8080", 8080),
+        ],
+    )
+    def test_valid_ports(self, port, expected):
+        assert _validate_port(port) == expected
+
+    @pytest.mark.parametrize(
+        ("port", "match"),
+        [
+            (1023, "reserved"),
+            (80, "reserved"),
+            (65536, "out of range"),
+            (99999, "out of range"),
+            (9119, "blocked"),
+        ],
+    )
+    def test_invalid_ports(self, port, match):
+        with pytest.raises(ValueError, match=match):
+            _validate_port(port)
+
+    @pytest.mark.parametrize(
+        "port",
+        ["not-a-number", "", None],
+    )
+    def test_unparseable_ports(self, port):
+        with pytest.raises(ValueError, match="Invalid port"):
+            _validate_port(port)
+
+
+class TestExtractHost:
+    @pytest.mark.parametrize(
+        ("host", "expected"),
+        [
+            ("localhost", "localhost"),
+            ("127.0.0.1", "127.0.0.1"),
+            ("127.0.0.1:5173", "127.0.0.1"),
+            ("[::1]", "::1"),
+            ("[::1]:5173", "::1"),
+            ("::1", "::1"),
+            ("2001:db8::1", "2001:db8::1"),
+            ("", "localhost"),
+            ("   ", "localhost"),
+            ("0.0.0.0", "0.0.0.0"),
+            ("example.com:8080", "example.com"),
+        ],
+    )
+    def test_extract_host(self, host, expected):
+        assert _extract_host(host) == expected
+
+
+class TestFormatHostForUrl:
+    @pytest.mark.parametrize(
+        ("host", "expected"),
+        [
+            ("localhost", "localhost"),
+            ("127.0.0.1", "127.0.0.1"),
+            ("::1", "[::1]"),
+            ("2001:db8::1", "[2001:db8::1]"),
+            ("[::1]", "[::1]"),
+            ("0.0.0.0", "0.0.0.0"),
+        ],
+    )
+    def test_format_host_for_url(self, host, expected):
+        assert _format_host_for_url(host) == expected
+
+    def test_round_trip_ipv4(self):
+        host = "127.0.0.1"
+        assert _format_host_for_url(_extract_host(host)) == "127.0.0.1"
+
+    def test_round_trip_ipv6_bare(self):
+        host = "::1"
+        assert _format_host_for_url(_extract_host(host)) == "[::1]"
+
+    def test_round_trip_ipv6_bracketed(self):
+        host = "[::1]:5173"
+        assert _format_host_for_url(_extract_host(host)) == "[::1]"
+
+    def test_round_trip_ipv4_with_port(self):
+        host = "192.168.1.1:8080"
+        assert _format_host_for_url(_extract_host(host)) == "192.168.1.1"


### PR DESCRIPTION
## Summary

- Derives `dev_panel_url` from `THEIA_DEV_HOST` env var or defaults to `localhost` (request headers are never trusted)
- Adds `THEIA_DEV_HOST` env var for explicit override
- Adds port validation (rejects <1024, >65535, and port 9119)
- `make dev` binds to `127.0.0.1` by default
- Updates dashboard example and documentation

Closes #45