### PR TITLE
fix(panel): prevent mouseup on side panel from closing it

### DIFF
--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -426,6 +426,8 @@ export async function mount(
   });
 
   element.addEventListener("mouseup", (e) => {
+    const target = e.target as HTMLElement;
+    if (target.closest("aside")) return;
     if (isMouseDown && !hasDragged && performance.now() - lastWheelAt >= 200) {
       const idx = picker.pickAt(e.clientX, e.clientY, 1.0);
       if (idx !== null) {


### PR DESCRIPTION
## Summary

Fixes #58 — clicking the "Focus on connected nodes" checkbox (or close button, or nav links) inside the side panel caused it to close because the `mouseup` event bubbled to the canvas container, which called `sidePanel.hide()`.

## Fix

Added a guard in the `mouseup` handler on the canvas container to return early when the click originated inside the side panel (`<aside>`). This is **Option A** from the issue — minimal, correct, and covers all interactive elements in the panel (checkbox, close button, nav links).

## Verification

- `tsc --noEmit` — passes
- `prettier --check` — passes
- `ruff check` — passes