### PR TITLE
fix(plugin): restore 'View in Sessions' to use full page navigation (#60)

### DIFF
--- a/plugin/src/index.js
+++ b/plugin/src/index.js
@@ -314,10 +314,7 @@
         h(Badge, { variant: "outline", className: "font-courier text-xs truncate max-w-[24ch]" }, selectedNode),
         h(Button, {
           onClick: function () {
-            // issue #24: use pushState to avoid full-page reload for BrowserRouter
-            var url = "#/sessions?id=" + encodeURIComponent(selectedNode);
-            history.pushState({}, "", url);
-            window.dispatchEvent(new PopStateEvent("popstate"));
+            window.location.href = "/sessions?resume=" + encodeURIComponent(selectedNode);
           },
           variant: "outline", size: "sm",
         }, "View in Sessions")


### PR DESCRIPTION
Closes #60

## Summary

The "View in Sessions" button was broken by a bad merge conflict resolution that overwrote the original PR #40 fix. The current code used `history.pushState` with a hash URL (`#/sessions?id=...`), which BrowserRouter cannot handle — resulting in no navigation occurring.

## Fix

Replaced the broken `pushState` + synthetic `popstate` workaround with the correct full-page navigation:

```js
window.location.href = "/sessions?resume=" + encodeURIComponent(selectedNode);
```

This is the same approach used by the "resume in chat" button in the sessions list and matches the original PR #40 fix.

## Verification

- `tsc --noEmit` — passes
- `prettier --check` — passes
- `ruff check` — passes