### PR TITLE
fix(api): make plugin_api importable without parent package — fixes #66

### DIFF
--- a/plugin/api/plugin_api.py
+++ b/plugin/api/plugin_api.py
@@ -25,7 +25,39 @@ import os
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
-from .graph_data import load_graph
+# Resolve ``load_graph`` in a way that works regardless of how this module
+# is imported by the host dashboard.
+#
+# The Hermes plugin loader has historically used
+# ``importlib.util.spec_from_file_location`` with a flat module name and no
+# parent package, which makes the relative form ``from .graph_data import ...``
+# raise ``ImportError: attempted relative import with no known parent package``.
+# When that import fails the FastAPI router never registers, the ``/graph``
+# route falls through to the SPA catch-all, and the frontend tries to
+# ``JSON.parse`` an HTML page (issue #66).
+#
+# The proper fix is to upstream the package-aware loader patch
+# (``submodule_search_locations`` + synthetic parent package), but until that
+# reaches every Hermes install we keep this module portable: prefer the
+# relative import when we *are* loaded as part of a package, and fall back
+# to a direct file load otherwise.
+try:
+    from .graph_data import load_graph  # noqa: F401  (preferred path)
+except ImportError:  # pragma: no cover - exercised on un-patched Hermes loaders
+    import importlib.util
+    from pathlib import Path
+
+    _graph_data_path = Path(__file__).with_name("graph_data.py")
+    _spec = importlib.util.spec_from_file_location(
+        "_theia_constellation_graph_data", _graph_data_path
+    )
+    if _spec is None or _spec.loader is None:  # pragma: no cover - defensive
+        raise ImportError(
+            f"Cannot load graph_data module from {_graph_data_path}"
+        ) from None
+    _graph_data = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_graph_data)
+    load_graph = _graph_data.load_graph
 
 router = APIRouter()
 log = logging.getLogger("theia-constellation")

--- a/plugin/api/tests/test_plugin_api.py
+++ b/plugin/api/tests/test_plugin_api.py
@@ -99,3 +99,56 @@ class TestFormatHostForUrl:
     def test_round_trip_ipv4_with_port(self):
         host = "192.168.1.1:8080"
         assert _format_host_for_url(_extract_host(host)) == "192.168.1.1"
+
+
+class TestStandaloneImport:
+    """Regression tests for issue #66.
+
+    The Hermes dashboard plugin loader has historically loaded the API
+    module via ``importlib.util.spec_from_file_location`` with a flat
+    module name and no parent package.  Under that loader, the module's
+    ``from .graph_data import load_graph`` would raise
+    ``ImportError: attempted relative import with no known parent package``,
+    causing the FastAPI router to never register and the dashboard to
+    fail with ``JSON.parse: unexpected character`` on ``/graph``.
+
+    These tests exercise both loader shapes to ensure the module remains
+    portable across Hermes versions.
+    """
+
+    def _load(self, fqn: str, *, with_parent_package: bool):
+        import importlib.machinery
+        import importlib.util
+
+        api_path = Path(__file__).resolve().parents[1] / "plugin_api.py"
+        plugin_dir = api_path.parent
+
+        if with_parent_package:
+            pkg_name = f"{fqn}_pkg"
+            pkg_spec = importlib.machinery.ModuleSpec(pkg_name, None, is_package=True)
+            pkg_spec.submodule_search_locations = [str(plugin_dir)]
+            pkg_mod = importlib.util.module_from_spec(pkg_spec)
+            pkg_mod.__path__ = [str(plugin_dir)]
+            sys.modules[pkg_name] = pkg_mod
+            spec = importlib.util.spec_from_file_location(f"{pkg_name}.plugin_api", api_path)
+            mod = importlib.util.module_from_spec(spec)
+            mod.__package__ = pkg_name
+            sys.modules[f"{pkg_name}.plugin_api"] = mod
+        else:
+            spec = importlib.util.spec_from_file_location(fqn, api_path)
+            mod = importlib.util.module_from_spec(spec)
+
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_loads_without_parent_package(self):
+        """Pre-#66 loader: relative import must fall back gracefully."""
+        mod = self._load("issue66_no_parent", with_parent_package=False)
+        assert callable(mod.load_graph)
+        assert mod.router is not None
+
+    def test_loads_with_parent_package(self):
+        """Post-#66 loader: relative import must continue to work."""
+        mod = self._load("issue66_with_parent", with_parent_package=True)
+        assert callable(mod.load_graph)
+        assert mod.router is not None


### PR DESCRIPTION
## Summary

Fixes #66.

The Hermes dashboard's plugin loader (`_mount_plugin_api_routes`) has historically used `importlib.util.spec_from_file_location` with a flat module name and no parent package. Under that loader, `from .graph_data import load_graph` at `plugin/api/plugin_api.py:28` raises `ImportError: attempted relative import with no known parent package`, the FastAPI router never registers, and `/api/plugins/theia-constellation/graph` falls through to the SPA catch-all returning `index.html`. The frontend's `JSON.parse(html)` then surfaces the **"Graph data unavailable — JSON.parse: unexpected character at line 1 column 1"** banner reported in the issue.

A package-aware loader patch already exists upstream ([`zebster-cmd/hermes-agent@306acc97`](https://github.com/zebster-cmd/hermes-agent/commit/306acc97) — `fix(web_server): support relative imports in plugin API loader`) but has not yet propagated to every Hermes install (notably not to `NousResearch/hermes-agent` upstream). Until it does, this change keeps the Theia plugin portable.

## Approach

Make `plugin_api.py` resilient to either loader shape:

- **Try the relative import first** — works on patched loaders, native Python imports, and pytest collection.
- **Fall back to a direct file load** of `graph_data.py` via `importlib.util.spec_from_file_location` when the relative import fails, exposing `load_graph` as a module-level binding so the rest of the file is unchanged.

No changes to the public surface — `router`, `load_graph`, route handlers all behave exactly as before. The fallback only kicks in when the host loader doesn't register a parent package.

## Tests

Adds `TestStandaloneImport` to `plugin/api/tests/test_plugin_api.py`. The class spins up both loader shapes inline:

| Test | Loader shape | Mirrors |
|---|---|---|
| `test_loads_without_parent_package` | flat `spec_from_file_location`, no parent package, no `submodule_search_locations` | Pre-`306acc97` Hermes / vanilla NousResearch |
| `test_loads_with_parent_package` | synthetic parent package with `submodule_search_locations` and `mod.__package__` set | Post-`306acc97` Hermes (zebster-cmd fork) |

Both assert the module exposes a callable `load_graph` and a non-`None` `router`.

## Verification

```text
$ ruff check plugin/api/*.py
All checks passed!

$ ruff format --check plugin/api/*.py
3 files already formatted

$ python3 -m pytest plugin/api/tests/test_plugin_api.py -v
...
35 passed in 0.10s
```

Manual repro confirming the test exercises the regression:

```text
$ python3 -c "..."  # load origin/main:plugin/api/plugin_api.py via flat loader
EXPECTED FAIL on unpatched file under broken loader: attempted relative import with no known parent package
```

Same loader shape against the patched file in this PR loads cleanly and exposes the FastAPI router.

## Why Theia-side instead of Hermes-side

The previously-discussed strategy was to upstream the loader patch on the Hermes side. That work exists on `zebster-cmd/hermes-agent@306acc97` and remains the right long-term fix, but it requires getting changes into Hermes installs that aren't under our control. This PR is the complementary Theia-side change so the plugin works **today** on every Hermes version — including stock `NousResearch/hermes-agent`, the various forks, and any user who installed via `curl … | bash` before the loader patch lands.

If/when `306acc97` reaches every Hermes install, the fallback branch becomes dead code but does no harm; we can revisit removing it then.

## Files touched

- `plugin/api/plugin_api.py` — replace single relative import with try/except fallback (+34/-1)
- `plugin/api/tests/test_plugin_api.py` — add `TestStandaloneImport` regression class (+53)

Closes #66.
