### PR TITLE
fix: memory-share and cron-chain edges missing from graph

### DIFF
--- a/theia-core/theia_core/detect/memory_share.py
+++ b/theia-core/theia_core/detect/memory_share.py
@@ -18,14 +18,15 @@ def detect_memory_share(sessions: Iterable[Session]) -> list[Edge]:
                 continue
             if event.memory_id in last_writer:
                 last_id, last_sal = last_writer[event.memory_id]
-                edges.append(
-                    Edge(
-                        source=last_id,
-                        target=sess.id,
-                        kind="memory-share",
-                        weight=min(1.0, max(last_sal, event.salience)),
-                        evidence={"memory_id": event.memory_id},
+                if last_id != sess.id:
+                    edges.append(
+                        Edge(
+                            source=last_id,
+                            target=sess.id,
+                            kind="memory-share",
+                            weight=min(1.0, max(last_sal, event.salience)),
+                            evidence={"memory_id": event.memory_id},
+                        )
                     )
-                )
             last_writer[event.memory_id] = (sess.id, event.salience)
     return edges

--- a/theia-core/theia_core/ingest.py
+++ b/theia-core/theia_core/ingest.py
@@ -89,14 +89,19 @@ def _infer_memory_events(tool_calls: list[ToolCall]) -> list[MemoryEvent]:
             args = {}
         action = str(args.get("action", "")).lower()
         write_actions = {"write", "store", "save", "add", "replace", "remove"}
-        kind = "write" if action in write_actions else "read"
+        has_content = "content" in args or "old_text" in args
+        kind = "write" if (action in write_actions) or (not action and has_content) else "read"
 
-        mem_id = str(args.get("memory_id", args.get("id", "")))
+        mem_id = str(args.get("memory_id", args.get("id", args.get("target", ""))))
         if not mem_id:
             content = ""
             if action in ("add", "replace") and "content" in args:
                 content = str(args["content"])
             elif action in ("replace", "remove") and "old_text" in args:
+                content = str(args["old_text"])
+            elif "content" in args:
+                content = str(args["content"])
+            elif "old_text" in args:
                 content = str(args["old_text"])
             mem_id = hashlib.sha256(content.encode()).hexdigest()[:16] if content else "unknown"
         events.append(MemoryEvent(kind=kind, memory_id=mem_id, raw=tc.raw))


### PR DESCRIPTION
## Summary

Fixes two edge kinds not appearing in the generated constellation graph.

### memory-share (was 0 on real DB before the fix)

Two bugs in `_infer_memory_events` (`theia-core/theia_core/ingest.py`):

1. **Missing `target` fallback**: The Hermes memory tool uses `target` (e.g. `"user"`, `"memory"`) instead of `memory_id`/`id` in its arguments. The fallback was content-hashing, which produced unique IDs per call — no two sessions ever shared a memory_id, so no edges were created. Added `args.get("target", "")` to the fallback chain.

2. **Missing action misclassified as read**: Tool calls without an explicit `action` field but with `content`/`old_text` were treated as reads. Now correctly classified as writes.

One bug in `detect_memory_share` (`theia-core/theia_core/detect/memory_share.py`):

3. **Self-loop edges**: When a session had multiple memory events for the same target, `source` and `target` were the same session. Added a `last_id != sess.id` guard.

### cron-chain (was 0 on real DB before the fix)

Already working in current code — the stale deployed graph simply predated the cron.py detector. No code change needed.

### Verification

- All 39 existing tests pass
- `ruff check` and `ruff format --check` clean
- Production graph regenerated at `~/.hermes/theia-graph.json`