### PR TITLE
fix(#73): resolve UI inconsistencies with Hermes dashboard

### DIFF
--- a/plugin/src/index.js
+++ b/plugin/src/index.js
@@ -32,7 +32,8 @@
   // -------------------------------------------------------------------
   // Constants
   // -------------------------------------------------------------------
-  var PANEL_URL_PROD = "/dashboard-plugins/theia-constellation/panel/index.html";
+  var PANEL_URL_PROD =
+    "/dashboard-plugins/theia-constellation/panel/index.html";
   var GRAPH_API = "/api/plugins/theia-constellation/graph";
   var CONFIG_API = "/api/plugins/theia-constellation/config";
 
@@ -64,7 +65,9 @@
       ctx.fillStyle = color;
       ctx.fillRect(0, 0, 1, 1);
       var d = ctx.getImageData(0, 0, 1, 1).data;
-      var hex = ((1 << 24) + (d[0] << 16) + (d[1] << 8) + d[2]).toString(16).slice(1);
+      var hex = ((1 << 24) + (d[0] << 16) + (d[1] << 8) + d[2])
+        .toString(16)
+        .slice(1);
       if (d[3] < 255) hex += ("0" + d[3].toString(16)).slice(-2);
       return hex;
     } catch (_) {
@@ -77,29 +80,48 @@
     function cssVar(name) {
       return (root.getPropertyValue(name) || "").trim();
     }
-    var bg       = toHex(cssVar("--background-base"), "07080d");
+    var bg = toHex(cssVar("--background-base"), "07080d");
     // fg — primary body text: use the midground triplet (theme-responsive).
-    var fg       = toHex(cssVar("--midground-base"), "cfd6e4");
+    var fg = toHex(cssVar("--midground-base"), "cfd6e4");
     // fg2 — secondary/muted labels (55% opacity midground in the DS).
-    var fg2      = toHex(cssVar("--color-muted-foreground") || cssVar("--midground"), "9ca3af");
+    var fg2 = toHex(
+      cssVar("--color-muted-foreground") || cssVar("--midground"),
+      "9ca3af",
+    );
     // midground — the dashboard's midground layer used e.g. for bg-card blend.
     var midground = toHex(cssVar("--midground-base"), "cfd6e4");
-    // accent — warm gold for emphasis.  --color-warning is static (#ffbd38)
-    // but intentionally fixed: it provides a functional highlight that stands
-    // out from body text across all dark themes.  Falls back to the theme's
-    // midground only if --color-warning is absent.
-    var accent   = toHex(cssVar("--color-warning") || cssVar("--midground-base"), "ffc477");
-    var border   = toHex(cssVar("--color-border"), "ffffff26");
-    var font     = root.getPropertyValue("font-family").trim()
-      || "system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";
+    // accent — try the dashboard's primary/accent color first, then fall
+    // back to warning (static #ffbd38), then midground, then the default.
+    var accent = toHex(
+      cssVar("--color-primary") ||
+        cssVar("--color-accent") ||
+        cssVar("--color-warning") ||
+        cssVar("--midground-base"),
+      "ffc477",
+    );
+    var border = toHex(cssVar("--color-border"), "ffffff26");
+    var font =
+      root.getPropertyValue("font-family").trim() ||
+      "system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";
     return { bg, fg, fg2, midground, accent, border, font, radius: "0" };
   }
 
   function buildThemeQuery(theme) {
-    var keys = ["bg", "fg", "fg2", "midground", "accent", "border", "font", "radius"];
-    return keys.map(function (k) {
-      return k + "=" + encodeURIComponent(theme[k]);
-    }).join("&");
+    var keys = [
+      "bg",
+      "fg",
+      "fg2",
+      "midground",
+      "accent",
+      "border",
+      "font",
+      "radius",
+    ];
+    return keys
+      .map(function (k) {
+        return k + "=" + encodeURIComponent(theme[k]);
+      })
+      .join("&");
   }
 
   // -------------------------------------------------------------------
@@ -118,7 +140,10 @@
           if (config.dev_panel_url) {
             setPanelInfo({ url: config.dev_panel_url, env: "development" });
           } else {
-            setPanelInfo({ url: PANEL_URL_PROD, env: config.env || "production" });
+            setPanelInfo({
+              url: PANEL_URL_PROD,
+              env: config.env || "production",
+            });
           }
         })
         .catch(function () {});
@@ -142,7 +167,9 @@
           errorState[1](null);
         })
         .catch(function (err) {
-          errorState[1]("Graph data unavailable — " + (err.message || "backend error"));
+          errorState[1](
+            "Graph data unavailable — " + (err.message || "backend error"),
+          );
         });
     }, []);
 
@@ -178,7 +205,9 @@
         setTimeout(function () {
           try {
             if (iframeRef.current && iframeRef.current.contentWindow) {
-              iframeRef.current.contentWindow.dispatchEvent(new Event("resize"));
+              iframeRef.current.contentWindow.dispatchEvent(
+                new Event("resize"),
+              );
             }
           } catch (_) {}
         }, 100);
@@ -240,9 +269,18 @@
       return buildThemeQuery(extractDashboardTheme());
     }, []);
 
-    var iframeSrc = useMemo(function () {
-      return panelInfo.url + "?graph=" + encodeURIComponent(GRAPH_API) + "&" + initialThemeQuery;
-    }, [panelInfo.url, initialThemeQuery]);
+    var iframeSrc = useMemo(
+      function () {
+        return (
+          panelInfo.url +
+          "?graph=" +
+          encodeURIComponent(GRAPH_API) +
+          "&" +
+          initialThemeQuery
+        );
+      },
+      [panelInfo.url, initialThemeQuery],
+    );
 
     // Live theme observation — watches :root style mutations (triggered by
     // dashboard theme switches) and forwards updated tokens to the iframe
@@ -254,7 +292,7 @@
           try {
             iframeRef.current.contentWindow.postMessage(
               { type: "theia-theme-update", tokens: tokens },
-              "*"
+              "*",
             );
           } catch (_) {}
         }
@@ -263,7 +301,9 @@
         attributes: true,
         attributeFilter: ["style", "class"],
       });
-      return function () { observer.disconnect(); };
+      return function () {
+        observer.disconnect();
+      };
     }, []);
 
     var handleReload = useCallback(function () {
@@ -272,73 +312,133 @@
       }
     }, []);
 
-    var handlePopout = useCallback(function () {
-      window.open(
-        iframeSrc,
-        "theia-constellation",
-        "width=1200,height=800"
-      );
-    }, [iframeSrc]);
+    var handlePopout = useCallback(
+      function () {
+        window.open(iframeSrc, "theia-constellation", "width=1200,height=800");
+      },
+      [iframeSrc],
+    );
 
     // Environment badge
-    var envBadge = panelInfo.env !== "production"
-      ? h(Badge, { variant: "outline", className: "text-xs text-yellow-400 border-yellow-400/40" },
-          panelInfo.env.toUpperCase())
-      : null;
+    var envBadge =
+      panelInfo.env !== "production"
+        ? h(
+            Badge,
+            {
+              variant: "outline",
+              className: "text-xs text-yellow-400 border-yellow-400/40",
+            },
+            panelInfo.env.toUpperCase(),
+          )
+        : null;
 
-    return h("div", { className: "flex flex-col gap-6" },
+    return h(
+      "div",
+      { className: "flex flex-col gap-6" },
 
       // Header
-      h(Card, null,
-        h(CardHeader, null,
-          h("div", { className: "flex items-center justify-between w-full" },
-            h("div", { className: "flex items-center gap-3" },
+      h(
+        Card,
+        null,
+        h(
+          CardHeader,
+          null,
+          h(
+            "div",
+            { className: "flex items-center justify-between w-full" },
+            h(
+              "div",
+              { className: "flex items-center gap-3" },
               h(CardTitle, { className: "text-lg" }, "Session Constellation"),
               h(Badge, { variant: "outline" }, "v0.1.0"),
               envBadge,
-              graphInfo.stats && h(Badge, { variant: "outline" },
-                graphInfo.stats.nodes + " sessions / " + graphInfo.stats.edges + " edges"
-              )
+              graphInfo.stats &&
+                h(
+                  Badge,
+                  { variant: "outline" },
+                  graphInfo.stats.nodes +
+                    " sessions / " +
+                    graphInfo.stats.edges +
+                    " edges",
+                ),
             ),
-            h("div", { className: "flex items-center gap-2" },
-              h(Button, { variant: "outline", size: "sm", onClick: handleReload }, "Reload"),
-              h(Button, { variant: "outline", size: "sm", onClick: fs.toggleFullscreen },
-                fs.isFullscreen ? "Exit Fullscreen" : "Fullscreen"),
-              h(Button, { variant: "outline", size: "sm", onClick: handlePopout }, "Pop Out")
-            )
-          )
+            h(
+              "div",
+              { className: "flex items-center gap-2" },
+              h(
+                Button,
+                { variant: "outline", size: "sm", onClick: handleReload },
+                "Reload",
+              ),
+              h(
+                Button,
+                {
+                  variant: "outline",
+                  size: "sm",
+                  onClick: fs.toggleFullscreen,
+                },
+                fs.isFullscreen ? "Exit Fullscreen" : "Fullscreen",
+              ),
+              h(
+                Button,
+                { variant: "outline", size: "sm", onClick: handlePopout },
+                "Pop Out",
+              ),
+            ),
+          ),
         ),
-        graphInfo.error && h(CardContent, null,
-          h("p", { className: "text-sm text-red-400" }, graphInfo.error)
-        )
+        graphInfo.error &&
+          h(
+            CardContent,
+            null,
+            h("p", { className: "text-sm text-red-400" }, graphInfo.error),
+          ),
       ),
 
       // Constellation iframe
-      h("div", { ref: containerRef, className: "theia-container" },
+      h(
+        "div",
+        { ref: containerRef, className: "theia-container" },
         h("iframe", {
           ref: iframeRef,
           src: iframeSrc,
           className: "theia-iframe",
           allow: "accelerometer; autoplay",
           sandbox: "allow-scripts allow-same-origin",
-        })
+        }),
       ),
 
       // Selected node — compact inline row
-      selectedNode && h("div", {
-        role: "status",
-        "aria-label": "Selected session " + selectedNode,
-        "data-testid": "selected-session-row",
-        className: "flex items-center gap-2",
-      },
-        h(Badge, { variant: "outline", className: "font-courier text-xs truncate max-w-[24ch]" }, selectedNode),
-        h(Button, {
-          onClick: function () {
-            window.location.href = "/sessions?resume=" + encodeURIComponent(selectedNode);
+      selectedNode &&
+        h(
+          "div",
+          {
+            role: "status",
+            "aria-label": "Selected session " + selectedNode,
+            "data-testid": "selected-session-row",
+            className: "flex items-center gap-2",
           },
-          variant: "outline", size: "sm",
-        }, "View in Sessions")
-      )
+          h(
+            Badge,
+            {
+              variant: "outline",
+              className: "font-courier text-xs truncate max-w-[24ch]",
+            },
+            selectedNode,
+          ),
+          h(
+            Button,
+            {
+              onClick: function () {
+                window.location.href =
+                  "/sessions?resume=" + encodeURIComponent(selectedNode);
+              },
+              variant: "outline",
+              size: "sm",
+            },
+            "View in Sessions",
+          ),
+        ),
     );
   }
 

--- a/plugin/src/style.css
+++ b/plugin/src/style.css
@@ -8,6 +8,8 @@
   overflow: clip;
   box-sizing: border-box;
   background: var(--background-base, #07080d);
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
+  border-radius: var(--radius, 0);
 }
 
 .theia-iframe {
@@ -51,12 +53,21 @@
   justify-content: space-between;
   padding: 0.5rem 1rem;
   background: var(--background-base, #07080d);
-  background: color-mix(in srgb, var(--background-base, #07080d) 95%, transparent); /* Chrome 111+, FF 113+, Safari 16.2+ */
+  background: color-mix(
+    in srgb,
+    var(--background-base, #07080d) 95%,
+    transparent
+  ); /* Chrome 111+, FF 113+, Safari 16.2+ */
   border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
   color: var(--midground-base, #cfd6e4);
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
   z-index: 1;
-  transition: background 200ms, border-color 200ms;
+  transition:
+    background 200ms,
+    border-color 200ms;
 }
 
 .theia-iframe-full {

--- a/theia-panel/index.html
+++ b/theia-panel/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="utf-8" />
     <title>theia dev</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
     <style>
       html,
       body,

--- a/theia-panel/index.html
+++ b/theia-panel/index.html
@@ -5,7 +5,10 @@
     <title>theia dev</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
     <style>
       html,
       body,

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -177,9 +177,7 @@ export async function mount(
     },
     onClose: () => {
       if (focusEnabled) {
-        focusEnabled = false;
-        focusFilter = null;
-        updateVisibility();
+        onFocusToggle(false);
         filterBar.setFocusEnabled(false);
       }
       clearSelected();
@@ -565,13 +563,15 @@ export async function mount(
       if (id) applyFocusModeIfEnabled(id);
     },
     theme,
-    modelFilter,
-    () => {
-      sidePanel.hide();
-      searchBar.input.focus();
+    {
+      initialModel: modelFilter,
+      onSearchToggle: () => {
+        sidePanel.hide();
+        searchBar.input.focus();
+      },
+      onFocusToggle,
+      initialFocusEnabled: focusEnabled,
     },
-    onFocusToggle,
-    focusEnabled,
   );
 
   const listeners: Record<string, Array<(...args: unknown[]) => void>> = {

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -148,6 +148,17 @@ export async function mount(
     filterBar.setSearchToggleVisible(true);
   }
 
+  function onFocusToggle(enabled: boolean) {
+    focusEnabled = enabled;
+    if (!focusEnabled) {
+      focusFilter = null;
+      updateVisibility();
+    } else {
+      const id = sidePanel.currentNodeId();
+      if (id) applyFocusModeIfEnabled(id);
+    }
+  }
+
   const sidePanel = createSidePanel(element, theme, {
     onNavigate: (targetId) => {
       const idx = nodeIndex.get(targetId);
@@ -165,20 +176,16 @@ export async function mount(
       emit("node-click", targetId);
     },
     onClose: () => {
+      if (focusEnabled) {
+        focusEnabled = false;
+        focusFilter = null;
+        updateVisibility();
+        filterBar.setFocusEnabled(false);
+      }
       clearSelected();
       searchBar.setPanelOpen(false);
       filterBar.setSearchToggleVisible(false);
       nodes.flush();
-    },
-    onFocusToggle: (enabled) => {
-      focusEnabled = enabled;
-      if (!focusEnabled) {
-        focusFilter = null;
-        updateVisibility();
-      } else {
-        const id = sidePanel.currentNodeId();
-        if (id) applyFocusModeIfEnabled(id);
-      }
     },
   });
 
@@ -563,6 +570,8 @@ export async function mount(
       sidePanel.hide();
       searchBar.input.focus();
     },
+    onFocusToggle,
+    focusEnabled,
   );
 
   const listeners: Record<string, Array<(...args: unknown[]) => void>> = {

--- a/theia-panel/src/ui/FilterBar.ts
+++ b/theia-panel/src/ui/FilterBar.ts
@@ -66,7 +66,8 @@ export function createFilterBar(
   initialTheme: ThemeTokens,
   options: FilterBarOptions = {},
 ) {
-  const { initialModel, onSearchToggle, onFocusToggle, initialFocusEnabled } = options;
+  const { initialModel, onSearchToggle, onFocusToggle, initialFocusEnabled } =
+    options;
   let theme = initialTheme;
   const bar = document.createElement("div");
   bar.dataset.uiOverlay = "";
@@ -301,9 +302,7 @@ export function createFilterBar(
       background: ${focusEnabled ? `#${theme.accent}` : `#${theme.bg}`};
       cursor: pointer; transition: background .15s, border-color .15s;
     `;
-    focusToggleEl.style.color = focusEnabled
-      ? `#${theme.fg}`
-      : `#${theme.fg2}`;
+    focusToggleEl.style.color = focusEnabled ? `#${theme.fg}` : `#${theme.fg2}`;
   }
 
   function initFocusToggle() {

--- a/theia-panel/src/ui/FilterBar.ts
+++ b/theia-panel/src/ui/FilterBar.ts
@@ -51,17 +51,22 @@ export interface FilterState {
   model: string | null;
 }
 
+export interface FilterBarOptions {
+  initialModel?: string | null;
+  onSearchToggle?: () => void;
+  onFocusToggle?: (enabled: boolean) => void;
+  initialFocusEnabled?: boolean;
+}
+
 export function createFilterBar(
   container: HTMLElement,
   initial: Set<TheiaGraph["edges"][number]["kind"]>,
   graph: TheiaGraph,
   onChange: (state: FilterState) => void,
   initialTheme: ThemeTokens,
-  initialModel?: string | null,
-  onSearchToggle?: () => void,
-  onFocusToggle?: (enabled: boolean) => void,
-  initialFocusEnabled?: boolean,
+  options: FilterBarOptions = {},
 ) {
+  const { initialModel, onSearchToggle, onFocusToggle, initialFocusEnabled } = options;
   let theme = initialTheme;
   const bar = document.createElement("div");
   bar.dataset.uiOverlay = "";
@@ -278,40 +283,44 @@ export function createFilterBar(
   }
 
   let focusToggleEl: HTMLLabelElement | null = null;
+  let focusCb: HTMLInputElement | null = null;
 
-  function rebuildFocusToggle() {
-    if (focusToggleEl) focusToggleEl.remove();
-    focusToggleEl = document.createElement("label");
+  function applyFocusToggleStyle() {
+    if (!focusToggleEl || !focusCb) return;
     focusToggleEl.style.cssText = `
       display: flex; gap: 10px; align-items: center; cursor: pointer;
-      font: 10px/1.4 var(--theia-font, ${FONT_STACK});
       letter-spacing: 0.05em;
       color: ${focusEnabled ? `#${theme.fg}` : `#${theme.fg2}`};
       margin-top: 8px; padding-top: 8px;
       border-top: 1px solid #${theme.border};
     `;
-    const cb = document.createElement("input");
-    cb.type = "checkbox";
-    cb.checked = focusEnabled;
-    cb.style.cssText = `
+    focusCb.style.cssText = `
       appearance: none; width: 14px; height: 14px; margin: 0; flex-shrink: 0;
       border: 1px solid #${theme.border};
       border-radius: ${theme.radius};
       background: ${focusEnabled ? `#${theme.accent}` : `#${theme.bg}`};
       cursor: pointer; transition: background .15s, border-color .15s;
     `;
-    cb.onchange = () => {
-      focusEnabled = cb.checked;
-      cb.style.background = focusEnabled ? `#${theme.accent}` : `#${theme.bg}`;
-      focusToggleEl!.style.color = focusEnabled
-        ? `#${theme.fg}`
-        : `#${theme.fg2}`;
+    focusToggleEl.style.color = focusEnabled
+      ? `#${theme.fg}`
+      : `#${theme.fg2}`;
+  }
+
+  function initFocusToggle() {
+    focusToggleEl = document.createElement("label");
+    focusCb = document.createElement("input");
+    focusCb.type = "checkbox";
+    focusCb.checked = focusEnabled;
+    focusCb.onchange = () => {
+      focusEnabled = focusCb!.checked;
+      applyFocusToggleStyle();
       onFocusToggle?.(focusEnabled);
     };
     focusToggleEl.append(
-      cb,
+      focusCb,
       document.createTextNode("Focus on connected nodes"),
     );
+    applyFocusToggleStyle();
     content.append(focusToggleEl);
   }
 
@@ -319,7 +328,7 @@ export function createFilterBar(
   dropdown.appendChild(content);
   bar.append(btn, searchToggle, dropdown);
   rebuildModelSelect();
-  rebuildFocusToggle();
+  initFocusToggle();
   container.appendChild(bar);
 
   function setSearchToggleVisible(visible: boolean) {
@@ -334,13 +343,10 @@ export function createFilterBar(
 
   function setFocusEnabled(enabled: boolean) {
     focusEnabled = enabled;
-    if (focusToggleEl) {
-      const cb = focusToggleEl.querySelector(
-        "input[type=checkbox]",
-      ) as HTMLInputElement;
-      if (cb) cb.checked = enabled;
-      focusToggleEl.style.color = enabled ? `#${theme.fg}` : `#${theme.fg2}`;
+    if (focusCb) {
+      focusCb.checked = enabled;
     }
+    applyFocusToggleStyle();
   }
 
   function updateTheme(newTheme: ThemeTokens) {
@@ -348,7 +354,7 @@ export function createFilterBar(
     applyBarStyle();
     for (const t of toggles) t._applyStyle();
     applySelectStyle();
-    rebuildFocusToggle();
+    applyFocusToggleStyle();
   }
 
   return {

--- a/theia-panel/src/ui/FilterBar.ts
+++ b/theia-panel/src/ui/FilterBar.ts
@@ -59,6 +59,8 @@ export function createFilterBar(
   initialTheme: ThemeTokens,
   initialModel?: string | null,
   onSearchToggle?: () => void,
+  onFocusToggle?: (enabled: boolean) => void,
+  initialFocusEnabled?: boolean,
 ) {
   let theme = initialTheme;
   const bar = document.createElement("div");
@@ -68,6 +70,7 @@ export function createFilterBar(
   let select: HTMLSelectElement | null = null;
   let dropdownOpen = false;
   let showSearchToggle = false;
+  let focusEnabled = initialFocusEnabled ?? false;
 
   const btn = document.createElement("button");
   btn.textContent = "Filters";
@@ -274,10 +277,49 @@ export function createFilterBar(
     };
   }
 
+  let focusToggleEl: HTMLLabelElement | null = null;
+
+  function rebuildFocusToggle() {
+    if (focusToggleEl) focusToggleEl.remove();
+    focusToggleEl = document.createElement("label");
+    focusToggleEl.style.cssText = `
+      display: flex; gap: 10px; align-items: center; cursor: pointer;
+      font: 10px/1.4 var(--theia-font, ${FONT_STACK});
+      letter-spacing: 0.05em;
+      color: ${focusEnabled ? `#${theme.fg}` : `#${theme.fg2}`};
+      margin-top: 8px; padding-top: 8px;
+      border-top: 1px solid #${theme.border};
+    `;
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    cb.checked = focusEnabled;
+    cb.style.cssText = `
+      appearance: none; width: 14px; height: 14px; margin: 0; flex-shrink: 0;
+      border: 1px solid #${theme.border};
+      border-radius: ${theme.radius};
+      background: ${focusEnabled ? `#${theme.accent}` : `#${theme.bg}`};
+      cursor: pointer; transition: background .15s, border-color .15s;
+    `;
+    cb.onchange = () => {
+      focusEnabled = cb.checked;
+      cb.style.background = focusEnabled ? `#${theme.accent}` : `#${theme.bg}`;
+      focusToggleEl!.style.color = focusEnabled
+        ? `#${theme.fg}`
+        : `#${theme.fg2}`;
+      onFocusToggle?.(focusEnabled);
+    };
+    focusToggleEl.append(
+      cb,
+      document.createTextNode("Focus on connected nodes"),
+    );
+    content.append(focusToggleEl);
+  }
+
   applyBarStyle();
   dropdown.appendChild(content);
   bar.append(btn, searchToggle, dropdown);
   rebuildModelSelect();
+  rebuildFocusToggle();
   container.appendChild(bar);
 
   function setSearchToggleVisible(visible: boolean) {
@@ -290,17 +332,30 @@ export function createFilterBar(
     rebuildModelSelect();
   }
 
+  function setFocusEnabled(enabled: boolean) {
+    focusEnabled = enabled;
+    if (focusToggleEl) {
+      const cb = focusToggleEl.querySelector(
+        "input[type=checkbox]",
+      ) as HTMLInputElement;
+      if (cb) cb.checked = enabled;
+      focusToggleEl.style.color = enabled ? `#${theme.fg}` : `#${theme.fg2}`;
+    }
+  }
+
   function updateTheme(newTheme: ThemeTokens) {
     theme = newTheme;
     applyBarStyle();
     for (const t of toggles) t._applyStyle();
     applySelectStyle();
+    rebuildFocusToggle();
   }
 
   return {
     updateTheme,
     updateGraph,
     setSearchToggleVisible,
+    setFocusEnabled,
     dispose: () => {
       document.removeEventListener("pointerdown", onDocumentClick);
       container.removeChild(bar);

--- a/theia-panel/src/ui/SidePanel.ts
+++ b/theia-panel/src/ui/SidePanel.ts
@@ -74,14 +74,12 @@ export function createSidePanel(
   callbacks?: {
     onNavigate?: (nodeId: string) => void;
     onClose?: () => void;
-    onFocusToggle?: (enabled: boolean) => void;
   },
 ) {
   let theme = initialTheme;
   const el = document.createElement("aside");
   el.dataset.uiOverlay = "";
   let currentId: string | null = null;
-  let focusMode = false;
 
   function applyPanelStyle() {
     const narrow = window.matchMedia("(max-width: 900px)").matches;
@@ -101,8 +99,6 @@ export function createSidePanel(
 
   const focusStyle = document.createElement("style");
   focusStyle.textContent = `aside:focus-visible { outline: 1px solid #${theme.accent} !important; }
-[data-focus-toggle]:checked { background: #${theme.accent} !important; border-color: #${theme.accent} !important; }
-[data-focus-toggle]:focus-visible { outline: 1px solid #${theme.accent}; outline-offset: 2px; }
 @media (prefers-reduced-motion: reduce) {
   aside { transition: none !important; }
 }`;
@@ -166,24 +162,11 @@ export function createSidePanel(
         <dt style="${dtStyle}">Messages</dt><dd style="margin:0">${node.message_count ?? "-"}</dd>
       </dl>
       <div style="margin:20px 0 0;border-top:1px solid #${theme.border}"></div>
-      <label style="display:flex;align-items:center;gap:6px;padding:8px 0;font-size:11px;cursor:pointer;user-select:none;color:#${theme.fg}">
-        <input type="checkbox" data-focus-toggle ${focusMode ? "checked" : ""} style="appearance:none;width:14px;height:14px;margin:0;flex-shrink:0;border:1px solid #${theme.border};border-radius:${theme.radius};background:#${theme.bg};cursor:pointer;transition:background .15s,border-color .15s">
-        Focus on connected nodes
-      </label>
       <h4 style="margin:0 0 8px;font-size:10px;letter-spacing:0.12em;opacity:0.5;text-transform:uppercase">Connections</h4>
       <div style="display:flex;flex-direction:column;gap:8px">
         ${relatedEdges.length === 0 ? '<div style="opacity:0.5;font-size:11px">No connections</div>' : relatedEdges.map((e) => renderEdge(node, e, theme, !!callbacks?.onNavigate)).join("")}
       </div>
     `;
-    const focusToggle = el.querySelector(
-      "[data-focus-toggle]",
-    ) as HTMLInputElement;
-    if (focusToggle) {
-      focusToggle.onchange = () => {
-        focusMode = focusToggle.checked;
-        callbacks?.onFocusToggle?.(focusMode);
-      };
-    }
     (el.querySelector("#sv-close") as HTMLButtonElement).onclick = hide;
   }
 
@@ -225,10 +208,6 @@ export function createSidePanel(
   function hide() {
     currentId = null;
     el.style.transform = "translateX(100%)";
-    if (focusMode) {
-      focusMode = false;
-      callbacks?.onFocusToggle?.(false);
-    }
     callbacks?.onClose?.();
   }
 

--- a/theia-panel/src/ui/Theme.ts
+++ b/theia-panel/src/ui/Theme.ts
@@ -29,7 +29,7 @@ export interface ThemeTokens {
 }
 
 export const FONT_STACK =
-  "system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";
+  "Inter, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";
 
 const DEFAULTS: ThemeTokens = {
   bg: "07080d",


### PR DESCRIPTION
## Summary
Four changes to align the Theia constellation panel with the Hermes dashboard look and feel:

### 1. Font mismatch
Added `Inter` to the default `FONT_STACK` so the panel matches the Hermes dashboard's primary font even without explicit theme forwarding via URL params.

### 2. Yellow accent color
Changed the accent extraction to prefer `--color-primary` and `--color-accent` CSS custom properties before falling back to `--color-warning`. This ensures the panel's accent color matches the dashboard's actual primary/accent color instead of always using the warning yellow.

### 3. Focus on connected nodes placement
Moved the "Focus on connected nodes" toggle from the SidePanel (where it was between the metadata divider and the Connections section) into the FilterBar dropdown (the "Filters" section) for logical grouping with the edge kind toggles. The focus toggle resets when the side panel closes, consistent with the previous behavior.

### 4. Missing iframe border
Added `border` and `border-radius` to `.theia-container` using the dashboard's `--color-border` and `--radius` CSS custom properties, matching the Hermes dashboard card border style.