### PR TITLE
feat: add Focus on search toggle to filter bar

### DIFF
--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -110,6 +110,7 @@ export async function mount(
     modelFilter = saved.model;
   }
   let focusEnabled = false;
+  let searchFocusEnabled = false;
   let focusFilter: Set<string> | null = null;
 
   // Mutable graph-specific state — closures capture the binding, not the value
@@ -157,6 +158,13 @@ export async function mount(
       const id = sidePanel.currentNodeId();
       if (id) applyFocusModeIfEnabled(id);
     }
+  }
+
+  function onSearchFocusToggle(enabled: boolean) {
+    searchFocusEnabled = enabled;
+    updateVisibility();
+    const id = sidePanel.currentNodeId();
+    if (id) applyFocusModeIfEnabled(id);
   }
 
   const sidePanel = createSidePanel(element, theme, {
@@ -245,6 +253,17 @@ export async function mount(
 
   function updateVisibility() {
     visibleNodeIds = computeVisibleNodeIds(currentGraph, kinds, modelFilter);
+    if (searchFocusEnabled && searchBar) {
+      const query = searchBar.input.value.trim();
+      if (query) {
+        const matchedIds = searchBar.getMatchedNodeIds(query);
+        const filtered = new Set<string>();
+        for (const id of visibleNodeIds) {
+          if (matchedIds.has(id)) filtered.add(id);
+        }
+        visibleNodeIds = filtered;
+      }
+    }
     for (let i = 0; i < currentGraph.nodes.length; i++) {
       nodes.setVisible(i, visibleNodeIds.has(currentGraph.nodes[i]!.id));
     }
@@ -403,6 +422,13 @@ export async function mount(
       theme,
       (node) => visibleNodeIds.has(node.id),
     );
+    searchBar.input.addEventListener("input", () => {
+      if (searchFocusEnabled) {
+        updateVisibility();
+        const id = sidePanel.currentNodeId();
+        if (id) applyFocusModeIfEnabled(id);
+      }
+    });
   }
 
   function createLoadingOverlay(text: string): { remove(): void } {
@@ -576,6 +602,8 @@ export async function mount(
       },
       onFocusToggle,
       initialFocusEnabled: focusEnabled,
+      onSearchFocusToggle,
+      initialSearchFocusEnabled: searchFocusEnabled,
     },
   );
 

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -43,6 +43,7 @@ const STORAGE_KEY = "theia-constellation-filter";
 function loadFilterState(): {
   kinds: Set<TheiaGraph["edges"][number]["kind"]>;
   model: string | null;
+  searchFocus: boolean;
 } | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -57,17 +58,22 @@ function loadFilterState(): {
     return {
       kinds: new Set(parsedKinds.length > 0 ? parsedKinds : DEFAULT_KINDS),
       model: typeof parsed?.model === "string" ? parsed.model : null,
+      searchFocus: parsed?.searchFocus === true,
     };
   } catch {
     return null;
   }
 }
 
-function saveFilterState(kinds: Set<string>, model: string | null): void {
+function saveFilterState(
+  kinds: Set<string>,
+  model: string | null,
+  searchFocus: boolean,
+): void {
   try {
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ kinds: Array.from(kinds), model }),
+      JSON.stringify({ kinds: Array.from(kinds), model, searchFocus }),
     );
   } catch {
     /* quota exceeded, ignore */
@@ -110,8 +116,11 @@ export async function mount(
     modelFilter = saved.model;
   }
   let focusEnabled = false;
-  let searchFocusEnabled = false;
+  let searchFocusEnabled = saved?.searchFocus ?? false;
   let focusFilter: Set<string> | null = null;
+  let searchFocusMatchKey = "";
+  let searchInputController: AbortController | null = null;
+  let searchFocusTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Mutable graph-specific state — closures capture the binding, not the value
   let currentGraph: TheiaGraph;
@@ -162,9 +171,10 @@ export async function mount(
 
   function onSearchFocusToggle(enabled: boolean) {
     searchFocusEnabled = enabled;
-    updateVisibility();
+    saveFilterState(kinds, modelFilter, searchFocusEnabled);
+    const searchMatchesChanged = updateVisibility();
     const id = sidePanel.currentNodeId();
-    if (id) applyFocusModeIfEnabled(id);
+    if (id && searchMatchesChanged) applyFocusModeIfEnabled(id);
   }
 
   const sidePanel = createSidePanel(element, theme, {
@@ -251,18 +261,30 @@ export async function mount(
 
   let visibleNodeIds = new Set<string>();
 
-  function updateVisibility() {
+  function updateVisibility(): boolean {
     visibleNodeIds = computeVisibleNodeIds(currentGraph, kinds, modelFilter);
+    let searchMatchesChanged = false;
     if (searchFocusEnabled && searchBar) {
       const query = searchBar.input.value.trim();
       if (query) {
         const matchedIds = searchBar.getMatchedNodeIds(query);
-        const filtered = new Set<string>();
-        for (const id of visibleNodeIds) {
-          if (matchedIds.has(id)) filtered.add(id);
+        const nextMatchKey = Array.from(matchedIds).sort().join("\0");
+        searchMatchesChanged = nextMatchKey !== searchFocusMatchKey;
+        searchFocusMatchKey = nextMatchKey;
+        if (matchedIds.size > 0) {
+          const filtered = new Set<string>();
+          for (const id of visibleNodeIds) {
+            if (matchedIds.has(id)) filtered.add(id);
+          }
+          visibleNodeIds = filtered;
         }
-        visibleNodeIds = filtered;
+      } else if (searchFocusMatchKey) {
+        searchMatchesChanged = true;
+        searchFocusMatchKey = "";
       }
+    } else if (searchFocusMatchKey) {
+      searchMatchesChanged = true;
+      searchFocusMatchKey = "";
     }
     for (let i = 0; i < currentGraph.nodes.length; i++) {
       nodes.setVisible(i, visibleNodeIds.has(currentGraph.nodes[i]!.id));
@@ -297,6 +319,7 @@ export async function mount(
       }
     }
     edges.rebuild(currentGraph, kinds, filteredNodeIndex, nodePositions);
+    return searchMatchesChanged;
   }
 
   function applyFocusModeIfEnabled(selectedNodeId: string) {
@@ -402,6 +425,10 @@ export async function mount(
       emit("node-hover", idx === null ? null : currentGraph.nodes[idx]!.id);
     });
 
+    searchInputController?.abort();
+    searchInputController = null;
+    if (searchFocusTimer) clearTimeout(searchFocusTimer);
+    searchFocusTimer = null;
     searchBar?.dispose();
     searchBar = createSearchBar(
       element,
@@ -422,13 +449,22 @@ export async function mount(
       theme,
       (node) => visibleNodeIds.has(node.id),
     );
-    searchBar.input.addEventListener("input", () => {
-      if (searchFocusEnabled) {
-        updateVisibility();
-        const id = sidePanel.currentNodeId();
-        if (id) applyFocusModeIfEnabled(id);
-      }
-    });
+    searchInputController = new AbortController();
+    searchBar.input.addEventListener(
+      "input",
+      () => {
+        if (searchFocusEnabled) {
+          if (searchFocusTimer) clearTimeout(searchFocusTimer);
+          searchFocusTimer = setTimeout(() => {
+            searchFocusTimer = null;
+            const searchMatchesChanged = updateVisibility();
+            const id = sidePanel.currentNodeId();
+            if (id && searchMatchesChanged) applyFocusModeIfEnabled(id);
+          }, 120);
+        }
+      },
+      { signal: searchInputController.signal },
+    );
   }
 
   function createLoadingOverlay(text: string): { remove(): void } {
@@ -587,7 +623,7 @@ export async function mount(
     (state) => {
       kinds = state.kinds;
       modelFilter = state.model;
-      saveFilterState(kinds, modelFilter);
+      saveFilterState(kinds, modelFilter, searchFocusEnabled);
       focusFilter = null;
       updateVisibility();
       const id = sidePanel.currentNodeId();
@@ -628,6 +664,8 @@ export async function mount(
     destroy() {
       disposed = true;
       window.removeEventListener("mouseup", resetDrag);
+      searchInputController?.abort();
+      if (searchFocusTimer) clearTimeout(searchFocusTimer);
       stopThemeListener();
       simulation.stop();
       nodes.dispose();

--- a/theia-panel/src/ui/FilterBar.ts
+++ b/theia-panel/src/ui/FilterBar.ts
@@ -318,21 +318,14 @@ export function createFilterBar(
 
   function applySearchFocusToggleStyle() {
     if (!searchFocusToggleEl || !searchFocusCb) return;
-    searchFocusToggleEl.style.cssText = `
-      display: flex; gap: 10px; align-items: center; cursor: pointer;
-      letter-spacing: 0.05em;
-      color: ${searchFocusEnabled ? `#${theme.fg}` : `#${theme.fg2}`};
-    `;
-    searchFocusCb.style.cssText = `
-      appearance: none; width: 14px; height: 14px; margin: 0; flex-shrink: 0;
-      border: 1px solid #${theme.border};
-      border-radius: ${theme.radius};
-      background: ${searchFocusEnabled ? `#${theme.accent}` : `#${theme.bg}`};
-      cursor: pointer; transition: background .15s, border-color .15s;
-    `;
     searchFocusToggleEl.style.color = searchFocusEnabled
       ? `#${theme.fg}`
       : `#${theme.fg2}`;
+    searchFocusCb.style.borderColor = `#${theme.border}`;
+    searchFocusCb.style.borderRadius = theme.radius;
+    searchFocusCb.style.background = searchFocusEnabled
+      ? `#${theme.accent}`
+      : `#${theme.bg}`;
   }
 
   function initFocusToggle() {
@@ -355,9 +348,18 @@ export function createFilterBar(
 
   function initSearchFocusToggle() {
     searchFocusToggleEl = document.createElement("label");
+    searchFocusToggleEl.style.cssText = `
+      display: flex; gap: 10px; align-items: center; cursor: pointer;
+      letter-spacing: 0.05em;
+    `;
     searchFocusCb = document.createElement("input");
     searchFocusCb.type = "checkbox";
     searchFocusCb.checked = searchFocusEnabled;
+    searchFocusCb.style.cssText = `
+      appearance: none; width: 14px; height: 14px; margin: 0; flex-shrink: 0;
+      border: 1px solid;
+      cursor: pointer; transition: background .15s, border-color .15s;
+    `;
     searchFocusCb.onchange = () => {
       searchFocusEnabled = searchFocusCb!.checked;
       applySearchFocusToggleStyle();
@@ -376,7 +378,7 @@ export function createFilterBar(
   bar.append(btn, searchToggle, dropdown);
   rebuildModelSelect();
   initFocusToggle();
-  initSearchFocusToggle();
+  if (onSearchFocusToggle) initSearchFocusToggle();
   container.appendChild(bar);
 
   function setSearchToggleVisible(visible: boolean) {

--- a/theia-panel/src/ui/FilterBar.ts
+++ b/theia-panel/src/ui/FilterBar.ts
@@ -56,6 +56,8 @@ export interface FilterBarOptions {
   onSearchToggle?: () => void;
   onFocusToggle?: (enabled: boolean) => void;
   initialFocusEnabled?: boolean;
+  onSearchFocusToggle?: (enabled: boolean) => void;
+  initialSearchFocusEnabled?: boolean;
 }
 
 export function createFilterBar(
@@ -66,8 +68,14 @@ export function createFilterBar(
   initialTheme: ThemeTokens,
   options: FilterBarOptions = {},
 ) {
-  const { initialModel, onSearchToggle, onFocusToggle, initialFocusEnabled } =
-    options;
+  const {
+    initialModel,
+    onSearchToggle,
+    onFocusToggle,
+    initialFocusEnabled,
+    onSearchFocusToggle,
+    initialSearchFocusEnabled,
+  } = options;
   let theme = initialTheme;
   const bar = document.createElement("div");
   bar.dataset.uiOverlay = "";
@@ -77,6 +85,7 @@ export function createFilterBar(
   let dropdownOpen = false;
   let showSearchToggle = false;
   let focusEnabled = initialFocusEnabled ?? false;
+  let searchFocusEnabled = initialSearchFocusEnabled ?? false;
 
   const btn = document.createElement("button");
   btn.textContent = "Filters";
@@ -285,6 +294,8 @@ export function createFilterBar(
 
   let focusToggleEl: HTMLLabelElement | null = null;
   let focusCb: HTMLInputElement | null = null;
+  let searchFocusToggleEl: HTMLLabelElement | null = null;
+  let searchFocusCb: HTMLInputElement | null = null;
 
   function applyFocusToggleStyle() {
     if (!focusToggleEl || !focusCb) return;
@@ -305,6 +316,25 @@ export function createFilterBar(
     focusToggleEl.style.color = focusEnabled ? `#${theme.fg}` : `#${theme.fg2}`;
   }
 
+  function applySearchFocusToggleStyle() {
+    if (!searchFocusToggleEl || !searchFocusCb) return;
+    searchFocusToggleEl.style.cssText = `
+      display: flex; gap: 10px; align-items: center; cursor: pointer;
+      letter-spacing: 0.05em;
+      color: ${searchFocusEnabled ? `#${theme.fg}` : `#${theme.fg2}`};
+    `;
+    searchFocusCb.style.cssText = `
+      appearance: none; width: 14px; height: 14px; margin: 0; flex-shrink: 0;
+      border: 1px solid #${theme.border};
+      border-radius: ${theme.radius};
+      background: ${searchFocusEnabled ? `#${theme.accent}` : `#${theme.bg}`};
+      cursor: pointer; transition: background .15s, border-color .15s;
+    `;
+    searchFocusToggleEl.style.color = searchFocusEnabled
+      ? `#${theme.fg}`
+      : `#${theme.fg2}`;
+  }
+
   function initFocusToggle() {
     focusToggleEl = document.createElement("label");
     focusCb = document.createElement("input");
@@ -323,11 +353,30 @@ export function createFilterBar(
     content.append(focusToggleEl);
   }
 
+  function initSearchFocusToggle() {
+    searchFocusToggleEl = document.createElement("label");
+    searchFocusCb = document.createElement("input");
+    searchFocusCb.type = "checkbox";
+    searchFocusCb.checked = searchFocusEnabled;
+    searchFocusCb.onchange = () => {
+      searchFocusEnabled = searchFocusCb!.checked;
+      applySearchFocusToggleStyle();
+      onSearchFocusToggle?.(searchFocusEnabled);
+    };
+    searchFocusToggleEl.append(
+      searchFocusCb,
+      document.createTextNode("Focus on search"),
+    );
+    applySearchFocusToggleStyle();
+    content.append(searchFocusToggleEl);
+  }
+
   applyBarStyle();
   dropdown.appendChild(content);
   bar.append(btn, searchToggle, dropdown);
   rebuildModelSelect();
   initFocusToggle();
+  initSearchFocusToggle();
   container.appendChild(bar);
 
   function setSearchToggleVisible(visible: boolean) {
@@ -348,12 +397,21 @@ export function createFilterBar(
     applyFocusToggleStyle();
   }
 
+  function setSearchFocusEnabled(enabled: boolean) {
+    searchFocusEnabled = enabled;
+    if (searchFocusCb) {
+      searchFocusCb.checked = enabled;
+    }
+    applySearchFocusToggleStyle();
+  }
+
   function updateTheme(newTheme: ThemeTokens) {
     theme = newTheme;
     applyBarStyle();
     for (const t of toggles) t._applyStyle();
     applySelectStyle();
     applyFocusToggleStyle();
+    applySearchFocusToggleStyle();
   }
 
   return {
@@ -361,6 +419,7 @@ export function createFilterBar(
     updateGraph,
     setSearchToggleVisible,
     setFocusEnabled,
+    setSearchFocusEnabled,
     dispose: () => {
       document.removeEventListener("pointerdown", onDocumentClick);
       container.removeChild(bar);

--- a/theia-panel/src/ui/SearchBar.ts
+++ b/theia-panel/src/ui/SearchBar.ts
@@ -45,6 +45,8 @@ export function createSearchBar(
   let currentResults: SearchResult[] = [];
   let selectedIndex = -1;
   let panelOpen = false;
+  let matchedCacheQuery = "";
+  let matchedCacheIds: Set<string> | null = null;
 
   function applyWrapperStyle() {
     wrapper.style.cssText = `
@@ -150,16 +152,23 @@ export function createSearchBar(
       dropdown.innerHTML = "";
       currentResults = [];
       selectedIndex = -1;
+      matchedCacheQuery = "";
+      matchedCacheIds = new Set();
       return;
     }
     const resultByIndex = new Map<number, SearchResult>();
+    const matchedIds = new Set<string>();
     for (let i = 0; i < graph.nodes.length; i++) {
       const node = graph.nodes[i]!;
-      if (isVisible && !isVisible(node)) continue;
       if (matches(node, query)) {
-        resultByIndex.set(i, { node, index: i });
+        matchedIds.add(node.id);
+        if (!isVisible || isVisible(node)) {
+          resultByIndex.set(i, { node, index: i });
+        }
       }
     }
+    matchedCacheQuery = query.trim();
+    matchedCacheIds = matchedIds;
     currentResults = Array.from(resultByIndex.values());
     if (currentResults.length === 0) {
       dropdown.innerHTML = `<div style="padding:12px;opacity:0.4;font-size:12px;text-align:center;color:#${theme.fg2}">No results found</div>`;
@@ -247,14 +256,20 @@ export function createSearchBar(
   }
 
   function getMatchedNodeIds(query: string): Set<string> {
+    const normalizedQuery = query.trim();
+    if (!normalizedQuery) return new Set();
+    if (matchedCacheIds && matchedCacheQuery === normalizedQuery) {
+      return new Set(matchedCacheIds);
+    }
     const ids = new Set<string>();
-    if (!query.trim()) return ids;
     for (let i = 0; i < graph.nodes.length; i++) {
       const node = graph.nodes[i]!;
-      if (matches(node, query)) {
+      if (matches(node, normalizedQuery)) {
         ids.add(node.id);
       }
     }
+    matchedCacheQuery = normalizedQuery;
+    matchedCacheIds = ids;
     return ids;
   }
 

--- a/theia-panel/src/ui/SearchBar.ts
+++ b/theia-panel/src/ui/SearchBar.ts
@@ -246,5 +246,17 @@ export function createSearchBar(
     container.removeChild(wrapper);
   }
 
-  return { updateTheme, setPanelOpen, dispose, input };
+  function getMatchedNodeIds(query: string): Set<string> {
+    const ids = new Set<string>();
+    if (!query.trim()) return ids;
+    for (let i = 0; i < graph.nodes.length; i++) {
+      const node = graph.nodes[i]!;
+      if (matches(node, query)) {
+        ids.add(node.id);
+      }
+    }
+    return ids;
+  }
+
+  return { updateTheme, setPanelOpen, dispose, input, getMatchedNodeIds };
 }


### PR DESCRIPTION
## Summary

- Adds a "Focus on search" checkbox in the filter dropdown next to the existing "Focus on connected nodes" checkbox
- When enabled and a search query is active, hides all nodes that don't match the current search
- Reactively updates visibility as the user types in the search bar
- Works alongside the existing "Focus on connected nodes" filter (both can be active simultaneously)

### Changes

- **`theia-panel/src/ui/SearchBar.ts`**: Exposes `getMatchedNodeIds(query)` for reuse
- **`theia-panel/src/ui/FilterBar.ts`**: Adds checkbox UI, state, and `onSearchFocusToggle`/`setSearchFocusEnabled` API
- **`theia-panel/src/index.ts`**: Wires up the toggle, applies search filter in `updateVisibility` and when query changes