### PR TITLE
fix(#69): correct iframe rendering at extreme aspect ratios

### DIFF
--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -96,11 +96,12 @@ export async function mount(
   edgesScene.add(edges.group);
 
   const post = createPost(ctx.renderer, ctx.scene, ctx.camera, element);
-  const originalResize = ctx.resize;
-  ctx.resize = () => {
-    originalResize();
-    post.resize();
-  };
+  // Run the post-processing resize after the base scene resize. Must
+  // use ctx.onResize — replacing ctx.resize from outside would not
+  // affect the internal ResizeObserver, leaving post render-targets at
+  // the wrong size when the container resizes (causing blur during
+  // fullscreen toggle in particular). See Scene.ts for the rationale.
+  ctx.onResize(() => post.resize());
 
   let kinds = new Set(options.edgeKinds ?? DEFAULT_KINDS);
   let modelFilter: string | null = null;

--- a/theia-panel/src/scene/Scene.ts
+++ b/theia-panel/src/scene/Scene.ts
@@ -21,6 +21,35 @@ export interface SceneContext {
   setCameraState(state: CameraState): void;
   dispose(): void;
   resize(): void;
+  /**
+   * Register a callback to run after the base scene resize logic
+   * (camera + renderer). Used by the post-processing pipeline to keep
+   * its render targets in sync — replacing ctx.resize from outside
+   * does not work because the internal ResizeObserver captures the
+   * original function reference at construction time.
+   */
+  onResize(fn: () => void): void;
+}
+
+// Reference framing: a 60° vertical FOV at a "normal" 16:9 aspect.
+// When the container is wider/shorter than this (issue #69 — the panel
+// gets squeezed into ~1920×507 inside the dashboard, aspect ≈ 3.79), a
+// fixed-vertical-FOV camera makes content read as zoomed-in because the
+// same vertical world units are stretched across the full viewport
+// while horizontal context is much wider. Recomputing the vertical FOV
+// so the *horizontal* extent stays roughly constant gives identical
+// perceptual scale at any aspect ratio, without touching the existing
+// zoom/radius/focus systems used for user interaction.
+const BASE_FOV_DEG = 60;
+const BASE_ASPECT = 16 / 9;
+const BASE_FOV_TAN_HALF = Math.tan((BASE_FOV_DEG * Math.PI) / 360);
+
+function fovForAspect(a: number): number {
+  if (a >= BASE_ASPECT) {
+    const tanHalf = (BASE_FOV_TAN_HALF * BASE_ASPECT) / a;
+    return (Math.atan(tanHalf) * 360) / Math.PI;
+  }
+  return BASE_FOV_DEG;
 }
 
 export function createScene(container: HTMLElement): SceneContext {
@@ -28,7 +57,12 @@ export function createScene(container: HTMLElement): SceneContext {
 
   const { clientWidth: w, clientHeight: h } = container;
   const aspect = w / h;
-  const camera = new THREE.PerspectiveCamera(60, aspect, 0.01, 100);
+  const camera = new THREE.PerspectiveCamera(
+    fovForAspect(aspect),
+    aspect,
+    0.01,
+    100,
+  );
 
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
   renderer.setPixelRatio(window.devicePixelRatio);
@@ -56,12 +90,21 @@ export function createScene(container: HTMLElement): SceneContext {
   }
   updateCamera();
 
+  const resizeListeners: Array<() => void> = [];
+
   const resize = () => {
     const { clientWidth: w2, clientHeight: h2 } = container;
+    if (w2 === 0 || h2 === 0) return;
     const a = w2 / h2;
     camera.aspect = a;
+    camera.fov = fovForAspect(a);
     camera.updateProjectionMatrix();
+    // Re-sync DPR — fullscreen transitions and monitor changes can
+    // change devicePixelRatio, and the renderer caches it from the
+    // first setPixelRatio call.
+    renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(w2, h2, true);
+    for (const fn of resizeListeners) fn();
   };
 
   const ro = new ResizeObserver(resize);
@@ -141,6 +184,9 @@ export function createScene(container: HTMLElement): SceneContext {
       updateCamera();
     },
     resize,
+    onResize(fn) {
+      resizeListeners.push(fn);
+    },
     dispose() {
       if (rafId !== null) cancelAnimationFrame(rafId);
       ro.disconnect();


### PR DESCRIPTION
Closes #69.

## Problem

The constellation graph appeared ~125% magnified and blurry when embedded in the Hermes dashboard, but rendered correctly when the Vite dev server was accessed directly. Earlier investigation in #67 ruled out the obvious CSS culprits but didn't land a fix.

## Investigation

Iframe + host instrumentation (\`devicePixelRatio\`, \`getBoundingClientRect\`, ancestor \`transform\`/\`zoom\` walk, canvas CSS vs attribute size) confirmed:

| Suspect | Verdict |
|---|---|
| Host \`transform: scale()\` on iframe or ancestor | Ruled out — \`ancestorsWithScaling: []\` |
| Host \`zoom\` on iframe or ancestor | Ruled out — \`zoom: \"1\"\` everywhere |
| \`devicePixelRatio\` mismatch | Ruled out — \`1\` on both sides |
| Canvas CSS != attribute size | Ruled out — perfect 1:1 ratio |

There is no CSS magnification. The actual cause is a combination of three rendering bugs that surface together because the dashboard chrome leaves the panel with an extreme aspect ratio (e.g. 1920x507, aspect ~3.79, vs ~1.78 in direct Vite).

## Fixes

### 1. Vertical-FOV camera at extreme aspect ratios

Three.js \`PerspectiveCamera\` uses a *vertical* FOV. At fixed 60° the same vertical world extent is crammed into far fewer pixels in a wide-and-short viewport while the horizontal stretches — visually reads as \"zoomed in\" on the central band even though every pixel is 1:1.

\`theia-panel/src/scene/Scene.ts\` now recomputes \`camera.fov\` from container aspect on init and resize. When aspect exceeds 16:9 the vertical FOV is pulled in so horizontal world extent stays constant; below 16:9 the FOV is unchanged.

\`\`\`ts
fovForAspect(a) = 60                       when a < 16/9
fovForAspect(a) = 2*atan(tan(30°)*16/9/a)  when a >= 16/9
\`\`\`

### 2. Post-pipeline never resized (the blur in fullscreen)

\`theia-panel/src/index.ts\` used to wrap \`ctx.resize\`:

\`\`\`ts
const originalResize = ctx.resize;
ctx.resize = () => { originalResize(); post.resize(); };
\`\`\`

But \`Scene.ts\`'s internal \`ResizeObserver\` had already captured the *original* \`resize\` closure. Reassigning the property had no effect on what the observer actually called, so \`post.resize()\` was **never called when the container actually resized**. Bloom / dither / edges / scene render targets stayed sized for the initial viewport, then the compositor stretched those textures across the new canvas — exactly the blur observed in fullscreen.

Fix: add \`Scene.onResize(fn)\` and run registered listeners inside the closure the \`ResizeObserver\` invokes. The consumer now uses \`ctx.onResize(() => post.resize())\`.

### 3. DPR never re-synced; zero-size resize unguarded

- \`renderer.setPixelRatio(window.devicePixelRatio)\` ran once at init. On fullscreen transitions or monitor changes the cached DPR could become stale → framebuffer mismatch → blur. Now re-applied on every resize.
- During fullscreen transition the container can briefly report \`clientWidth/Height === 0\`, producing a NaN aspect ratio. Now guarded.

## Performance

- Resize: +1 \`tan\` + 1 \`atan\` + 1 \`setPixelRatio\` per resize event (layout-rare).
- Render loop: zero added cost. Projection matrix set once per resize, used as before.
- GPU/draw cost: unchanged (same scene, same nodes/edges).

## Testing

- \`make ci\` passes: ruff + mypy + tsc + prettier + pytest (39) + vitest (2) + manifest validation + embed build + package.
- Manually verified in the dashboard: graph renders at the same perceptual size as direct Vite; fullscreen toggle is sharp; wheel-zoom / focus-on-node / fullscreen all keep working (untouched APIs).

## Files

- \`theia-panel/src/scene/Scene.ts\` — \`fovForAspect\`, \`onResize\` listener pattern, DPR re-sync, zero-size guard
- \`theia-panel/src/index.ts\` — use \`ctx.onResize(() => post.resize())\` instead of broken property reassignment