### PR TITLE
[codex] Animate onboarding edge links

### DIFF
--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -41,6 +41,7 @@ const ONBOARDING_STORAGE_KEY = "theia-first-load-onboarding-complete";
 const PHYSICS_SNAPSHOT_KEY_PREFIX = "theia-physics-snapshot:";
 const ONBOARDING_ROTATION_RADIANS = Math.PI * 1.15;
 const ONBOARDING_BLINK_MS = 3200;
+const ONBOARDING_LINK_UP_MS = 700;
 const PHYSICS_SNAPSHOT_INTERVAL_MS = 5000;
 const ONBOARDING_BASE_ZOOM = 0.72;
 const ONBOARDING_MIN_ZOOM = 0.42;
@@ -63,6 +64,12 @@ function revealBrightness(t: number): number {
   if (t >= 1) return 1;
   const eased = easeQuadInOut(t);
   return 1 + 0.5 * Math.sin(Math.PI * eased);
+}
+
+function edgeKey(edge: TheiaGraph["edges"][number]): string {
+  return edge.source < edge.target
+    ? `${edge.source}|${edge.target}|${edge.kind}`
+    : `${edge.target}|${edge.source}|${edge.kind}`;
 }
 
 function hasCompletedOnboarding(): boolean {
@@ -185,6 +192,7 @@ export async function mount(
     rankByIndex: Map<number, number>;
     revealedNodeIds: Set<string>;
     revealStartedAtByIndex: Map<number, number>;
+    linkStartedAtByKey: Map<string, number>;
     lastRevealedCount: number;
     lastEase: number;
     cameraZoom: number;
@@ -624,6 +632,7 @@ export async function mount(
       rankByIndex: new Map(order.map((index, rank) => [index, rank])),
       revealedNodeIds: new Set(),
       revealStartedAtByIndex: new Map(),
+      linkStartedAtByKey: new Map(),
       lastRevealedCount: 0,
       lastEase: 0,
       cameraZoom: ONBOARDING_BASE_ZOOM,
@@ -639,6 +648,31 @@ export async function mount(
     setNodeVisibilityFromState();
     rebuildVisibleEdges();
     replaceSimulation(activeVisibleNodeIds(), true);
+  }
+
+  function updateOnboardingLinks(now: number) {
+    if (!onboarding) {
+      edges.setConnectionProgress(null);
+      return;
+    }
+    for (const edge of currentGraph.edges) {
+      if (
+        onboarding.revealedNodeIds.has(edge.source) &&
+        onboarding.revealedNodeIds.has(edge.target)
+      ) {
+        const key = edgeKey(edge);
+        if (!onboarding.linkStartedAtByKey.has(key)) {
+          onboarding.linkStartedAtByKey.set(key, now);
+        }
+      }
+    }
+    edges.setConnectionProgress((edge) => {
+      const startedAt = onboarding?.linkStartedAtByKey.get(edgeKey(edge));
+      if (startedAt === undefined) return 0;
+      return easeQuadInOut(
+        Math.min(1, (now - startedAt) / ONBOARDING_LINK_UP_MS),
+      );
+    });
   }
 
   function updateOnboarding(now: number) {
@@ -671,6 +705,7 @@ export async function mount(
           : Math.min(1, (now - revealedAt) / ONBOARDING_BLINK_MS);
       nodes.setBrightness(idx, revealBrightness(blinkProgress));
     }
+    updateOnboardingLinks(now);
 
     const rotationDelta =
       (eased - onboarding.lastEase) * ONBOARDING_ROTATION_RADIANS;
@@ -701,6 +736,7 @@ export async function mount(
       onboarding.overlay.remove();
       setNodeVisibilityFromState();
       rebuildVisibleEdges();
+      updateOnboardingLinks(now);
       savePhysicsSnapshot();
     }
 
@@ -720,6 +756,7 @@ export async function mount(
           nodes.setBrightness(idx, 1);
         }
         onboarding = null;
+        edges.setConnectionProgress(null);
       }
     }
   }

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -66,10 +66,16 @@ function revealBrightness(t: number): number {
   return 1 + 0.5 * Math.sin(Math.PI * eased);
 }
 
+const edgeKeyCache = new WeakMap<TheiaGraph["edges"][number], string>();
 function edgeKey(edge: TheiaGraph["edges"][number]): string {
-  return edge.source < edge.target
-    ? `${edge.source}|${edge.target}|${edge.kind}`
-    : `${edge.target}|${edge.source}|${edge.kind}`;
+  let key = edgeKeyCache.get(edge);
+  if (key !== undefined) return key;
+  key =
+    edge.source < edge.target
+      ? `${edge.source}|${edge.target}|${edge.kind}`
+      : `${edge.target}|${edge.source}|${edge.kind}`;
+  edgeKeyCache.set(edge, key);
+  return key;
 }
 
 function hasCompletedOnboarding(): boolean {

--- a/theia-panel/src/scene/Edges.ts
+++ b/theia-panel/src/scene/Edges.ts
@@ -8,11 +8,14 @@ type GraphEdge = TheiaGraph["edges"][number];
 const VERT = `
 attribute float aOpacity;
 attribute float aPhase;
+attribute float aReveal;
 varying float vOpacity;
 varying float vPhase;
+varying float vReveal;
 void main() {
   vOpacity = aOpacity;
   vPhase = aPhase;
+  vReveal = aReveal;
   gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
 }
 `;
@@ -20,11 +23,12 @@ void main() {
 const FRAG = `
 varying float vOpacity;
 varying float vPhase;
+varying float vReveal;
 uniform vec3 color;
 uniform float uTime;
 void main() {
   float pulse = 0.85 + 0.15 * sin(uTime * 3.0 + vPhase);
-  float alpha = vOpacity * pulse;
+  float alpha = vOpacity * vReveal * pulse;
   gl_FragColor = vec4(color, alpha);
 }
 `;
@@ -47,6 +51,9 @@ export interface EdgeLayer {
   ): void;
   updatePositions(nodePositions: Float32Array): void;
   setHoverNode(nodeId: string | null): void;
+  setConnectionProgress(
+    getProgress: ((edge: GraphEdge) => number) | null,
+  ): void;
   setTime(t: number): void;
   dispose(): void;
 }
@@ -59,6 +66,7 @@ export function createEdges(): EdgeLayer {
     { line: THREE.LineSegments; edgeList: GraphEdge[]; validIndices: number[] }
   >();
   let currentNodeIndex: Map<string, number> | null = null;
+  let getConnectionProgress: ((edge: GraphEdge) => number) | null = null;
 
   function rebuild(
     graph: TheiaGraph,
@@ -93,6 +101,7 @@ export function createEdges(): EdgeLayer {
       const positions = new Float32Array(edges.length * 6);
       const opacities = new Float32Array(edges.length * 2);
       const phases = new Float32Array(edges.length * 2);
+      const reveals = new Float32Array(edges.length * 2);
       const validIndices: number[] = [];
       for (let i = 0; i < edges.length; i++) {
         const e = edges[i]!;
@@ -120,6 +129,9 @@ export function createEdges(): EdgeLayer {
           hash01(e.source + "|" + e.target + "|" + e.kind) * Math.PI * 2;
         phases[i * 2 + 0] = phase;
         phases[i * 2 + 1] = phase;
+        const reveal = getConnectionProgress?.(e) ?? 1;
+        reveals[i * 2 + 0] = reveal;
+        reveals[i * 2 + 1] = reveal;
         validIndices.push(i);
       }
       const geometry = new THREE.BufferGeometry();
@@ -132,6 +144,7 @@ export function createEdges(): EdgeLayer {
         new THREE.BufferAttribute(opacities, 1),
       );
       geometry.setAttribute("aPhase", new THREE.BufferAttribute(phases, 1));
+      geometry.setAttribute("aReveal", new THREE.BufferAttribute(reveals, 1));
       let mat = materials.get(kind);
       if (!mat) {
         const c = new THREE.Color(PALETTE_MAP[kind]);
@@ -173,8 +186,17 @@ export function createEdges(): EdgeLayer {
         const tx = nodePositions[ti * 3 + 0]!;
         const ty = nodePositions[ti * 3 + 1]!;
         const tz = nodePositions[ti * 3 + 2]!;
+        const progress = Math.max(
+          0,
+          Math.min(1, getConnectionProgress?.(e) ?? 1),
+        );
         posAttr.setXYZ(i * 2 + 0, sx, sy, sz);
-        posAttr.setXYZ(i * 2 + 1, tx, ty, tz);
+        posAttr.setXYZ(
+          i * 2 + 1,
+          sx + (tx - sx) * progress,
+          sy + (ty - sy) * progress,
+          sz + (tz - sz) * progress,
+        );
       }
       posAttr.needsUpdate = true;
     }
@@ -205,6 +227,31 @@ export function createEdges(): EdgeLayer {
     }
   }
 
+  function setConnectionProgress(
+    getProgress: ((edge: GraphEdge) => number) | null,
+  ) {
+    getConnectionProgress = getProgress;
+    for (const {
+      line,
+      edgeList,
+      validIndices,
+    } of lineSegmentsByKind.values()) {
+      const attr = line.geometry.getAttribute("aReveal") as
+        | THREE.BufferAttribute
+        | undefined;
+      if (!attr) continue;
+      for (const i of validIndices) {
+        const reveal = Math.max(
+          0,
+          Math.min(1, getConnectionProgress?.(edgeList[i]!) ?? 1),
+        );
+        attr.setX(i * 2 + 0, reveal);
+        attr.setX(i * 2 + 1, reveal);
+      }
+      attr.needsUpdate = true;
+    }
+  }
+
   function setTime(t: number) {
     for (const mat of materials.values()) {
       (mat.uniforms.uTime as { value: number }).value = t;
@@ -218,5 +265,13 @@ export function createEdges(): EdgeLayer {
     materials.forEach((m) => m.dispose());
   }
 
-  return { group, rebuild, updatePositions, setHoverNode, setTime, dispose };
+  return {
+    group,
+    rebuild,
+    updatePositions,
+    setHoverNode,
+    setConnectionProgress,
+    setTime,
+    dispose,
+  };
 }


### PR DESCRIPTION
## Summary
- add per-edge reveal progress to the Three.js edge layer
- animate onboarding connections so links draw in after both endpoint nodes are revealed
- reset edge reveal state after onboarding completes

## Validation
- npm run format:check
- npm run typecheck