### PR TITLE
[codex] Persist selected session focus

### DIFF
--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -406,7 +406,10 @@ export async function mount(
   }
 
   function select(idx: number) {
-    clearSelected();
+    if (selectedIdx !== null && selectedIdx !== idx) {
+      nodes.setSelected(selectedIdx, false);
+      nodes.setHighlight(selectedIdx, false);
+    }
     selectedIdx = idx;
     nodes.setSelected(idx, true);
     nodes.setHighlight(idx, false);
@@ -1173,8 +1176,7 @@ export async function mount(
       if (selectedId !== null) {
         const idx = nodeIndex.get(selectedId);
         if (idx !== undefined) {
-          selectedIdx = idx;
-          nodes.setSelected(idx, true);
+          select(idx);
           const n = currentGraph.nodes[idx]!;
           const related = currentGraph.edges.filter(
             (e) =>

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -391,12 +391,18 @@ export async function mount(
   }
 
   const tooltip = createTooltip(element, theme);
+
+  function selectedNodeId(): string | null {
+    return selectedIdx === null ? null : currentGraph.nodes[selectedIdx]!.id;
+  }
+
   function clearSelected() {
     if (selectedIdx !== null) {
       nodes.setSelected(selectedIdx, false);
       nodes.setHighlight(selectedIdx, false);
       selectedIdx = null;
     }
+    edges.setHoverNode(null);
   }
 
   function select(idx: number) {
@@ -404,6 +410,7 @@ export async function mount(
     selectedIdx = idx;
     nodes.setSelected(idx, true);
     nodes.setHighlight(idx, false);
+    edges.setHoverNode(currentGraph.nodes[idx]!.id);
   }
 
   function enterPanelMode(
@@ -434,21 +441,28 @@ export async function mount(
     if (id && searchMatchesChanged) applyFocusModeIfEnabled(id);
   }
 
+  function navigateToNode(targetId: string) {
+    const idx = nodeIndex.get(targetId);
+    if (idx === undefined || !activeVisibleNodeIds().has(targetId)) return;
+    const sn = simNodes[idx];
+    if (!sn) return;
+    select(idx);
+    ctx.focusOn(sn.x, sn.y, 1.5);
+    const n = currentGraph.nodes[idx]!;
+    const related = currentGraph.edges.filter(
+      (e) => (e.source === n.id || e.target === n.id) && kinds.has(e.kind),
+    );
+    enterPanelMode(n, related);
+    applyFocusModeIfEnabled(n.id);
+    emit("node-click", targetId);
+  }
+
   const sidePanel = createSidePanel(element, theme, {
     onNavigate: (targetId) => {
-      const idx = nodeIndex.get(targetId);
-      if (idx === undefined || !activeVisibleNodeIds().has(targetId)) return;
-      const sn = simNodes[idx];
-      if (!sn) return;
-      select(idx);
-      ctx.focusOn(sn.x, sn.y, 1.5);
-      const n = currentGraph.nodes[idx]!;
-      const related = currentGraph.edges.filter(
-        (e) => (e.source === n.id || e.target === n.id) && kinds.has(e.kind),
-      );
-      enterPanelMode(n, related);
-      applyFocusModeIfEnabled(n.id);
-      emit("node-click", targetId);
+      navigateToNode(targetId);
+    },
+    onGoToSession: (nodeId) => {
+      navigateToNode(nodeId);
     },
     onClose: () => {
       if (focusEnabled) {
@@ -574,6 +588,7 @@ export async function mount(
       }
     }
     edges.rebuild(currentGraph, kinds, filteredNodeIndex, nodePositions);
+    edges.setHoverNode(selectedNodeId());
   }
 
   function setNodeVisibilityFromState() {
@@ -804,7 +819,7 @@ export async function mount(
     picker.onHover((idx) => {
       const nodeId = idx === null ? null : currentGraph.nodes[idx]!.id;
       element.style.cursor = idx === null ? "" : "pointer";
-      edges.setHoverNode(nodeId);
+      edges.setHoverNode(nodeId ?? selectedNodeId());
       for (let i = 0; i < nodes.count; i++) {
         if (i === idx) {
           nodes.setHighlight(i, true);

--- a/theia-panel/src/ui/SidePanel.ts
+++ b/theia-panel/src/ui/SidePanel.ts
@@ -73,6 +73,7 @@ export function createSidePanel(
   initialTheme: ThemeTokens,
   callbacks?: {
     onNavigate?: (nodeId: string) => void;
+    onGoToSession?: (nodeId: string) => void;
     onClose?: () => void;
   },
 ) {
@@ -132,6 +133,10 @@ export function createSidePanel(
     }
   }
 
+  function handleGoToSession() {
+    if (currentId) callbacks?.onGoToSession?.(currentId);
+  }
+
   function onNavKeyDown(e: KeyboardEvent, targetId: string) {
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
@@ -154,6 +159,14 @@ export function createSidePanel(
       <h3 style="margin:0 30px 2px 0;color:#${theme.accent};font-size:15px;letter-spacing:0.02em">${escape(node.title || node.id)}</h3>
       <div style="opacity:0.5;color:#${theme.fg2};margin-bottom:2px;font-size:11px">${node.id}</div>
       ${headerSummary}
+      ${
+        callbacks?.onGoToSession
+          ? `<button id="sv-go-session" type="button"
+        style="margin:12px 0 0;padding:6px 10px;background:${cardBg(theme)};border:1px solid #${theme.border};color:#${theme.fg};font:12px/1.4 var(--theia-font, ${FONT_STACK});cursor:pointer">
+        Go to session
+      </button>`
+          : ""
+      }
       <dl style="margin:14px 0 0;display:grid;grid-template-columns:auto 1fr;gap:3px 12px;font-size:12px">
         <dt style="${dtStyle}">Started</dt><dd style="margin:0">${new Date(node.started_at).toLocaleString()}</dd>
         <dt style="${dtStyle}">Duration</dt><dd style="margin:0">${Math.round(node.duration_sec)}s</dd>
@@ -168,6 +181,10 @@ export function createSidePanel(
       </div>
     `;
     (el.querySelector("#sv-close") as HTMLButtonElement).onclick = hide;
+    const goButton = el.querySelector(
+      "#sv-go-session",
+    ) as HTMLButtonElement | null;
+    if (goButton) goButton.onclick = handleGoToSession;
   }
 
   el.addEventListener("click", (e) => {


### PR DESCRIPTION
## Summary

- make the selected node keep the same edge-focus dimming behavior used by hover after the pointer leaves
- make the side-panel Go to session control reuse the same camera-focus navigation path as connection-list session clicks

## Root Cause

The selection path only marked the node as selected and did not keep the edge hover focus active after hover cleared. The Go to session control emitted the host node-click event directly instead of going through the panel navigation routine that selects and focuses the node.

## Validation

- npm run typecheck
- npm run format:check
- npm test
- npm run build
