### PR TITLE
perf(panel): shader, idle gate, DPR cap, physics rewrites

### DIFF
--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -255,9 +255,32 @@ export async function mount(
     }
     simNodes = nextNodes;
     simulation.alpha(animateNew ? 0.22 : simulation.alphaTarget());
+    wakePhysics();
+  }
+
+  // Settled-physics gate: skip the per-frame sim/lerp/edge-rewrite when
+  // the layout has stabilised. The lerp drives matrix uploads and a full
+  // edge-position attribute rewrite every frame; with 1.6k nodes that's
+  // most of the per-frame cost once the simulation has converged.
+  let settledFrames = 0;
+  const SETTLED_THRESHOLD = 30;
+  // Threshold ≈ 0.001² in world units — well below visible motion at any
+  // reasonable zoom, since node sizes top out at 0.18 (see Nodes.ts).
+  const SETTLE_EPSILON_SQ = 1e-6;
+  // Energy injected on wake so filter/visibility changes actually produce
+  // a visible re-equilibration. Without this, alpha sits at alphaTarget
+  // (0.012, see Simulation.ts) which makes wake invisible — sub-pixel
+  // motion that re-settles within a few ticks.
+  const WAKE_ALPHA = 0.18;
+  function wakePhysics() {
+    settledFrames = 0;
+    if (simulation && simulation.alpha() < WAKE_ALPHA) {
+      simulation.alpha(WAKE_ALPHA);
+    }
   }
 
   function syncRenderedPositionsFromSimulation() {
+    wakePhysics();
     for (let i = 0; i < simNodes.length; i++) {
       const sn = simNodes[i];
       if (!sn) continue;
@@ -521,6 +544,11 @@ export async function mount(
       nodes.setVisible(i, activeIds.has(currentGraph.nodes[i]!.id));
     }
     nodes.flush();
+    // Filter/focus toggles change the active set without going through
+    // replaceSimulation; wake physics so the layout can re-equilibrate
+    // for the new visible node set. The gate will re-arm after the
+    // simulation re-settles.
+    wakePhysics();
   }
 
   const EDGE_KIND_LABELS: Record<TheiaGraph["edges"][number]["kind"], string> =
@@ -947,17 +975,24 @@ export async function mount(
   }
 
   function tick() {
+    if (settledFrames >= SETTLED_THRESHOLD) return;
     simulation.tick(1);
     const smoothing = onboarding ? 0.14 : 0.34;
+    let maxDeltaSq = 0;
     for (let i = 0; i < simNodes.length; i++) {
       const sn = simNodes[i];
       if (!sn) continue;
       const px = renderedPositions[i * 3]!;
       const py = renderedPositions[i * 3 + 1]!;
       const pz = renderedPositions[i * 3 + 2]!;
-      const x = px + (sn.x - px) * smoothing;
-      const y = py + (sn.y - py) * smoothing;
-      const z = pz + (sn.z - pz) * smoothing;
+      const dx = (sn.x - px) * smoothing;
+      const dy = (sn.y - py) * smoothing;
+      const dz = (sn.z - pz) * smoothing;
+      const x = px + dx;
+      const y = py + dy;
+      const z = pz + dz;
+      const deltaSq = dx * dx + dy * dy + dz * dz;
+      if (deltaSq > maxDeltaSq) maxDeltaSq = deltaSq;
       renderedPositions[i * 3] = x;
       renderedPositions[i * 3 + 1] = y;
       renderedPositions[i * 3 + 2] = z;
@@ -965,6 +1000,8 @@ export async function mount(
     }
     nodes.flush();
     edges.updatePositions(nodePositions);
+    if (maxDeltaSq < SETTLE_EPSILON_SQ) settledFrames++;
+    else settledFrames = 0;
   }
 
   let disposed = false;
@@ -979,7 +1016,6 @@ export async function mount(
     const t = now / 1000;
     nodes.setTime(t);
     edges.setTime(t);
-    nodes.setCameraPosition(ctx.camera.position);
     post.renderEdges(edgesScene, ctx.camera);
     post.render();
     requestAnimationFrame(frame);

--- a/theia-panel/src/physics/Simulation.ts
+++ b/theia-panel/src/physics/Simulation.ts
@@ -48,83 +48,130 @@ function forceAnchor(strength = 0.15) {
 /**
  * Custom force: mild attraction toward the centroid of each node's
  * immediate neighbors. Keeps clusters coherent without exploding.
+ *
+ * Adjacency is resolved once per simulation in initialize(), not per
+ * tick. Links and node identities don't change between ticks for a
+ * given simulation; rebuilding the adjacency map every tick was pure
+ * GC churn at 1.6k nodes (thousands of Map/Set allocations per tick).
  */
 function forceCluster(links: PhysicsLink[], strength = 0.03) {
   let nodes: PhysicsNode[] = [];
+  let neighborIdx: Int32Array[] = [];
   function force(alpha: number) {
-    const adj = new Map<string, Set<string>>();
-    const nodeMap = new Map<string, PhysicsNode>();
-    for (const n of nodes) {
-      adj.set(n.id, new Set());
-      nodeMap.set(n.id, n);
-    }
-    for (const l of links) {
-      adj.get(l.source)?.add(l.target);
-      adj.get(l.target)?.add(l.source);
-    }
-
-    for (const n of nodes) {
-      const neighbors = adj.get(n.id);
-      if (!neighbors || neighbors.size === 0) continue;
+    for (let i = 0; i < nodes.length; i++) {
+      const n = nodes[i]!;
+      const idx = neighborIdx[i]!;
+      const count = idx.length;
+      if (count === 0) continue;
       let cx = 0;
       let cy = 0;
       let cz = 0;
-      let count = 0;
-      for (const nid of neighbors) {
-        const neighbor = nodeMap.get(nid);
-        if (neighbor) {
-          cx += neighbor.x;
-          cy += neighbor.y;
-          cz += neighbor.z;
-          count++;
-        }
+      for (let k = 0; k < count; k++) {
+        const neighbor = nodes[idx[k]!]!;
+        cx += neighbor.x;
+        cy += neighbor.y;
+        cz += neighbor.z;
       }
-      if (count > 0) {
-        cx /= count;
-        cy /= count;
-        cz /= count;
-        n.vx = (n.vx ?? 0) + (cx - n.x) * strength * alpha;
-        n.vy = (n.vy ?? 0) + (cy - n.y) * strength * alpha;
-        n.vz = (n.vz ?? 0) + (cz - n.z) * strength * alpha;
-      }
+      cx /= count;
+      cy /= count;
+      cz /= count;
+      n.vx = (n.vx ?? 0) + (cx - n.x) * strength * alpha;
+      n.vy = (n.vy ?? 0) + (cy - n.y) * strength * alpha;
+      n.vz = (n.vz ?? 0) + (cz - n.z) * strength * alpha;
     }
   }
   force.initialize = (n: PhysicsNode[]) => {
     nodes = n;
+    const idxById = new Map<string, number>();
+    for (let i = 0; i < n.length; i++) idxById.set(n[i]!.id, i);
+    const tmp: number[][] = n.map(() => []);
+    for (const l of links) {
+      const si = idxById.get(l.source);
+      const ti = idxById.get(l.target);
+      if (si === undefined || ti === undefined) continue;
+      tmp[si]!.push(ti);
+      tmp[ti]!.push(si);
+    }
+    neighborIdx = tmp.map((a) => Int32Array.from(a));
   };
   return force;
 }
 
-/** Custom 3D collision force. */
+/**
+ * Custom 3D collision force, spatial-hashed.
+ *
+ * The previous O(N²) all-pairs check did ~1.28M pair tests per tick at
+ * 1.6k nodes — the dominant cost in the entire simulation. Now we bin
+ * nodes into a uniform cubic grid sized to the maximum collision
+ * distance, so each node only checks its own cell + 26 neighbors.
+ * Average candidate set drops from N to a small constant (proportional
+ * to local density), giving ~O(N) per tick at typical layouts.
+ */
 function forceCollide(strength = 0.5) {
   let nodes: PhysicsNode[] = [];
+  let cellSize = 0.4;
+  const grid = new Map<number, number[]>();
+  // Pack 3 signed ints into a single key. ±2¹⁰ cells per axis covers
+  // layouts spanning a few world units at our scale.
+  const key3 = (cx: number, cy: number, cz: number) =>
+    ((cx + 1024) << 20) | ((cy + 1024) << 10) | (cz + 1024);
   function force(alpha: number) {
+    grid.clear();
+    const inv = 1 / cellSize;
+    for (let i = 0; i < nodes.length; i++) {
+      const n = nodes[i]!;
+      const k = key3(
+        Math.floor(n.x * inv),
+        Math.floor(n.y * inv),
+        Math.floor(n.z * inv),
+      );
+      const bucket = grid.get(k);
+      if (bucket) bucket.push(i);
+      else grid.set(k, [i]);
+    }
     for (let i = 0; i < nodes.length; i++) {
       const a = nodes[i]!;
-      for (let j = i + 1; j < nodes.length; j++) {
-        const b = nodes[j]!;
-        const dx = a.x - b.x;
-        const dy = a.y - b.y;
-        const dz = a.z - b.z;
-        const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
-        const minDist = a.radius + b.radius + 0.02;
-        if (dist > 0 && dist < minDist) {
-          const overlap = minDist - dist;
-          const fx = (dx / dist) * overlap * strength * alpha;
-          const fy = (dy / dist) * overlap * strength * alpha;
-          const fz = (dz / dist) * overlap * strength * alpha;
-          a.vx = (a.vx ?? 0) + fx;
-          a.vy = (a.vy ?? 0) + fy;
-          a.vz = (a.vz ?? 0) + fz;
-          b.vx = (b.vx ?? 0) - fx;
-          b.vy = (b.vy ?? 0) - fy;
-          b.vz = (b.vz ?? 0) - fz;
+      const cx = Math.floor(a.x * inv);
+      const cy = Math.floor(a.y * inv);
+      const cz = Math.floor(a.z * inv);
+      for (let dx = -1; dx <= 1; dx++) {
+        for (let dy = -1; dy <= 1; dy++) {
+          for (let dz = -1; dz <= 1; dz++) {
+            const bucket = grid.get(key3(cx + dx, cy + dy, cz + dz));
+            if (!bucket) continue;
+            for (let bi = 0; bi < bucket.length; bi++) {
+              const j = bucket[bi]!;
+              if (j <= i) continue;
+              const b = nodes[j]!;
+              const ddx = a.x - b.x;
+              const ddy = a.y - b.y;
+              const ddz = a.z - b.z;
+              const distSq = ddx * ddx + ddy * ddy + ddz * ddz;
+              const minDist = a.radius + b.radius + 0.02;
+              if (distSq > 0 && distSq < minDist * minDist) {
+                const dist = Math.sqrt(distSq);
+                const overlap = minDist - dist;
+                const fx = (ddx / dist) * overlap * strength * alpha;
+                const fy = (ddy / dist) * overlap * strength * alpha;
+                const fz = (ddz / dist) * overlap * strength * alpha;
+                a.vx = (a.vx ?? 0) + fx;
+                a.vy = (a.vy ?? 0) + fy;
+                a.vz = (a.vz ?? 0) + fz;
+                b.vx = (b.vx ?? 0) - fx;
+                b.vy = (b.vy ?? 0) - fy;
+                b.vz = (b.vz ?? 0) - fz;
+              }
+            }
+          }
         }
       }
     }
   }
   force.initialize = (n: PhysicsNode[]) => {
     nodes = n;
+    let maxR = 0;
+    for (const node of n) if (node.radius > maxR) maxR = node.radius;
+    cellSize = Math.max(0.05, maxR * 2 + 0.02);
   };
   return force;
 }

--- a/theia-panel/src/scene/Edges.ts
+++ b/theia-panel/src/scene/Edges.ts
@@ -126,13 +126,29 @@ export function createEdges(): EdgeLayer {
         if (si === undefined || ti === undefined) continue;
         const s = graph.nodes[si]!;
         const t = graph.nodes[ti]!;
-        positions[i * 6 + 0] = s.position.x;
-        positions[i * 6 + 1] = s.position.y;
+        // Read live positions from `nodePositions` for x/y too — not just z.
+        // `node.position` is the raw dataset anchor; the simulation places
+        // nodes at `position * spread` (Simulation.ts) plus whatever physics
+        // shifts them, so anchors don't match the rendered layout. The
+        // original code only got away with reading anchors here because
+        // tick() ran every frame and `updatePositions` immediately
+        // overwrote these values; the idle-tick gate exposed the latent
+        // mismatch as edges snapping to ~origin after a rebuild.
+        positions[i * 6 + 0] = nodePositions
+          ? (nodePositions[si * 3 + 0] ?? s.position.x)
+          : s.position.x;
+        positions[i * 6 + 1] = nodePositions
+          ? (nodePositions[si * 3 + 1] ?? s.position.y)
+          : s.position.y;
         positions[i * 6 + 2] = nodePositions
           ? (nodePositions[si * 3 + 2] ?? 0)
           : 0;
-        positions[i * 6 + 3] = t.position.x;
-        positions[i * 6 + 4] = t.position.y;
+        positions[i * 6 + 3] = nodePositions
+          ? (nodePositions[ti * 3 + 0] ?? t.position.x)
+          : t.position.x;
+        positions[i * 6 + 4] = nodePositions
+          ? (nodePositions[ti * 3 + 1] ?? t.position.y)
+          : t.position.y;
         positions[i * 6 + 5] = nodePositions
           ? (nodePositions[ti * 3 + 2] ?? 0)
           : 0;

--- a/theia-panel/src/scene/Nodes.ts
+++ b/theia-panel/src/scene/Nodes.ts
@@ -84,24 +84,39 @@ function stellarAgeColor(
 }
 
 const VERT = `
+attribute vec3 aBaseColor;
+attribute float aWaveOffset;
+attribute float aBrightness;
+attribute float aDim;
+attribute float aState;
+
 varying vec2 vUv;
-varying vec3 vColor;
+varying vec3 vBaseColor;
 varying vec3 vCenterPos;
+varying float vWaveOffset;
+varying float vBrightness;
+varying float vDim;
+varying float vState;
+
 void main() {
   vUv = uv;
-  vColor = instanceColor;
+  vBaseColor = aBaseColor;
+  vWaveOffset = aWaveOffset;
+  vBrightness = aBrightness;
+  vDim = aDim;
+  vState = aState;
 
   vec3 instancePos = instanceMatrix[3].xyz;
-  vec3 scale = vec3(
-    length(instanceMatrix[0].xyz),
-    length(instanceMatrix[1].xyz),
-    length(instanceMatrix[2].xyz)
-  );
+  // writeMatrix() always sets identity quaternion + uniform scale, so the
+  // instance matrix is diagonal-scale + translation. Pull scale straight
+  // from the matrix diagonal — equivalent to length(matrix[0].xyz)
+  // without three sqrts per vertex.
+  float instScale = instanceMatrix[0][0];
 
   vCenterPos = instancePos;
 
   vec4 viewPos = viewMatrix * vec4(instancePos, 1.0);
-  viewPos.xy += position.xy * scale.xy;
+  viewPos.xy += position.xy * instScale;
 
   gl_Position = projectionMatrix * viewPos;
 }
@@ -110,19 +125,50 @@ void main() {
 const FRAG = `
 precision highp float;
 uniform sampler2D map;
-uniform vec3 uCameraPos;
+uniform float uTime;
+uniform vec3 uHighlightColor;
+uniform vec3 uSelectedColor;
+uniform float uDimFactor;
+
 varying vec2 vUv;
-varying vec3 vColor;
+varying vec3 vBaseColor;
 varying vec3 vCenterPos;
+varying float vWaveOffset;
+varying float vBrightness;
+varying float vDim;
+varying float vState;
+
 void main() {
   vec4 texColor = texture2D(map, vUv);
-  vec3 finalColor = texColor.rgb * vColor;
+
+  // Selected (state=2) and highlighted (state=1) override twinkle/brightness,
+  // matching the original CPU-side branching in setTime(). vState is
+  // per-instance, so all fragments of a given quad take the same branch
+  // — coherent control flow, fine on modern GPUs.
+  vec3 tint;
+  float effect;
+  if (vState > 1.5) {
+    tint = uSelectedColor;
+    effect = 1.0;
+  } else if (vState > 0.5) {
+    tint = uHighlightColor;
+    effect = 1.0;
+  } else {
+    tint = vBaseColor;
+    float twinkle = 1.0 + 0.12 * sin(uTime * 1.5 + vWaveOffset);
+    float dim = mix(1.0, uDimFactor, vDim);
+    effect = twinkle * vBrightness * dim;
+  }
+
+  vec3 rgb = min(texColor.rgb * tint * effect, vec3(1.0));
   float alpha = texColor.a;
-  float dist = distance(vCenterPos, uCameraPos);
+  // cameraPosition is auto-injected by ShaderMaterial — no explicit
+  // uniform needed.
+  float dist = distance(vCenterPos, cameraPosition);
   float fade = smoothstep(0.15, 0.8, dist);
   alpha *= fade;
   if (alpha < 0.01) discard;
-  gl_FragColor = vec4(finalColor, alpha);
+  gl_FragColor = vec4(rgb, alpha);
 }
 `;
 
@@ -137,7 +183,6 @@ export interface NodeLayer {
   setRevealScale(i: number, scale: number): void;
   setVisible(i: number, visible: boolean): void;
   setTime(t: number): void;
-  setCameraPosition(pos: THREE.Vector3): void;
   flush(): void;
   dispose(): void;
 }
@@ -150,10 +195,27 @@ export function createNodes(
 ): NodeLayer {
   const n = graph.nodes.length;
   const geometry = new THREE.PlaneGeometry(1, 1);
+  const highlightColor = new THREE.Color(PALETTE.nodeHighlight);
+  const selectedColor = new THREE.Color(PALETTE.nodeSelected);
   const material = new THREE.ShaderMaterial({
     uniforms: {
       map: { value: NODE_GLOW_TEXTURE },
-      uCameraPos: { value: new THREE.Vector3() },
+      uTime: { value: 0 },
+      uHighlightColor: {
+        value: new THREE.Vector3(
+          highlightColor.r,
+          highlightColor.g,
+          highlightColor.b,
+        ),
+      },
+      uSelectedColor: {
+        value: new THREE.Vector3(
+          selectedColor.r,
+          selectedColor.g,
+          selectedColor.b,
+        ),
+      },
+      uDimFactor: { value: DIM_FACTOR },
     },
     vertexShader: VERT,
     fragmentShader: FRAG,
@@ -163,8 +225,6 @@ export function createNodes(
   });
   const mesh = new THREE.InstancedMesh(geometry, material, n);
   const dummy = new THREE.Object3D();
-  const highlightColor = new THREE.Color(PALETTE.nodeHighlight);
-  const selectedColor = new THREE.Color(PALETTE.nodeSelected);
 
   // Compute time range for stellar age coloring
   let minTime = Infinity;
@@ -181,25 +241,47 @@ export function createNodes(
     maxTime = 1;
   }
 
-  // Precompute per-node size, color, and wave offset for spatial twinkling
   const nodeSizes = new Float32Array(n);
-  const nodeColors: THREE.Color[] = new Array(n);
-  const nodeWaveOffsets = new Float32Array(n);
+
+  // Per-instance shader inputs. These are uploaded only when their values
+  // actually change — not every frame. Twinkle/highlight/dim/select math
+  // moved into the fragment shader; setTime() collapses to a single
+  // uniform update.
+  const baseColorArr = new Float32Array(n * 3);
+  const waveOffsetArr = new Float32Array(n);
+  const brightnessArr = new Float32Array(n);
+  const dimArr = new Float32Array(n);
+  const stateArr = new Float32Array(n);
 
   for (let i = 0; i < n; i++) {
     const node = graph.nodes[i]!;
     const turns = node.message_count ?? node.tool_count;
     nodeSizes[i] = Math.min(0.18, 0.05 + Math.log1p(turns) * 0.014);
-    nodeColors[i] = stellarAgeColor(
-      node.started_at,
-      minTime,
-      maxTime,
-      node.model,
-    );
+    const c = stellarAgeColor(node.started_at, minTime, maxTime, node.model);
+    baseColorArr[i * 3 + 0] = c.r;
+    baseColorArr[i * 3 + 1] = c.g;
+    baseColorArr[i * 3 + 2] = c.b;
     // Spatial wave: coherent ripple across the constellation
-    nodeWaveOffsets[i] =
+    waveOffsetArr[i] =
       node.position.x * 2.0 + node.position.y * 1.5 + hash01(node.id) * 3.0;
+    brightnessArr[i] = 1;
+    dimArr[i] = 0;
+    stateArr[i] = 0;
   }
+
+  const baseColorAttr = new THREE.InstancedBufferAttribute(baseColorArr, 3);
+  const waveOffsetAttr = new THREE.InstancedBufferAttribute(waveOffsetArr, 1);
+  const brightnessAttr = new THREE.InstancedBufferAttribute(brightnessArr, 1);
+  const dimAttr = new THREE.InstancedBufferAttribute(dimArr, 1);
+  const stateAttr = new THREE.InstancedBufferAttribute(stateArr, 1);
+  brightnessAttr.setUsage(THREE.DynamicDrawUsage);
+  dimAttr.setUsage(THREE.DynamicDrawUsage);
+  stateAttr.setUsage(THREE.DynamicDrawUsage);
+  geometry.setAttribute("aBaseColor", baseColorAttr);
+  geometry.setAttribute("aWaveOffset", waveOffsetAttr);
+  geometry.setAttribute("aBrightness", brightnessAttr);
+  geometry.setAttribute("aDim", dimAttr);
+  geometry.setAttribute("aState", stateAttr);
 
   for (let i = 0; i < n; i++) {
     const node = graph.nodes[i]!;
@@ -212,17 +294,13 @@ export function createNodes(
     dummy.scale.set(sz, sz, sz);
     dummy.updateMatrix();
     mesh.setMatrixAt(i, dummy.matrix);
-    mesh.setColorAt(i, nodeColors[i]!);
   }
   mesh.instanceMatrix.needsUpdate = true;
-  if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
 
   const highlighted = new Set<number>();
   const selected = new Set<number>();
-  const dimmed = new Set<number>();
   const visibleFlags = new Array(n).fill(true);
   const revealScales = new Float32Array(n).fill(1);
-  const brightnessMultipliers = new Float32Array(n).fill(1);
 
   function writeMatrix(i: number) {
     const sz = visibleFlags[i] ? nodeSizes[i]! * revealScales[i]! : 0;
@@ -237,6 +315,15 @@ export function createNodes(
     mesh.setMatrixAt(i, dummy.matrix);
   }
 
+  // Selected wins over highlighted, matching original branching.
+  function writeState(i: number) {
+    const s = selected.has(i) ? 2 : highlighted.has(i) ? 1 : 0;
+    if (stateArr[i] !== s) {
+      stateArr[i] = s;
+      stateAttr.needsUpdate = true;
+    }
+  }
+
   return {
     mesh,
     count: n,
@@ -249,17 +336,26 @@ export function createNodes(
     setHighlight(i, on) {
       if (on) highlighted.add(i);
       else highlighted.delete(i);
+      writeState(i);
     },
     setSelected(i, on) {
       if (on) selected.add(i);
       else selected.delete(i);
+      writeState(i);
     },
     setBrightness(i, multiplier) {
-      brightnessMultipliers[i] = Math.max(0, multiplier);
+      const v = Math.max(0, multiplier);
+      if (brightnessArr[i] !== v) {
+        brightnessArr[i] = v;
+        brightnessAttr.needsUpdate = true;
+      }
     },
     setDim(i, on) {
-      if (on) dimmed.add(i);
-      else dimmed.delete(i);
+      const v = on ? 1 : 0;
+      if (dimArr[i] !== v) {
+        dimArr[i] = v;
+        dimAttr.needsUpdate = true;
+      }
     },
     setRevealScale(i, scale) {
       revealScales[i] = Math.max(0, scale);
@@ -270,46 +366,10 @@ export function createNodes(
       writeMatrix(i);
     },
     setTime(t: number) {
-      const colorAttr = mesh.instanceColor!;
-      for (let i = 0; i < n; i++) {
-        if (selected.has(i)) {
-          colorAttr.setXYZ(
-            i,
-            selectedColor.r,
-            selectedColor.g,
-            selectedColor.b,
-          );
-          continue;
-        }
-        if (highlighted.has(i)) {
-          colorAttr.setXYZ(
-            i,
-            highlightColor.r,
-            highlightColor.g,
-            highlightColor.b,
-          );
-          continue;
-        }
-        const tint = nodeColors[i]!;
-        // Gentle wavy blink: slow traveling wave across the constellation
-        const twinkle = 1.0 + 0.12 * Math.sin(t * 1.5 + nodeWaveOffsets[i]!);
-        const brightness = brightnessMultipliers[i]!;
-        const dim = dimmed.has(i) ? DIM_FACTOR : 1.0;
-        colorAttr.setXYZ(
-          i,
-          Math.min(1, tint.r * twinkle * brightness * dim),
-          Math.min(1, tint.g * twinkle * brightness * dim),
-          Math.min(1, tint.b * twinkle * brightness * dim),
-        );
-      }
-      colorAttr.needsUpdate = true;
-    },
-    setCameraPosition(pos) {
-      material.uniforms.uCameraPos!.value.copy(pos);
+      material.uniforms.uTime!.value = t;
     },
     flush() {
       mesh.instanceMatrix.needsUpdate = true;
-      if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
     },
     dispose() {
       geometry.dispose();

--- a/theia-panel/src/scene/Scene.ts
+++ b/theia-panel/src/scene/Scene.ts
@@ -52,6 +52,15 @@ function fovForAspect(a: number): number {
   return BASE_FOV_DEG;
 }
 
+// Cap pixel ratio to bound fragment work on high-DPR displays. The post
+// pipeline allocates four full-resolution HalfFloat render targets plus
+// runs a multi-pass composer + UnrealBloom — fragment cost scales with
+// dpr², so a 3× display would do 9× the shading of a 1× reference.
+// 2× is enough to look crisp without paying the full retina tax.
+const MAX_PIXEL_RATIO = 2;
+const effectivePixelRatio = (): number =>
+  Math.min(window.devicePixelRatio, MAX_PIXEL_RATIO);
+
 export function createScene(container: HTMLElement): SceneContext {
   const scene = new THREE.Scene();
 
@@ -65,7 +74,7 @@ export function createScene(container: HTMLElement): SceneContext {
   );
 
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
-  renderer.setPixelRatio(window.devicePixelRatio);
+  renderer.setPixelRatio(effectivePixelRatio());
   renderer.setSize(w, h, true);
   renderer.domElement.style.display = "block";
   container.appendChild(renderer.domElement);
@@ -102,7 +111,7 @@ export function createScene(container: HTMLElement): SceneContext {
     // Re-sync DPR — fullscreen transitions and monitor changes can
     // change devicePixelRatio, and the renderer caches it from the
     // first setPixelRatio call.
-    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setPixelRatio(effectivePixelRatio());
     renderer.setSize(w2, h2, true);
     for (const fn of resizeListeners) fn();
   };


### PR DESCRIPTION
Nine commits, all incremental and individually revertible. Starts as a small shader move to fix the 1.6k-node FPS drop and grows into a broader pass over the panel render + physics path.

Reporter took FPS from a median ~49 (p5 ~24) up to a stable 144 fps after commits 1-3.

## Recommended landing order

Each commit stands alone — feel free to land in any order, or cherry-pick a subset. Suggested order matches the commit history, lowest-risk first:

1. **`74b7319` perf(panel): move node twinkle/highlight/select into shader** — pure shader/attribute restructure inside `Nodes.ts`. No external API change. Visually identical.
2. **`257a420` perf(panel): skip physics tick when layout has settled** — the biggest single FPS win. Adds `wakePhysics()` to `replaceSimulation` + `syncRenderedPositionsFromSimulation`.
3. **`85f72c4` perf(panel): cap renderer pixel ratio at 2** — `Scene.ts` only. Quartered fragment work on 3× displays. No visual difference past 2×.
4. **`4cc1e4b` fix(panel): read live node positions in edge rebuild** — fixes a *latent* bug exposed by #2. `Edges.rebuild()` was reading endpoint x/y from `node.position` (raw dataset anchor) but z from live `nodePositions`; the simulation places nodes at `position * spread (1.8)`, so anchors don't match the rendered layout. Per-frame `tick()` was masking it. **Land before #2 if you want to be conservative — it's a strict correctness fix that's safe under the old code too.**
5. **`ef798c4` fix(panel): wake physics on visibility changes** — pairs with #2. `setNodeVisibilityFromState` now calls `wakePhysics()` so component-focus / focus-mode / onboarding-reveal all re-equilibrate the layout.
6. **`3ba6418` perf(physics): rewrite forceCluster + forceCollide for high-N** — physics-only. `forceCluster` adjacency hoisted out of per-tick (kills GC churn); `forceCollide` rewritten from O(N²) to spatial-hash (~O(N) at typical density). Independent of all panel/render changes.
7. **`737f732` perf(panel): cap physics tick rate at 60Hz** ⚠️ **Reverted by #8** — keep #8, drop this commit when squashing.
8. **`6ea677d` fix(panel): let physics tick at display refresh + bump alpha on wake** — undoes the 60Hz cap (physics ticks every rAF instead, in lockstep with render) and bumps `simulation.alpha()` to 0.18 on wake so visibility changes produce visible re-equilibration.
9. **`e9b01a3` refactor(panel): use built-in cameraPosition + skip vertex sqrts** — purely a code-hygiene pass against the threejs-shaders skill checklist. **No measurable perf gain** — kept because the cleanup is cheap and removes a redundant uniform from the per-frame path. Skip if you'd rather keep the diff minimal.

If squashing, I'd squash {7, 8} into a single commit ('cap physics tick at display refresh + alpha-on-wake') so the throttle/un-throttle history doesn't ship.

## What's intentionally NOT in this PR

- **Web Worker for physics.** Discussed; the right move once `index.ts` is refactored into `state/` + `interaction/` modules. Touching simulation in this 1500-line file means hitting 11+ call sites; doing it after the refactor turns it into a localized swap inside `state/simulation.ts`.
- **Bumping node twinkle amplitude.** Reporter observed nodes \"stop twinkling\" after settle — diagnosed as physics micro-jiggle being perceived as twinkle, not the shader pulse. The actual 12% color pulse survives bloom but is largely flattened by the 32-level dither in `Post.ts`. Easy follow-up: bump `0.12` → `0.25` in the FRAG, or move pulse to alpha (matches edges, more visible). Held to keep this PR scoped to perf.
- **Tuning `alphaDecay`.** Now that ticks run at display refresh (commit #8), high-refresh displays burn alpha 2.4× faster than d3-force expects. Settle behaviour is fine in practice but would be cleaner to scale `alphaDecay` by `60/refreshHz`.

## Caveats

- **Rebase needed.** `dev` has advanced 5 commits since the branch was cut (keyboard nav, hover throttle, touch tap, edge hover highlight). The rebase should be mostly clean — touched files overlap on `Nodes.ts` and `Picker.ts` but mostly in different regions. Worth a manual rebase rather than letting GitHub merge.
- **The idle-tick gate (#2) is load-bearing for fixes #4 + #5.** If you cherry-pick #2 without #4/#5, you'll re-introduce the edges-snap-to-origin bug after component focus toggles.
- **Tests.** `tsc --noEmit` clean; `vitest run` 10/10 pass. There's no test coverage for the simulation/render loop itself — the wins were verified by the reporter visually + via FPS console-logger.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 10/10 pass
- [x] Visual smoke (1.6k nodes, dashboard): twinkle/hover/select/search behave identically to dev; FPS jumped from ~49 median to 144
- [x] Component focus toggle on/off — edges stay attached to nodes; visible re-equilibration on toggle
- [ ] Re-test after rebase against current `dev`
- [ ] Spot-check on a 1× display to confirm the DPR cap doesn't visibly degrade at native resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)