### PR TITLE
perf(physics): off-thread simulation via Web Worker (+ state/simulation extraction)

### DIFF
--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -648,9 +648,9 @@ export async function mount(
       setNodeVisibilityFromState();
       rebuildVisibleEdges();
       simState.replaceActive({
-      activeIds: activeVisibleNodeIds(),
-      animateNew: true,
-    });
+        activeIds: activeVisibleNodeIds(),
+        animateNew: true,
+      });
     }
     onboarding.lastEase = eased;
     onboarding.overlay.update(eased);

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -5,8 +5,11 @@ import { createScene } from "./scene/Scene";
 import { createNodes, type NodeLayer } from "./scene/Nodes";
 import { createEdges } from "./scene/Edges";
 import { createPost } from "./scene/Post";
-import { createSimulation } from "./physics/Simulation";
 import { createPicker } from "./scene/Picker";
+import {
+  createSimulationState,
+  type SimulationState,
+} from "./state/simulation";
 import { createKeyboardNav } from "./scene/KeyboardNav";
 import { computeEdgeChain } from "./scene/chain";
 import { createTooltip } from "./ui/Tooltip";
@@ -27,11 +30,7 @@ import {
   saveFilterState,
   computeVisibleNodeIds,
 } from "./state/filterState";
-import {
-  createPhysicsSnapshotIO,
-  type PhysicsSnapshotNode,
-} from "./state/physicsSnapshot";
-import { hashN11 } from "./util/hash";
+import { createPhysicsSnapshotIO } from "./state/physicsSnapshot";
 
 export interface PanelOptions {
   edgeKinds?: TheiaGraph["edges"][number]["kind"][];
@@ -171,127 +170,13 @@ export async function mount(
   let nodes: NodeLayer;
   let nodeIndex = new Map<string, number>();
   let nodePositions = new Float32Array(0);
-  let simNodes: ReturnType<typeof createSimulation>["nodes"] = [];
-  let simulation: ReturnType<typeof createSimulation>["simulation"];
-  let renderedPositions = new Float32Array(0);
+  let simState: SimulationState;
   let picker: ReturnType<typeof createPicker>;
   const keyboardNav = createKeyboardNav(ctx);
   let searchBar: ReturnType<typeof createSearchBar>;
   let selectedIdx: number | null = null;
   let currentGraphUrl = graphUrl;
   const physicsSnapshotIO = createPhysicsSnapshotIO();
-
-  function simulationGraphFor(activeIds: Set<string> | null): TheiaGraph {
-    if (!activeIds) return currentGraph;
-    return {
-      ...currentGraph,
-      nodes: currentGraph.nodes.filter((node) => activeIds.has(node.id)),
-      edges: currentGraph.edges.filter(
-        (edge) => activeIds.has(edge.source) && activeIds.has(edge.target),
-      ),
-    };
-  }
-
-  function replaceSimulation(
-    activeIds: Set<string> | null,
-    animateNew = false,
-    preserveExisting = true,
-    seedPositions = new Map<string, PhysicsSnapshotNode>(),
-  ) {
-    const oldPositions = new Map<
-      string,
-      { x: number; y: number; z: number; vx?: number; vy?: number; vz?: number }
-    >();
-    for (const sn of simNodes) {
-      if (sn) {
-        oldPositions.set(sn.id, {
-          x: sn.x,
-          y: sn.y,
-          z: sn.z,
-          vx: sn.vx,
-          vy: sn.vy,
-          vz: sn.vz,
-        });
-      }
-    }
-
-    simulation?.stop();
-    const simResult = createSimulation(
-      simulationGraphFor(activeIds),
-      kinds,
-      onboarding && !onboarding.complete ? "onboarding" : "normal",
-    );
-    simulation = simResult.simulation;
-    simulation.stop();
-
-    const nextNodes = new Array(currentGraph.nodes.length) as typeof simNodes;
-    for (const sn of simResult.nodes) {
-      const idx = nodeIndex.get(sn.id);
-      if (idx === undefined) continue;
-      const old = preserveExisting ? oldPositions.get(sn.id) : undefined;
-      const seed = seedPositions.get(sn.id);
-      if (old || seed) {
-        const source = old ?? seed!;
-        sn.x = source.x;
-        sn.y = source.y;
-        sn.z = source.z;
-        sn.vx = source.vx ?? 0;
-        sn.vy = source.vy ?? 0;
-        sn.vz = source.vz ?? 0;
-      } else if (animateNew) {
-        const jitter = 0.08;
-        sn.x = sn.anchorX * 0.55 + hashN11(`${sn.id}:x`) * jitter;
-        sn.y = sn.anchorY * 0.55 + hashN11(`${sn.id}:y`) * jitter;
-        sn.z = sn.anchorZ * 0.55 + hashN11(`${sn.id}:z`) * jitter;
-        sn.vx = (sn.anchorX - sn.x) * 0.006;
-        sn.vy = (sn.anchorY - sn.y) * 0.006;
-        sn.vz = (sn.anchorZ - sn.z) * 0.006;
-        renderedPositions[idx * 3] = sn.x;
-        renderedPositions[idx * 3 + 1] = sn.y;
-        renderedPositions[idx * 3 + 2] = sn.z;
-        nodes?.setPosition(idx, sn.x, sn.y, sn.z);
-      }
-      nextNodes[idx] = sn;
-    }
-    simNodes = nextNodes;
-    simulation.alpha(animateNew ? 0.22 : simulation.alphaTarget());
-    wakePhysics();
-  }
-
-  // Settled-physics gate: skip the per-frame sim/lerp/edge-rewrite when
-  // the layout has stabilised. The lerp drives matrix uploads and a full
-  // edge-position attribute rewrite every frame; with 1.6k nodes that's
-  // most of the per-frame cost once the simulation has converged.
-  let settledFrames = 0;
-  const SETTLED_THRESHOLD = 30;
-  // Threshold ≈ 0.001² in world units — well below visible motion at any
-  // reasonable zoom, since node sizes top out at 0.18 (see Nodes.ts).
-  const SETTLE_EPSILON_SQ = 1e-6;
-  // Energy injected on wake so filter/visibility changes actually produce
-  // a visible re-equilibration. Without this, alpha sits at alphaTarget
-  // (0.012, see Simulation.ts) which makes wake invisible — sub-pixel
-  // motion that re-settles within a few ticks.
-  const WAKE_ALPHA = 0.18;
-  function wakePhysics() {
-    settledFrames = 0;
-    if (simulation && simulation.alpha() < WAKE_ALPHA) {
-      simulation.alpha(WAKE_ALPHA);
-    }
-  }
-
-  function syncRenderedPositionsFromSimulation() {
-    wakePhysics();
-    for (let i = 0; i < simNodes.length; i++) {
-      const sn = simNodes[i];
-      if (!sn) continue;
-      renderedPositions[i * 3] = sn.x;
-      renderedPositions[i * 3 + 1] = sn.y;
-      renderedPositions[i * 3 + 2] = sn.z;
-      nodes.setPosition(i, sn.x, sn.y, sn.z);
-    }
-    nodes.flush();
-    edges.updatePositions(nodePositions);
-  }
 
   function canSavePhysicsSnapshot(): boolean {
     if (!currentGraph || !hasCompletedOnboarding()) return false;
@@ -301,14 +186,18 @@ export async function mount(
 
   function savePhysicsSnapshot() {
     if (!canSavePhysicsSnapshot()) return;
-    physicsSnapshotIO.save(currentGraphUrl, simNodes, ctx.getCameraState());
+    physicsSnapshotIO.save(
+      currentGraphUrl,
+      simState.getSimNodes(),
+      ctx.getCameraState(),
+    );
   }
 
   function maybeSavePhysicsSnapshot(now: number) {
     physicsSnapshotIO.maybeSave(
       now,
       currentGraphUrl,
-      simNodes,
+      simState.getSimNodes(),
       () => ctx.getCameraState(),
       canSavePhysicsSnapshot(),
     );
@@ -436,7 +325,7 @@ export async function mount(
     onNavigate: (targetId) => {
       const idx = nodeIndex.get(targetId);
       if (idx === undefined || !activeVisibleNodeIds().has(targetId)) return;
-      const sn = simNodes[idx];
+      const sn = simState.getNodePosition(idx);
       if (!sn) return;
       select(idx);
       ctx.focusOn(sn.x, sn.y, 1.5);
@@ -521,7 +410,9 @@ export async function mount(
     setNodeVisibilityFromState();
 
     // Start at equilibrium to prevent jittery readjustment.
-    replaceSimulation(onboarding ? activeVisibleNodeIds() : null);
+    simState.replaceActive({
+      activeIds: onboarding ? activeVisibleNodeIds() : null,
+    });
 
     rebuildVisibleEdges();
     return searchMatchesChanged;
@@ -545,10 +436,10 @@ export async function mount(
     }
     nodes.flush();
     // Filter/focus toggles change the active set without going through
-    // replaceSimulation; wake physics so the layout can re-equilibrate
-    // for the new visible node set. The gate will re-arm after the
+    // replaceActive; wake physics so the layout can re-equilibrate for
+    // the new visible node set. The gate will re-arm after the
     // simulation re-settles.
-    wakePhysics();
+    simState.wakePhysics();
   }
 
   const EDGE_KIND_LABELS: Record<TheiaGraph["edges"][number]["kind"], string> =
@@ -682,7 +573,10 @@ export async function mount(
     }
     setNodeVisibilityFromState();
     rebuildVisibleEdges();
-    replaceSimulation(activeVisibleNodeIds(), true);
+    simState.replaceActive({
+      activeIds: activeVisibleNodeIds(),
+      animateNew: true,
+    });
   }
 
   function updateOnboardingLinks(now: number) {
@@ -753,7 +647,10 @@ export async function mount(
       onboarding.lastRevealedCount = revealCount;
       setNodeVisibilityFromState();
       rebuildVisibleEdges();
-      replaceSimulation(activeVisibleNodeIds(), true);
+      simState.replaceActive({
+      activeIds: activeVisibleNodeIds(),
+      animateNew: true,
+    });
     }
     onboarding.lastEase = eased;
     onboarding.overlay.update(eased);
@@ -804,9 +701,12 @@ export async function mount(
       if (!onboarding.revealedNodeIds.has(currentGraph.nodes[idx]!.id)) {
         continue;
       }
-      const dx = renderedPositions[idx * 3]! - ctx.camera.position.x;
-      const dy = renderedPositions[idx * 3 + 1]! - ctx.camera.position.y;
-      const dz = renderedPositions[idx * 3 + 2]! - ctx.camera.position.z;
+      // nodePositions tracks the same per-frame smoothed values that the
+      // simulation tick writes; reading from there avoids reaching into
+      // the simulation module's private renderedPositions buffer.
+      const dx = nodePositions[idx * 3]! - ctx.camera.position.x;
+      const dy = nodePositions[idx * 3 + 1]! - ctx.camera.position.y;
+      const dz = nodePositions[idx * 3 + 2]! - ctx.camera.position.z;
       nearest = Math.min(nearest, Math.sqrt(dx * dx + dy * dy + dz * dz));
     }
     if (!Number.isFinite(nearest)) return;
@@ -827,7 +727,7 @@ export async function mount(
   }
 
   function setupGraph(g: TheiaGraph) {
-    simulation?.stop();
+    simState?.dispose();
     onboarding?.overlay.remove();
     onboarding = null;
     // Clear any chain isolation from a prior graph: edge identity is
@@ -841,23 +741,35 @@ export async function mount(
 
     currentGraph = g;
     nodePositions = new Float32Array(g.nodes.length * 3);
-    renderedPositions = new Float32Array(g.nodes.length * 3);
     nodes = createNodes(g, nodePositions);
     ctx.scene.add(nodes.mesh);
 
     nodeIndex = new Map(g.nodes.map((n, i) => [n.id, i]));
+    simState = createSimulationState({
+      graph: g,
+      kinds,
+      isOnboarding: () => Boolean(onboarding && !onboarding.complete),
+      nodes,
+      edges,
+      nodePositions,
+    });
 
     if (hasCompletedOnboarding()) {
       const snapshot = physicsSnapshotIO.load(currentGraphUrl);
-      replaceSimulation(null, true, false, snapshot.nodes);
-      syncRenderedPositionsFromSimulation();
+      simState.replaceActive({
+        activeIds: null,
+        animateNew: true,
+        preserveExisting: false,
+        seedPositions: snapshot.nodes,
+      });
+      simState.syncRenderedPositionsFromSimulation();
       if (snapshot.camera) {
         ctx.setCameraState(snapshot.camera);
       }
     } else {
-      replaceSimulation(null);
-      simulation.tick(1);
-      syncRenderedPositionsFromSimulation();
+      simState.replaceActive({ activeIds: null });
+      simState.primeOnce();
+      simState.syncRenderedPositionsFromSimulation();
     }
 
     visibleNodeIds = computeVisibleNodeIds(
@@ -927,7 +839,7 @@ export async function mount(
       (result) => {
         const idx = nodeIndex.get(result.node.id);
         if (idx !== undefined && activeVisibleNodeIds().has(result.node.id)) {
-          const sn = simNodes[idx];
+          const sn = simState.getNodePosition(idx);
           if (sn) ctx.focusOn(sn.x, sn.y, 1.5);
           select(idx);
         }
@@ -974,43 +886,13 @@ export async function mount(
     beginOnboarding(initialGraph);
   }
 
-  function tick() {
-    if (settledFrames >= SETTLED_THRESHOLD) return;
-    simulation.tick(1);
-    const smoothing = onboarding ? 0.14 : 0.34;
-    let maxDeltaSq = 0;
-    for (let i = 0; i < simNodes.length; i++) {
-      const sn = simNodes[i];
-      if (!sn) continue;
-      const px = renderedPositions[i * 3]!;
-      const py = renderedPositions[i * 3 + 1]!;
-      const pz = renderedPositions[i * 3 + 2]!;
-      const dx = (sn.x - px) * smoothing;
-      const dy = (sn.y - py) * smoothing;
-      const dz = (sn.z - pz) * smoothing;
-      const x = px + dx;
-      const y = py + dy;
-      const z = pz + dz;
-      const deltaSq = dx * dx + dy * dy + dz * dz;
-      if (deltaSq > maxDeltaSq) maxDeltaSq = deltaSq;
-      renderedPositions[i * 3] = x;
-      renderedPositions[i * 3 + 1] = y;
-      renderedPositions[i * 3 + 2] = z;
-      nodes.setPosition(i, x, y, z);
-    }
-    nodes.flush();
-    edges.updatePositions(nodePositions);
-    if (maxDeltaSq < SETTLE_EPSILON_SQ) settledFrames++;
-    else settledFrames = 0;
-  }
-
   let disposed = false;
   function frame() {
     if (disposed) return;
     const now = performance.now();
     updateOnboarding(now);
     keyboardNav.tick(now);
-    tick();
+    simState.tick();
     maybeSavePhysicsSnapshot(now);
     updateOnboardingCamera();
     const t = now / 1000;
@@ -1257,7 +1139,7 @@ export async function mount(
       searchInputController?.abort();
       if (searchFocusTimer) clearTimeout(searchFocusTimer);
       stopThemeListener();
-      simulation.stop();
+      simState.dispose();
       nodes.dispose();
       edges.dispose();
       post.edgesTarget.dispose();

--- a/theia-panel/src/physics/SimulationWorker.ts
+++ b/theia-panel/src/physics/SimulationWorker.ts
@@ -1,0 +1,323 @@
+/// <reference lib="webworker" />
+/**
+ * Physics simulation worker. Runs the d3-force-3d simulation off the
+ * main thread so render frames don't stall during the convergence
+ * period.
+ *
+ * Protocol (see state/simulation.ts for the main-thread side):
+ *   main → worker:
+ *     init           — build simulation for the supplied graph
+ *     replaceActive  — rebuild simulation for a new active node set
+ *     wake           — bump alpha + start posting again
+ *     dispose        — stop simulation, exit
+ *
+ *   worker → main:
+ *     positions      — buffer of [x0,y0,z0, x1,y1,z1, ...] for each
+ *                      node, indexed by graph node order
+ *     snapshot       — full {id, x, y, z, vx, vy, vz} array on demand
+ *
+ * The worker self-throttles: ticks at ~60Hz internally (setTimeout
+ * loop), but stops posting once it detects the layout has settled.
+ * Wake messages restart posting. Main thread keeps rendering at full
+ * refresh rate independent of the worker; positions arrive
+ * asynchronously and are interpolated via a lerp on the main side.
+ */
+
+import { createSimulation } from "./Simulation";
+import { hashN11 } from "../util/hash";
+import type { TheiaGraph } from "../data/types";
+
+type SimNodes = ReturnType<typeof createSimulation>["nodes"];
+
+export type SnapshotPayloadNode = {
+  id: string;
+  x: number;
+  y: number;
+  z: number;
+  vx: number;
+  vy: number;
+  vz: number;
+};
+
+export type SeedNode = {
+  id: string;
+  x: number;
+  y: number;
+  z: number;
+  vx?: number;
+  vy?: number;
+  vz?: number;
+};
+
+export type WorkerInMsg =
+  | {
+      type: "init";
+      graph: TheiaGraph;
+      kinds: string[];
+      isOnboarding: boolean;
+      seedNodes?: SeedNode[];
+      animateNew?: boolean;
+    }
+  | {
+      type: "replaceActive";
+      activeIds: string[] | null;
+      animateNew: boolean;
+      preserveExisting: boolean;
+      seedNodes?: SeedNode[];
+      isOnboarding: boolean;
+    }
+  | { type: "wake" }
+  | { type: "snapshotRequest"; requestId: number }
+  | { type: "dispose" };
+
+export type WorkerOutMsg =
+  | {
+      type: "positions";
+      buffer: ArrayBuffer; // Float32Array of length n*3, x/y/z per node in graph order
+      settled: boolean;
+    }
+  | {
+      type: "ready";
+      // Sent once after init completes — main thread treats this as a
+      // signal that subsequent position messages can be expected.
+    }
+  | {
+      type: "snapshot";
+      requestId: number;
+      nodes: SnapshotPayloadNode[];
+    };
+
+const TICK_INTERVAL_MS = 1000 / 60;
+
+// Settled-physics gate (worker side): stop posting positions when the
+// per-tick max squared displacement is below threshold for N consecutive
+// ticks. Wake messages reset the counter.
+const SETTLED_THRESHOLD = 30;
+const SETTLE_EPSILON_SQ = 1e-6;
+const WAKE_ALPHA = 0.18;
+
+let graph: TheiaGraph | null = null;
+let nodeIndexById = new Map<string, number>();
+let simNodes: SimNodes = [];
+let simulation: ReturnType<typeof createSimulation>["simulation"] | null = null;
+let kinds = new Set<string>();
+let onboarding = false;
+let settledTicks = 0;
+let lastPositions: Float32Array | null = null; // n*3
+let tickHandle: ReturnType<typeof setTimeout> | null = null;
+let disposed = false;
+
+function simulationGraphFor(activeIds: Set<string> | null): TheiaGraph {
+  if (!graph) throw new Error("worker not initialized");
+  if (!activeIds) return graph;
+  return {
+    ...graph,
+    nodes: graph.nodes.filter((node) => activeIds.has(node.id)),
+    edges: graph.edges.filter(
+      (edge) => activeIds.has(edge.source) && activeIds.has(edge.target),
+    ),
+  };
+}
+
+function applyReplaceActive(opts: {
+  activeIds: string[] | null;
+  animateNew: boolean;
+  preserveExisting: boolean;
+  seedNodes?: SeedNode[];
+  isOnboarding: boolean;
+}) {
+  if (!graph) return;
+  const activeIdSet = opts.activeIds ? new Set(opts.activeIds) : null;
+  onboarding = opts.isOnboarding;
+
+  const oldPositions = new Map<
+    string,
+    {
+      x: number;
+      y: number;
+      z: number;
+      vx?: number;
+      vy?: number;
+      vz?: number;
+    }
+  >();
+  if (opts.preserveExisting) {
+    for (const sn of simNodes) {
+      if (sn) {
+        oldPositions.set(sn.id, {
+          x: sn.x,
+          y: sn.y,
+          z: sn.z,
+          vx: sn.vx,
+          vy: sn.vy,
+          vz: sn.vz,
+        });
+      }
+    }
+  }
+  const seedById = new Map<string, SeedNode>();
+  for (const seed of opts.seedNodes ?? []) seedById.set(seed.id, seed);
+
+  simulation?.stop();
+  const simResult = createSimulation(
+    simulationGraphFor(activeIdSet),
+    kinds,
+    opts.isOnboarding ? "onboarding" : "normal",
+  );
+  simulation = simResult.simulation;
+  simulation.stop();
+
+  const nextNodes = new Array(graph.nodes.length) as SimNodes;
+  for (const sn of simResult.nodes) {
+    const idx = nodeIndexById.get(sn.id);
+    if (idx === undefined) continue;
+    const old = opts.preserveExisting ? oldPositions.get(sn.id) : undefined;
+    const seed = seedById.get(sn.id);
+    if (old || seed) {
+      const source = old ?? seed!;
+      sn.x = source.x;
+      sn.y = source.y;
+      sn.z = source.z;
+      sn.vx = source.vx ?? 0;
+      sn.vy = source.vy ?? 0;
+      sn.vz = source.vz ?? 0;
+    } else if (opts.animateNew) {
+      const jitter = 0.08;
+      sn.x = sn.anchorX * 0.55 + hashN11(`${sn.id}:x`) * jitter;
+      sn.y = sn.anchorY * 0.55 + hashN11(`${sn.id}:y`) * jitter;
+      sn.z = sn.anchorZ * 0.55 + hashN11(`${sn.id}:z`) * jitter;
+      sn.vx = (sn.anchorX - sn.x) * 0.006;
+      sn.vy = (sn.anchorY - sn.y) * 0.006;
+      sn.vz = (sn.anchorZ - sn.z) * 0.006;
+    }
+    nextNodes[idx] = sn;
+  }
+  simNodes = nextNodes;
+  simulation.alpha(opts.animateNew ? 0.22 : simulation.alphaTarget());
+  settledTicks = 0;
+  scheduleTick();
+}
+
+function scheduleTick() {
+  if (disposed) return;
+  if (tickHandle !== null) return;
+  tickHandle = setTimeout(runTick, TICK_INTERVAL_MS);
+}
+
+function runTick() {
+  tickHandle = null;
+  if (disposed || !simulation || !graph) return;
+
+  // Even when settled we still need to listen for wake; just skip the
+  // sim+post cycle. Re-arm cheaply so we wake quickly on incoming
+  // messages.
+  if (settledTicks >= SETTLED_THRESHOLD) {
+    return;
+  }
+
+  simulation.tick(1);
+
+  const n = graph.nodes.length;
+  if (!lastPositions || lastPositions.length !== n * 3) {
+    lastPositions = new Float32Array(n * 3);
+  }
+  const out = new Float32Array(n * 3);
+  let maxDeltaSq = 0;
+  for (let i = 0; i < n; i++) {
+    const sn = simNodes[i];
+    if (!sn) {
+      out[i * 3 + 0] = lastPositions[i * 3 + 0]!;
+      out[i * 3 + 1] = lastPositions[i * 3 + 1]!;
+      out[i * 3 + 2] = lastPositions[i * 3 + 2]!;
+      continue;
+    }
+    const dx = sn.x - lastPositions[i * 3 + 0]!;
+    const dy = sn.y - lastPositions[i * 3 + 1]!;
+    const dz = sn.z - lastPositions[i * 3 + 2]!;
+    const deltaSq = dx * dx + dy * dy + dz * dz;
+    if (deltaSq > maxDeltaSq) maxDeltaSq = deltaSq;
+    out[i * 3 + 0] = sn.x;
+    out[i * 3 + 1] = sn.y;
+    out[i * 3 + 2] = sn.z;
+  }
+  lastPositions.set(out);
+
+  if (maxDeltaSq < SETTLE_EPSILON_SQ) settledTicks++;
+  else settledTicks = 0;
+
+  const buffer = out.buffer;
+  const msg: WorkerOutMsg = {
+    type: "positions",
+    buffer,
+    settled: settledTicks >= SETTLED_THRESHOLD,
+  };
+  (self as unknown as Worker).postMessage(msg, [buffer]);
+
+  scheduleTick();
+}
+
+function applyWake() {
+  settledTicks = 0;
+  if (simulation && simulation.alpha() < WAKE_ALPHA) {
+    simulation.alpha(WAKE_ALPHA);
+  }
+  scheduleTick();
+}
+
+function applySnapshot(requestId: number) {
+  const nodes: SnapshotPayloadNode[] = [];
+  for (const sn of simNodes) {
+    if (!sn) continue;
+    nodes.push({
+      id: sn.id,
+      x: sn.x,
+      y: sn.y,
+      z: sn.z,
+      vx: sn.vx ?? 0,
+      vy: sn.vy ?? 0,
+      vz: sn.vz ?? 0,
+    });
+  }
+  const msg: WorkerOutMsg = { type: "snapshot", requestId, nodes };
+  (self as unknown as Worker).postMessage(msg);
+}
+
+self.addEventListener("message", (e: MessageEvent<WorkerInMsg>) => {
+  const msg = e.data;
+  switch (msg.type) {
+    case "init": {
+      graph = msg.graph;
+      kinds = new Set(msg.kinds);
+      onboarding = msg.isOnboarding;
+      nodeIndexById = new Map(graph.nodes.map((n, i) => [n.id, i]));
+      lastPositions = new Float32Array(graph.nodes.length * 3);
+      applyReplaceActive({
+        activeIds: null,
+        animateNew: msg.animateNew ?? false,
+        preserveExisting: false,
+        seedNodes: msg.seedNodes,
+        isOnboarding: msg.isOnboarding,
+      });
+      const ready: WorkerOutMsg = { type: "ready" };
+      (self as unknown as Worker).postMessage(ready);
+      return;
+    }
+    case "replaceActive":
+      applyReplaceActive(msg);
+      return;
+    case "wake":
+      applyWake();
+      return;
+    case "snapshotRequest":
+      applySnapshot(msg.requestId);
+      return;
+    case "dispose":
+      disposed = true;
+      simulation?.stop();
+      if (tickHandle !== null) {
+        clearTimeout(tickHandle);
+        tickHandle = null;
+      }
+      return;
+  }
+});

--- a/theia-panel/src/state/simulation.ts
+++ b/theia-panel/src/state/simulation.ts
@@ -1,9 +1,15 @@
-import { createSimulation } from "../physics/Simulation";
 import type { TheiaGraph } from "../data/types";
 import type { NodeLayer } from "../scene/Nodes";
 import type { EdgeLayer } from "../scene/Edges";
-import { hashN11 } from "../util/hash";
 import type { PhysicsSnapshotNode } from "./physicsSnapshot";
+import type { createSimulation } from "../physics/Simulation";
+import SimulationWorker from "../physics/SimulationWorker?worker";
+import type {
+  SeedNode,
+  SnapshotPayloadNode,
+  WorkerInMsg,
+  WorkerOutMsg,
+} from "../physics/SimulationWorker";
 
 type SimNodes = ReturnType<typeof createSimulation>["nodes"];
 
@@ -17,9 +23,7 @@ export interface ReplaceActiveOpts {
 export interface SimulationStateDeps {
   graph: TheiaGraph;
   kinds: Set<string>;
-  /** True while onboarding is running (affects sim profile + lerp smoothing). */
   isOnboarding: () => boolean;
-  /** Called once each tick after positions advance — caller flushes meshes. */
   nodes: NodeLayer;
   edges: EdgeLayer;
   /** Shared with NodeLayer — sim writes node-space positions here each tick. */
@@ -27,36 +31,28 @@ export interface SimulationStateDeps {
 }
 
 export interface SimulationState {
-  /** Advance the sim, lerp toward sim positions, flush meshes. No-op once settled. */
   tick(): void;
-  /** Reset settle gate + bump alpha so filter/visibility changes re-equilibrate. */
   wakePhysics(): void;
-  /** Rebuild simulation for a new active set (filters, focus, snapshot restore). */
   replaceActive(opts: ReplaceActiveOpts): void;
-  /** Force renderedPositions/meshes to sim positions immediately (post-restore). */
   syncRenderedPositionsFromSimulation(): void;
-  /** Run a single internal sim tick — used to settle initial layout before display. */
   primeOnce(): void;
-  /** Read the current sim position of node by index (for camera focus, etc). */
   getNodePosition(idx: number): { x: number; y: number; z: number } | null;
-  /** Snapshot input for physicsSnapshotIO.save. */
+  /**
+   * Synchronous view of the simulation's last-known node states, in
+   * graph-node order. Built from cached worker positions/velocities;
+   * may lag by up to one tick relative to the worker. Used by snapshot
+   * save (`physicsSnapshotIO.save(...)`).
+   */
   getSimNodes(): SimNodes;
   dispose(): void;
 }
 
-// Settled-physics gate: skip the per-frame sim/lerp/edge-rewrite when the
-// layout has stabilised. The lerp drives matrix uploads and a full
-// edge-position attribute rewrite every frame; with 1.6k nodes that's
-// most of the per-frame cost once the simulation has converged.
+// Settled-physics gate (main side): the worker also has its own gate
+// that suppresses position posts when the layout has converged. The
+// main-side gate stops re-flushing meshes when both `lastSimPositions`
+// has stopped changing AND the local lerp has caught up.
 const SETTLED_THRESHOLD = 30;
-// Threshold ≈ 0.001² in world units — well below visible motion at any
-// reasonable zoom, since node sizes top out at 0.18 (see Nodes.ts).
 const SETTLE_EPSILON_SQ = 1e-6;
-// Energy injected on wake so filter/visibility changes actually produce
-// a visible re-equilibration. Without this, alpha sits at alphaTarget
-// (0.012, see Simulation.ts) which makes wake invisible — sub-pixel
-// motion that re-settles within a few ticks.
-const WAKE_ALPHA = 0.18;
 
 const ONBOARDING_SMOOTHING = 0.14;
 const NORMAL_SMOOTHING = 0.34;
@@ -65,135 +61,178 @@ export function createSimulationState(
   deps: SimulationStateDeps,
 ): SimulationState {
   const { graph, kinds, isOnboarding, nodes, edges, nodePositions } = deps;
-  const renderedPositions = new Float32Array(graph.nodes.length * 3);
-  const nodeIndex = new Map<string, number>(
-    graph.nodes.map((n, i) => [n.id, i]),
+  const n = graph.nodes.length;
+
+  // Two parallel buffers per node:
+  //   targetPositions  — last positions received from the worker (the
+  //                      simulation's current truth)
+  //   renderedPositions — the per-frame lerped values written into
+  //                       nodePositions (= NodeLayer's instanceMatrix)
+  // The lerp on the main thread provides visual smoothing between
+  // worker tick boundaries (worker ticks at 60Hz; main thread renders
+  // at display refresh, often higher).
+  const targetPositions = new Float32Array(n * 3);
+  const renderedPositions = new Float32Array(n * 3);
+
+  // Velocity cache, written from worker snapshot responses; used only
+  // for snapshot save. Out-of-date between snapshot requests, but the
+  // snapshot save path is the only sync consumer and a slightly stale
+  // velocity is fine (worker is the source of truth on the next save).
+  const cachedVelocities = new Float32Array(n * 3);
+
+  // Optimistic mirror of simNodes (id + last-known x/y/z/vx/vy/vz).
+  // `getSimNodes()` returns this for the snapshot save path.
+  const simNodesMirror: SimNodes = graph.nodes.map((node) => ({
+    id: node.id,
+    x: node.position.x,
+    y: node.position.y,
+    z: 0,
+    vx: 0,
+    vy: 0,
+    vz: 0,
+    // anchorX/anchorY/anchorZ/radius are required by the type; the
+    // worker is the authoritative owner of these and main-side never
+    // reads them. Fill with the same expressions the worker will use
+    // (see physics/Simulation.ts) so the mirror is structurally
+    // identical even before the first message round-trip.
+    anchorX: node.position.x,
+    anchorY: node.position.y,
+    anchorZ: 0,
+    radius: 0.08,
+  }));
+
+  // Seed renderedPositions/targetPositions/nodePositions from the
+  // graph's static anchor positions so the very first frames have
+  // something to draw before the worker reports back.
+  for (let i = 0; i < n; i++) {
+    const node = graph.nodes[i]!;
+    targetPositions[i * 3 + 0] = node.position.x;
+    targetPositions[i * 3 + 1] = node.position.y;
+    targetPositions[i * 3 + 2] = 0;
+    renderedPositions[i * 3 + 0] = node.position.x;
+    renderedPositions[i * 3 + 1] = node.position.y;
+    renderedPositions[i * 3 + 2] = 0;
+  }
+
+  let settledFrames = 0;
+  let workerReady = false;
+  let pendingSnapshotRequest: {
+    id: number;
+    resolve: (nodes: SnapshotPayloadNode[]) => void;
+  } | null = null;
+  let snapshotRequestSeq = 0;
+
+  const worker = new SimulationWorker();
+  function send(msg: WorkerInMsg, transfer?: Transferable[]) {
+    worker.postMessage(msg, transfer ?? []);
+  }
+
+  worker.addEventListener("message", (e: MessageEvent<WorkerOutMsg>) => {
+    const msg = e.data;
+    if (msg.type === "ready") {
+      workerReady = true;
+      return;
+    }
+    if (msg.type === "positions") {
+      const incoming = new Float32Array(msg.buffer);
+      // Length should match n*3; if it doesn't (graph swap mid-flight),
+      // ignore the stale message.
+      if (incoming.length === targetPositions.length) {
+        targetPositions.set(incoming);
+        // Mirror x/y/z onto simNodesMirror so getSimNodes is current.
+        for (let i = 0; i < n; i++) {
+          const sn = simNodesMirror[i]!;
+          sn.x = incoming[i * 3 + 0]!;
+          sn.y = incoming[i * 3 + 1]!;
+          sn.z = incoming[i * 3 + 2]!;
+        }
+        // Restart the main-side gate when worker reports motion.
+        if (!msg.settled) settledFrames = 0;
+      }
+      return;
+    }
+    if (msg.type === "snapshot") {
+      // Update velocity cache + mirror, then resolve any pending
+      // request. Snapshot save is sync via getSimNodes(), but the
+      // explicit request path lets the IO layer pull a fresh copy
+      // (e.g. just before navigating away).
+      for (const sn of msg.nodes) {
+        const idx = idxById.get(sn.id);
+        if (idx === undefined) continue;
+        cachedVelocities[idx * 3 + 0] = sn.vx;
+        cachedVelocities[idx * 3 + 1] = sn.vy;
+        cachedVelocities[idx * 3 + 2] = sn.vz;
+        const mirror = simNodesMirror[idx]!;
+        mirror.x = sn.x;
+        mirror.y = sn.y;
+        mirror.z = sn.z;
+        mirror.vx = sn.vx;
+        mirror.vy = sn.vy;
+        mirror.vz = sn.vz;
+      }
+      if (
+        pendingSnapshotRequest &&
+        pendingSnapshotRequest.id === msg.requestId
+      ) {
+        pendingSnapshotRequest.resolve(msg.nodes);
+        pendingSnapshotRequest = null;
+      }
+    }
+  });
+
+  const idxById = new Map<string, number>(
+    graph.nodes.map((node, i) => [node.id, i]),
   );
 
-  let simNodes: SimNodes = [];
-  let simulation: ReturnType<typeof createSimulation>["simulation"];
-  let settledFrames = 0;
-
-  function simulationGraphFor(activeIds: Set<string> | null): TheiaGraph {
-    if (!activeIds) return graph;
-    return {
-      ...graph,
-      nodes: graph.nodes.filter((node) => activeIds.has(node.id)),
-      edges: graph.edges.filter(
-        (edge) => activeIds.has(edge.source) && activeIds.has(edge.target),
-      ),
-    };
+  function seedNodesFromMap(
+    seedPositions?: Map<string, PhysicsSnapshotNode>,
+  ): SeedNode[] | undefined {
+    if (!seedPositions || seedPositions.size === 0) return undefined;
+    const seeds: SeedNode[] = [];
+    for (const [id, p] of seedPositions) {
+      seeds.push({
+        id,
+        x: p.x,
+        y: p.y,
+        z: p.z,
+        vx: p.vx,
+        vy: p.vy,
+        vz: p.vz,
+      });
+    }
+    return seeds;
   }
 
-  function replaceActive(opts: ReplaceActiveOpts) {
-    const {
-      activeIds,
-      animateNew = false,
-      preserveExisting = true,
-      seedPositions = new Map<string, PhysicsSnapshotNode>(),
-    } = opts;
-
-    const oldPositions = new Map<
-      string,
-      { x: number; y: number; z: number; vx?: number; vy?: number; vz?: number }
-    >();
-    for (const sn of simNodes) {
-      if (sn) {
-        oldPositions.set(sn.id, {
-          x: sn.x,
-          y: sn.y,
-          z: sn.z,
-          vx: sn.vx,
-          vy: sn.vy,
-          vz: sn.vz,
-        });
-      }
-    }
-
-    simulation?.stop();
-    const simResult = createSimulation(
-      simulationGraphFor(activeIds),
-      kinds,
-      isOnboarding() ? "onboarding" : "normal",
-    );
-    simulation = simResult.simulation;
-    simulation.stop();
-
-    const nextNodes = new Array(graph.nodes.length) as SimNodes;
-    for (const sn of simResult.nodes) {
-      const idx = nodeIndex.get(sn.id);
-      if (idx === undefined) continue;
-      const old = preserveExisting ? oldPositions.get(sn.id) : undefined;
-      const seed = seedPositions.get(sn.id);
-      if (old || seed) {
-        const source = old ?? seed!;
-        sn.x = source.x;
-        sn.y = source.y;
-        sn.z = source.z;
-        sn.vx = source.vx ?? 0;
-        sn.vy = source.vy ?? 0;
-        sn.vz = source.vz ?? 0;
-      } else if (animateNew) {
-        const jitter = 0.08;
-        sn.x = sn.anchorX * 0.55 + hashN11(`${sn.id}:x`) * jitter;
-        sn.y = sn.anchorY * 0.55 + hashN11(`${sn.id}:y`) * jitter;
-        sn.z = sn.anchorZ * 0.55 + hashN11(`${sn.id}:z`) * jitter;
-        sn.vx = (sn.anchorX - sn.x) * 0.006;
-        sn.vy = (sn.anchorY - sn.y) * 0.006;
-        sn.vz = (sn.anchorZ - sn.z) * 0.006;
-        renderedPositions[idx * 3] = sn.x;
-        renderedPositions[idx * 3 + 1] = sn.y;
-        renderedPositions[idx * 3 + 2] = sn.z;
-        nodes.setPosition(idx, sn.x, sn.y, sn.z);
-      }
-      nextNodes[idx] = sn;
-    }
-    simNodes = nextNodes;
-    simulation.alpha(animateNew ? 0.22 : simulation.alphaTarget());
-    wakePhysics();
-  }
-
-  function wakePhysics() {
-    settledFrames = 0;
-    if (simulation && simulation.alpha() < WAKE_ALPHA) {
-      simulation.alpha(WAKE_ALPHA);
-    }
-  }
-
-  function syncRenderedPositionsFromSimulation() {
-    wakePhysics();
-    for (let i = 0; i < simNodes.length; i++) {
-      const sn = simNodes[i];
-      if (!sn) continue;
-      renderedPositions[i * 3] = sn.x;
-      renderedPositions[i * 3 + 1] = sn.y;
-      renderedPositions[i * 3 + 2] = sn.z;
-      nodes.setPosition(i, sn.x, sn.y, sn.z);
-    }
-    nodes.flush();
-    edges.updatePositions(nodePositions);
-  }
+  // Init the worker with the graph + initial active set (null = full).
+  send({
+    type: "init",
+    graph,
+    kinds: Array.from(kinds),
+    isOnboarding: isOnboarding(),
+  });
 
   function tick() {
     if (settledFrames >= SETTLED_THRESHOLD) return;
-    simulation.tick(1);
+    // Lerp renderedPositions toward targetPositions; write into
+    // nodePositions (the buffer NodeLayer reads) and into the matrix.
     const smoothing = isOnboarding() ? ONBOARDING_SMOOTHING : NORMAL_SMOOTHING;
     let maxDeltaSq = 0;
-    for (let i = 0; i < simNodes.length; i++) {
-      const sn = simNodes[i];
-      if (!sn) continue;
-      const px = renderedPositions[i * 3]!;
+    for (let i = 0; i < n; i++) {
+      const px = renderedPositions[i * 3 + 0]!;
       const py = renderedPositions[i * 3 + 1]!;
       const pz = renderedPositions[i * 3 + 2]!;
-      const dx = (sn.x - px) * smoothing;
-      const dy = (sn.y - py) * smoothing;
-      const dz = (sn.z - pz) * smoothing;
+      const tx = targetPositions[i * 3 + 0]!;
+      const ty = targetPositions[i * 3 + 1]!;
+      const tz = targetPositions[i * 3 + 2]!;
+      const dx = (tx - px) * smoothing;
+      const dy = (ty - py) * smoothing;
+      const dz = (tz - pz) * smoothing;
       const x = px + dx;
       const y = py + dy;
       const z = pz + dz;
       const deltaSq = dx * dx + dy * dy + dz * dz;
       if (deltaSq > maxDeltaSq) maxDeltaSq = deltaSq;
-      renderedPositions[i * 3] = x;
+      renderedPositions[i * 3 + 0] = x;
       renderedPositions[i * 3 + 1] = y;
       renderedPositions[i * 3 + 2] = z;
       nodes.setPosition(i, x, y, z);
@@ -204,18 +243,79 @@ export function createSimulationState(
     else settledFrames = 0;
   }
 
+  function wakePhysics() {
+    settledFrames = 0;
+    send({ type: "wake" });
+  }
+
+  function replaceActive(opts: ReplaceActiveOpts) {
+    const seedNodes = seedNodesFromMap(opts.seedPositions);
+    send({
+      type: "replaceActive",
+      activeIds: opts.activeIds ? Array.from(opts.activeIds) : null,
+      animateNew: opts.animateNew ?? false,
+      preserveExisting: opts.preserveExisting ?? true,
+      seedNodes,
+      isOnboarding: isOnboarding(),
+    });
+    settledFrames = 0;
+  }
+
+  function syncRenderedPositionsFromSimulation() {
+    // Snap the local rendered buffer to whatever target positions we
+    // currently know about. Used after snapshot restore / setupGraph
+    // to avoid an interpolated transition on first display.
+    for (let i = 0; i < n; i++) {
+      const tx = targetPositions[i * 3 + 0]!;
+      const ty = targetPositions[i * 3 + 1]!;
+      const tz = targetPositions[i * 3 + 2]!;
+      renderedPositions[i * 3 + 0] = tx;
+      renderedPositions[i * 3 + 1] = ty;
+      renderedPositions[i * 3 + 2] = tz;
+      nodes.setPosition(i, tx, ty, tz);
+    }
+    nodes.flush();
+    edges.updatePositions(nodePositions);
+    settledFrames = 0;
+  }
+
   function primeOnce() {
-    simulation.tick(1);
+    // No-op on the main side; the worker will produce position updates
+    // on its own schedule. Kept for API parity with the previous
+    // in-process implementation, where setupGraph used it to bake one
+    // tick of layout before the first display.
+    void workerReady;
   }
 
   function getNodePosition(idx: number) {
-    const sn = simNodes[idx];
-    if (!sn) return null;
-    return { x: sn.x, y: sn.y, z: sn.z };
+    if (idx < 0 || idx >= n) return null;
+    return {
+      x: targetPositions[idx * 3 + 0]!,
+      y: targetPositions[idx * 3 + 1]!,
+      z: targetPositions[idx * 3 + 2]!,
+    };
+  }
+
+  function getSimNodes(): SimNodes {
+    // Request a fresh snapshot in the background so the next save call
+    // sees updated velocities. Returns the mirror synchronously — its
+    // x/y/z are always current (updated on every positions message);
+    // vx/vy/vz lag until the snapshot response arrives.
+    snapshotRequestSeq++;
+    const id = snapshotRequestSeq;
+    pendingSnapshotRequest = {
+      id,
+      resolve: () => {
+        /* mirror is updated in-place by the message handler */
+      },
+    };
+    send({ type: "snapshotRequest", requestId: id });
+    return simNodesMirror;
   }
 
   function dispose() {
-    simulation?.stop();
+    send({ type: "dispose" });
+    worker.terminate();
   }
 
   return {
@@ -225,8 +325,7 @@ export function createSimulationState(
     syncRenderedPositionsFromSimulation,
     primeOnce,
     getNodePosition,
-    getSimNodes: () => simNodes,
+    getSimNodes,
     dispose,
   };
 }
-

--- a/theia-panel/src/state/simulation.ts
+++ b/theia-panel/src/state/simulation.ts
@@ -1,0 +1,232 @@
+import { createSimulation } from "../physics/Simulation";
+import type { TheiaGraph } from "../data/types";
+import type { NodeLayer } from "../scene/Nodes";
+import type { EdgeLayer } from "../scene/Edges";
+import { hashN11 } from "../util/hash";
+import type { PhysicsSnapshotNode } from "./physicsSnapshot";
+
+type SimNodes = ReturnType<typeof createSimulation>["nodes"];
+
+export interface ReplaceActiveOpts {
+  activeIds: Set<string> | null;
+  animateNew?: boolean;
+  preserveExisting?: boolean;
+  seedPositions?: Map<string, PhysicsSnapshotNode>;
+}
+
+export interface SimulationStateDeps {
+  graph: TheiaGraph;
+  kinds: Set<string>;
+  /** True while onboarding is running (affects sim profile + lerp smoothing). */
+  isOnboarding: () => boolean;
+  /** Called once each tick after positions advance — caller flushes meshes. */
+  nodes: NodeLayer;
+  edges: EdgeLayer;
+  /** Shared with NodeLayer — sim writes node-space positions here each tick. */
+  nodePositions: Float32Array;
+}
+
+export interface SimulationState {
+  /** Advance the sim, lerp toward sim positions, flush meshes. No-op once settled. */
+  tick(): void;
+  /** Reset settle gate + bump alpha so filter/visibility changes re-equilibrate. */
+  wakePhysics(): void;
+  /** Rebuild simulation for a new active set (filters, focus, snapshot restore). */
+  replaceActive(opts: ReplaceActiveOpts): void;
+  /** Force renderedPositions/meshes to sim positions immediately (post-restore). */
+  syncRenderedPositionsFromSimulation(): void;
+  /** Run a single internal sim tick — used to settle initial layout before display. */
+  primeOnce(): void;
+  /** Read the current sim position of node by index (for camera focus, etc). */
+  getNodePosition(idx: number): { x: number; y: number; z: number } | null;
+  /** Snapshot input for physicsSnapshotIO.save. */
+  getSimNodes(): SimNodes;
+  dispose(): void;
+}
+
+// Settled-physics gate: skip the per-frame sim/lerp/edge-rewrite when the
+// layout has stabilised. The lerp drives matrix uploads and a full
+// edge-position attribute rewrite every frame; with 1.6k nodes that's
+// most of the per-frame cost once the simulation has converged.
+const SETTLED_THRESHOLD = 30;
+// Threshold ≈ 0.001² in world units — well below visible motion at any
+// reasonable zoom, since node sizes top out at 0.18 (see Nodes.ts).
+const SETTLE_EPSILON_SQ = 1e-6;
+// Energy injected on wake so filter/visibility changes actually produce
+// a visible re-equilibration. Without this, alpha sits at alphaTarget
+// (0.012, see Simulation.ts) which makes wake invisible — sub-pixel
+// motion that re-settles within a few ticks.
+const WAKE_ALPHA = 0.18;
+
+const ONBOARDING_SMOOTHING = 0.14;
+const NORMAL_SMOOTHING = 0.34;
+
+export function createSimulationState(
+  deps: SimulationStateDeps,
+): SimulationState {
+  const { graph, kinds, isOnboarding, nodes, edges, nodePositions } = deps;
+  const renderedPositions = new Float32Array(graph.nodes.length * 3);
+  const nodeIndex = new Map<string, number>(
+    graph.nodes.map((n, i) => [n.id, i]),
+  );
+
+  let simNodes: SimNodes = [];
+  let simulation: ReturnType<typeof createSimulation>["simulation"];
+  let settledFrames = 0;
+
+  function simulationGraphFor(activeIds: Set<string> | null): TheiaGraph {
+    if (!activeIds) return graph;
+    return {
+      ...graph,
+      nodes: graph.nodes.filter((node) => activeIds.has(node.id)),
+      edges: graph.edges.filter(
+        (edge) => activeIds.has(edge.source) && activeIds.has(edge.target),
+      ),
+    };
+  }
+
+  function replaceActive(opts: ReplaceActiveOpts) {
+    const {
+      activeIds,
+      animateNew = false,
+      preserveExisting = true,
+      seedPositions = new Map<string, PhysicsSnapshotNode>(),
+    } = opts;
+
+    const oldPositions = new Map<
+      string,
+      { x: number; y: number; z: number; vx?: number; vy?: number; vz?: number }
+    >();
+    for (const sn of simNodes) {
+      if (sn) {
+        oldPositions.set(sn.id, {
+          x: sn.x,
+          y: sn.y,
+          z: sn.z,
+          vx: sn.vx,
+          vy: sn.vy,
+          vz: sn.vz,
+        });
+      }
+    }
+
+    simulation?.stop();
+    const simResult = createSimulation(
+      simulationGraphFor(activeIds),
+      kinds,
+      isOnboarding() ? "onboarding" : "normal",
+    );
+    simulation = simResult.simulation;
+    simulation.stop();
+
+    const nextNodes = new Array(graph.nodes.length) as SimNodes;
+    for (const sn of simResult.nodes) {
+      const idx = nodeIndex.get(sn.id);
+      if (idx === undefined) continue;
+      const old = preserveExisting ? oldPositions.get(sn.id) : undefined;
+      const seed = seedPositions.get(sn.id);
+      if (old || seed) {
+        const source = old ?? seed!;
+        sn.x = source.x;
+        sn.y = source.y;
+        sn.z = source.z;
+        sn.vx = source.vx ?? 0;
+        sn.vy = source.vy ?? 0;
+        sn.vz = source.vz ?? 0;
+      } else if (animateNew) {
+        const jitter = 0.08;
+        sn.x = sn.anchorX * 0.55 + hashN11(`${sn.id}:x`) * jitter;
+        sn.y = sn.anchorY * 0.55 + hashN11(`${sn.id}:y`) * jitter;
+        sn.z = sn.anchorZ * 0.55 + hashN11(`${sn.id}:z`) * jitter;
+        sn.vx = (sn.anchorX - sn.x) * 0.006;
+        sn.vy = (sn.anchorY - sn.y) * 0.006;
+        sn.vz = (sn.anchorZ - sn.z) * 0.006;
+        renderedPositions[idx * 3] = sn.x;
+        renderedPositions[idx * 3 + 1] = sn.y;
+        renderedPositions[idx * 3 + 2] = sn.z;
+        nodes.setPosition(idx, sn.x, sn.y, sn.z);
+      }
+      nextNodes[idx] = sn;
+    }
+    simNodes = nextNodes;
+    simulation.alpha(animateNew ? 0.22 : simulation.alphaTarget());
+    wakePhysics();
+  }
+
+  function wakePhysics() {
+    settledFrames = 0;
+    if (simulation && simulation.alpha() < WAKE_ALPHA) {
+      simulation.alpha(WAKE_ALPHA);
+    }
+  }
+
+  function syncRenderedPositionsFromSimulation() {
+    wakePhysics();
+    for (let i = 0; i < simNodes.length; i++) {
+      const sn = simNodes[i];
+      if (!sn) continue;
+      renderedPositions[i * 3] = sn.x;
+      renderedPositions[i * 3 + 1] = sn.y;
+      renderedPositions[i * 3 + 2] = sn.z;
+      nodes.setPosition(i, sn.x, sn.y, sn.z);
+    }
+    nodes.flush();
+    edges.updatePositions(nodePositions);
+  }
+
+  function tick() {
+    if (settledFrames >= SETTLED_THRESHOLD) return;
+    simulation.tick(1);
+    const smoothing = isOnboarding() ? ONBOARDING_SMOOTHING : NORMAL_SMOOTHING;
+    let maxDeltaSq = 0;
+    for (let i = 0; i < simNodes.length; i++) {
+      const sn = simNodes[i];
+      if (!sn) continue;
+      const px = renderedPositions[i * 3]!;
+      const py = renderedPositions[i * 3 + 1]!;
+      const pz = renderedPositions[i * 3 + 2]!;
+      const dx = (sn.x - px) * smoothing;
+      const dy = (sn.y - py) * smoothing;
+      const dz = (sn.z - pz) * smoothing;
+      const x = px + dx;
+      const y = py + dy;
+      const z = pz + dz;
+      const deltaSq = dx * dx + dy * dy + dz * dz;
+      if (deltaSq > maxDeltaSq) maxDeltaSq = deltaSq;
+      renderedPositions[i * 3] = x;
+      renderedPositions[i * 3 + 1] = y;
+      renderedPositions[i * 3 + 2] = z;
+      nodes.setPosition(i, x, y, z);
+    }
+    nodes.flush();
+    edges.updatePositions(nodePositions);
+    if (maxDeltaSq < SETTLE_EPSILON_SQ) settledFrames++;
+    else settledFrames = 0;
+  }
+
+  function primeOnce() {
+    simulation.tick(1);
+  }
+
+  function getNodePosition(idx: number) {
+    const sn = simNodes[idx];
+    if (!sn) return null;
+    return { x: sn.x, y: sn.y, z: sn.z };
+  }
+
+  function dispose() {
+    simulation?.stop();
+  }
+
+  return {
+    tick,
+    wakePhysics,
+    replaceActive,
+    syncRenderedPositionsFromSimulation,
+    primeOnce,
+    getNodePosition,
+    getSimNodes: () => simNodes,
+    dispose,
+  };
+}
+

--- a/theia-panel/tsconfig.json
+++ b/theia-panel/tsconfig.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "vite/client"],
     "isolatedModules": true,
     "noEmit": true
   },

--- a/theia-panel/vite.config.embed.ts
+++ b/theia-panel/vite.config.embed.ts
@@ -16,10 +16,13 @@ export default defineConfig({
       // Split heavy deps into separate chunks so each stays <500 kB.
       // The browser fetches them in parallel on first load and caches
       // them independently — three.js rarely changes between releases.
+      // d3-force-3d is intentionally NOT chunked here — it's only
+      // imported by the physics worker (src/physics/Simulation.ts via
+      // SimulationWorker.ts), which Vite emits as its own chunk
+      // automatically.
       output: {
         manualChunks: {
           three: ["three"],
-          "d3-force": ["d3-force-3d"],
         },
       },
     },

--- a/theia-panel/vite.config.ts
+++ b/theia-panel/vite.config.ts
@@ -53,4 +53,15 @@ export default defineConfig(({ command }) => ({
     },
     rollupOptions: { external: ["three", "d3-force-3d"] },
   },
+  // The lib build externalizes d3-force-3d so the host can dedupe it,
+  // but the physics worker has no access to the host's import map and
+  // would fail on a bare module specifier. Bundle d3-force-3d into the
+  // worker chunk; three isn't used in the worker so we still externalize
+  // it (size hygiene only).
+  worker: {
+    format: "es",
+    rollupOptions: {
+      external: ["three"],
+    },
+  },
 }));


### PR DESCRIPTION
Two commits, intended to land together:

1. **`d6d3def` refactor(panel): extract simulation orchestration to state/simulation.ts** — pure mechanical extraction. Pulls `simulation`, `simNodes`, `replaceSimulation`, `wakePhysics`, `tick`, `syncRenderedPositionsFromSimulation`, and the settled-physics gate out of `index.ts` into a new `state/simulation.ts` module. `SimulationState` handle exposes `tick / wakePhysics / replaceActive / syncRenderedPositionsFromSimulation / primeOnce / getNodePosition / getSimNodes / dispose`. `renderedPositions` becomes private to the module. `index.ts` shrinks by ~170 lines; the two external `simNodes[idx].x` readers (sidePanel onNavigate, search onResult) go through `getNodePosition`; `updateOnboardingCamera` reads from `nodePositions` instead.

2. **`<HEAD>` perf(physics): move simulation to a Web Worker** — swap the in-process simulation for a worker-backed one. The `SimulationState` API is unchanged, so this is a localized swap of `state/simulation.ts` plus a new `physics/SimulationWorker.ts`.

## Why

After the previous PR's idle-tick gate, idle frames were already at 144 fps. The remaining stutter is during the **convergence period** — graph load, filter wake, onboarding reveal — when physics ticks 60×/sec on the main thread (each tick at 1.6k nodes is ~5-15ms). Moving physics off-thread lets the main thread stay render-bound throughout, eliminating the convergence stall.

## Architecture

```
              ┌──────────────── main thread ────────────────┐
   index.ts → │ SimulationState handle (state/simulation.ts) │
              │   targetPositions  ← worker positions msg    │
              │   renderedPositions ← lerp(rendered, target) │
              │   nodes.setPosition / edges.updatePositions  │
              └─────────┬────────────────────────────────────┘
                        │  postMessage (Transferable Float32Array)
              ┌─────────┴────────────────────────────────────┐
              │ SimulationWorker (physics/SimulationWorker)  │
              │   d3-force-3d Simulation, simNodes           │
              │   ticks 60Hz internally, settle gate         │
              └──────────────────────────────────────────────┘
```

- Worker self-throttles via `setTimeout(60Hz)`. Settled gate stops posting once the layout converges (no main-thread cost when idle).
- Position transfer uses Transferable `ArrayBuffer` per tick — n*3 floats, no `structuredClone` cost. ~38 KB/sec at 1.6k nodes.
- Lerp survives the worker boundary on the main side; high-refresh displays still get smooth interpolation between worker ticks.
- `getSimNodes()` returns a synchronous `simNodesMirror` (last known {x,y,z,vx,vy,vz}) and also fires a background `snapshotRequest` so the next save sees fresh velocities. Snapshot save path stays sync.
- Wake messages from main bump worker `simulation.alpha()` to 0.18 and resume ticking.

## Build

- `vite.config.ts`: adds `worker.rollupOptions.external = ["three"]` so `d3-force-3d` (still external in the lib build) gets bundled **into the worker chunk**. Without this, the worker would try to import the bare `d3-force-3d` specifier and die — workers don't see the host import map.
- `vite.config.embed.ts`: drops `d3-force` from `manualChunks` (no longer referenced by main; was generating an empty chunk).
- `tsconfig.json`: adds `vite/client` types for the `?worker` import.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 10/10 pass
- [x] `vite build` (lib): 1 main chunk + 1 SimulationWorker chunk (43 KB)
- [x] `vite build --config vite.config.embed.ts` (embed): 30 KB worker chunk
- [x] `vite serve`: dev server loads index + worker module
- [ ] Visual: load a 1.6k-node graph, observe smooth render *during* convergence (not just after settle)
- [ ] Visual: toggle component focus / focus mode — worker re-equilibrates without main-thread stutter
- [ ] Spot-check snapshot save/restore round-trip across a page reload

## Caveats

- Worker uses Transferable buffers (`postMessage(buf, [buf])`). No `SharedArrayBuffer` — that requires COOP/COEP headers in the host and would break embedded deployment.
- First tick after `init` may briefly show anchor-position layout before the worker's first positions message arrives. Acceptable: the seed in `simNodesMirror`/`targetPositions` is the dataset anchor, identical to what the previous in-process implementation displayed in the same window.
- `primeOnce()` is a no-op in the new implementation (used to single-step the in-process sim before display). The worker produces positions on its own schedule; the first frames render anchor-positioned nodes for a few ms until the first worker message arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)