### PR TITLE
perf+refactor(panel): search input lag, onboarding stutter, supernova reveal

### DIFF
--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -18,11 +18,7 @@ import { createSearchBar } from "./ui/SearchBar";
 import { createSidePanel } from "./ui/SidePanel";
 import { readTheme, applyTheme, onThemeMessage } from "./ui/Theme";
 import type { ThemeTokens } from "./ui/Theme";
-import {
-  createLoadingOverlay,
-  createChainOverlay,
-  createOnboardingOverlay,
-} from "./ui/Overlays";
+import { createLoadingOverlay, createChainOverlay } from "./ui/Overlays";
 import {
   VALID_KINDS,
   DEFAULT_KINDS,
@@ -31,6 +27,11 @@ import {
   computeVisibleNodeIds,
 } from "./state/filterState";
 import { createPhysicsSnapshotIO } from "./state/physicsSnapshot";
+import {
+  createOnboarding,
+  hasCompletedOnboarding,
+  type OnboardingController,
+} from "./state/onboarding";
 
 export interface PanelOptions {
   edgeKinds?: TheiaGraph["edges"][number]["kind"][];
@@ -43,33 +44,6 @@ export interface Controller {
   reload(graphUrl?: string): Promise<void>;
 }
 
-const ONBOARDING_STORAGE_KEY = "theia-first-load-onboarding-complete";
-const ONBOARDING_ROTATION_RADIANS = Math.PI * 1.15;
-const ONBOARDING_BLINK_MS = 3200;
-const ONBOARDING_LINK_UP_MS = 700;
-const ONBOARDING_BASE_ZOOM = 0.72;
-const ONBOARDING_MIN_ZOOM = 0.42;
-const ONBOARDING_NEAR_DISTANCE = 3.2;
-const ONBOARDING_SAFE_DISTANCE = 5.6;
-
-function easeQuadInOut(t: number): number {
-  return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
-}
-
-function popScale(t: number): number {
-  if (t <= 0) return 0;
-  if (t >= 1) return 1;
-  const eased = easeQuadInOut(t);
-  return 1 + 0.28 * Math.sin(Math.PI * eased);
-}
-
-function revealBrightness(t: number): number {
-  if (t <= 0) return 0;
-  if (t >= 1) return 1;
-  const eased = easeQuadInOut(t);
-  return 1 + 0.5 * Math.sin(Math.PI * eased);
-}
-
 const edgeKeyCache = new WeakMap<TheiaGraph["edges"][number], string>();
 function edgeKey(edge: TheiaGraph["edges"][number]): string {
   let key = edgeKeyCache.get(edge);
@@ -80,22 +54,6 @@ function edgeKey(edge: TheiaGraph["edges"][number]): string {
       : `${edge.target}|${edge.source}|${edge.kind}`;
   edgeKeyCache.set(edge, key);
   return key;
-}
-
-function hasCompletedOnboarding(): boolean {
-  try {
-    return localStorage.getItem(ONBOARDING_STORAGE_KEY) === "1";
-  } catch {
-    return true;
-  }
-}
-
-function markOnboardingComplete(): void {
-  try {
-    localStorage.setItem(ONBOARDING_STORAGE_KEY, "1");
-  } catch {
-    /* quota exceeded, ignore */
-  }
 }
 
 export async function mount(
@@ -146,22 +104,7 @@ export async function mount(
     update(nodeCount: number, edgeCount: number, label: string): void;
     remove(): void;
   } | null = null;
-  let onboarding: {
-    startedAt: number;
-    durationMs: number;
-    order: number[];
-    rankByIndex: Map<number, number>;
-    revealedNodeIds: Set<string>;
-    revealStartedAtByIndex: Map<number, number>;
-    linkStartedAtByKey: Map<string, number>;
-    lastRevealedCount: number;
-    lastHeavyRebuildAt: number;
-    lastEase: number;
-    cameraZoom: number;
-    cameraAutoZoomEnabled: boolean;
-    complete: boolean;
-    overlay: { update(progress: number): void; remove(): void };
-  } | null = null;
+  let onboarding: OnboardingController;
   let searchFocusMatchKey = "";
   let searchInputController: AbortController | null = null;
   let searchFocusTimer: ReturnType<typeof setTimeout> | null = null;
@@ -181,7 +124,7 @@ export async function mount(
 
   function canSavePhysicsSnapshot(): boolean {
     if (!currentGraph || !hasCompletedOnboarding()) return false;
-    if (onboarding && !onboarding.complete) return false;
+    if (onboarding.isActive() && !onboarding.isComplete()) return false;
     return true;
   }
 
@@ -370,10 +313,9 @@ export async function mount(
     if (componentFilter) {
       ids = new Set([...ids].filter((id) => componentFilter!.has(id)));
     }
-    if (onboarding) {
-      ids = new Set(
-        [...ids].filter((id) => onboarding!.revealedNodeIds.has(id)),
-      );
+    if (onboarding.isActive()) {
+      const revealed = onboarding.revealedNodeIds();
+      ids = new Set([...ids].filter((id) => revealed.has(id)));
     }
     return ids;
   }
@@ -412,7 +354,7 @@ export async function mount(
 
     // Start at equilibrium to prevent jittery readjustment.
     simState.replaceActive({
-      activeIds: onboarding ? activeVisibleNodeIds() : null,
+      activeIds: onboarding.isActive() ? activeVisibleNodeIds() : null,
     });
 
     rebuildVisibleEdges();
@@ -539,220 +481,24 @@ export async function mount(
     }
   }
 
-  function shouldRunOnboarding(g: TheiaGraph): boolean {
-    return g.nodes.length > 0 && !hasCompletedOnboarding();
-  }
-
-  function beginOnboarding(g: TheiaGraph) {
-    const order = g.nodes
-      .map((node, index) => ({ index, time: Date.parse(node.started_at) }))
-      .sort((a, b) => {
-        const at = Number.isFinite(a.time) ? a.time : Number.POSITIVE_INFINITY;
-        const bt = Number.isFinite(b.time) ? b.time : Number.POSITIVE_INFINITY;
-        return at - bt || a.index - b.index;
-      })
-      .map(({ index }) => index);
-    onboarding = {
-      startedAt: performance.now(),
-      durationMs: Math.max(1, Math.ceil(g.nodes.length / 3)) * 1000,
-      order,
-      rankByIndex: new Map(order.map((index, rank) => [index, rank])),
-      revealedNodeIds: new Set(),
-      revealStartedAtByIndex: new Map(),
-      linkStartedAtByKey: new Map(),
-      lastRevealedCount: 0,
-      lastHeavyRebuildAt: 0,
-      lastEase: 0,
-      cameraZoom: ONBOARDING_BASE_ZOOM,
-      cameraAutoZoomEnabled: true,
-      complete: false,
-      overlay: createOnboardingOverlay(element),
-    };
-    ctx.setZoom(ONBOARDING_BASE_ZOOM);
-    for (let i = 0; i < g.nodes.length; i++) {
-      nodes.setRevealScale(i, 0);
-      nodes.setBrightness(i, 0);
-    }
-    setNodeVisibilityFromState();
-    rebuildVisibleEdges();
-    simState.replaceActive({
-      activeIds: activeVisibleNodeIds(),
-      animateNew: true,
-    });
-  }
-
-  function updateOnboardingLinks(now: number) {
-    if (!onboarding) {
-      edges.setConnectionProgress(null);
-      return;
-    }
-    for (const edge of currentGraph.edges) {
-      if (
-        onboarding.revealedNodeIds.has(edge.source) &&
-        onboarding.revealedNodeIds.has(edge.target)
-      ) {
-        const key = edgeKey(edge);
-        if (!onboarding.linkStartedAtByKey.has(key)) {
-          onboarding.linkStartedAtByKey.set(key, now);
-        }
-      }
-    }
-    edges.setConnectionProgress((edge) => {
-      const startedAt = onboarding?.linkStartedAtByKey.get(edgeKey(edge));
-      if (startedAt === undefined) return 0;
-      return easeQuadInOut(
-        Math.min(1, (now - startedAt) / ONBOARDING_LINK_UP_MS),
-      );
-    });
-  }
-
-  function updateOnboarding(now: number) {
-    if (!onboarding) return;
-    const raw = Math.min(
-      1,
-      (now - onboarding.startedAt) / onboarding.durationMs,
-    );
-    const eased = easeQuadInOut(raw);
-    const revealFloat = eased * onboarding.order.length;
-    const revealCount = Math.min(
-      onboarding.order.length,
-      Math.ceil(revealFloat),
-    );
-
-    for (let rank = onboarding.lastRevealedCount; rank < revealCount; rank++) {
-      const idx = onboarding.order[rank]!;
-      onboarding.revealedNodeIds.add(currentGraph.nodes[idx]!.id);
-      onboarding.revealStartedAtByIndex.set(idx, now);
-    }
-
-    for (const idx of onboarding.order) {
-      const rank = onboarding.rankByIndex.get(idx)!;
-      const localProgress = Math.max(0, Math.min(1, revealFloat - rank));
-      nodes.setRevealScale(idx, popScale(localProgress));
-      const revealedAt = onboarding.revealStartedAtByIndex.get(idx);
-      const blinkProgress =
-        revealedAt === undefined
-          ? 0
-          : Math.min(1, (now - revealedAt) / ONBOARDING_BLINK_MS);
-      nodes.setBrightness(idx, revealBrightness(blinkProgress));
-    }
-    updateOnboardingLinks(now);
-
-    const rotationDelta =
-      (eased - onboarding.lastEase) * ONBOARDING_ROTATION_RADIANS;
-    if (rotationDelta !== 0) {
-      const state = ctx.getCameraState();
-      ctx.setCameraState({ ...state, theta: state.theta + rotationDelta });
-    }
-
-    // Heavy rebuild throttle. Each rebuild iterates all 1.6k nodes
-    // (setNodeVisibilityFromState), regenerates the entire edges
-    // geometry (rebuildVisibleEdges), and asks the worker to recreate
-    // the d3-force-3d simulation for the new active set. With reveals
-    // crossing integer boundaries multiple times per frame at 60Hz, the
-    // un-throttled version fires this on essentially every frame —
-    // which was the source of the visible reveal-period FPS drop.
-    //
-    // Throttle to ~150ms; always force a final rebuild when the last
-    // node has been revealed so the simulation gets the full active
-    // set before settling. setRevealScale on individual nodes still
-    // happens every frame inside the loop above, so the visual reveal
-    // animation continues smoothly between rebuilds.
-    const HEAVY_REBUILD_INTERVAL_MS = 150;
-    const sawNewReveals = revealCount !== onboarding.lastRevealedCount;
-    onboarding.lastRevealedCount = revealCount;
-    const finalReveal = revealCount === onboarding.order.length;
-    if (
-      sawNewReveals &&
-      (finalReveal ||
-        now - onboarding.lastHeavyRebuildAt > HEAVY_REBUILD_INTERVAL_MS)
-    ) {
-      onboarding.lastHeavyRebuildAt = now;
-      setNodeVisibilityFromState();
-      rebuildVisibleEdges();
-      simState.replaceActive({
-        activeIds: activeVisibleNodeIds(),
-        animateNew: true,
-      });
-    }
-    onboarding.lastEase = eased;
-    onboarding.overlay.update(eased);
-
-    if (raw >= 1 && !onboarding.complete) {
-      for (const idx of onboarding.order) {
-        onboarding.revealedNodeIds.add(currentGraph.nodes[idx]!.id);
-        nodes.setRevealScale(idx, 1);
-        if (!onboarding.revealStartedAtByIndex.has(idx)) {
-          onboarding.revealStartedAtByIndex.set(idx, now);
-        }
-      }
-      onboarding.complete = true;
-      markOnboardingComplete();
-      onboarding.overlay.remove();
-      setNodeVisibilityFromState();
-      rebuildVisibleEdges();
-      updateOnboardingLinks(now);
-      savePhysicsSnapshot();
-    }
-
-    if (onboarding.complete) {
-      let allBlinkDone = true;
-      for (const idx of onboarding.order) {
-        const revealedAt = onboarding.revealStartedAtByIndex.get(idx) ?? now;
-        const blinkProgress = Math.min(
-          1,
-          (now - revealedAt) / ONBOARDING_BLINK_MS,
-        );
-        nodes.setBrightness(idx, revealBrightness(blinkProgress));
-        allBlinkDone &&= blinkProgress >= 1;
-      }
-      if (allBlinkDone) {
-        for (const idx of onboarding.order) {
-          nodes.setBrightness(idx, 1);
-        }
-        onboarding = null;
-        edges.setConnectionProgress(null);
-      }
-    }
-  }
-
-  function updateOnboardingCamera() {
-    if (!onboarding || onboarding.complete || !onboarding.cameraAutoZoomEnabled)
-      return;
-    let nearest = Number.POSITIVE_INFINITY;
-    for (const idx of onboarding.order) {
-      if (!onboarding.revealedNodeIds.has(currentGraph.nodes[idx]!.id)) {
-        continue;
-      }
-      // nodePositions tracks the same per-frame smoothed values that the
-      // simulation tick writes; reading from there avoids reaching into
-      // the simulation module's private renderedPositions buffer.
-      const dx = nodePositions[idx * 3]! - ctx.camera.position.x;
-      const dy = nodePositions[idx * 3 + 1]! - ctx.camera.position.y;
-      const dz = nodePositions[idx * 3 + 2]! - ctx.camera.position.z;
-      nearest = Math.min(nearest, Math.sqrt(dx * dx + dy * dy + dz * dz));
-    }
-    if (!Number.isFinite(nearest)) return;
-
-    const crowding = Math.max(
-      0,
-      Math.min(
-        1,
-        (ONBOARDING_SAFE_DISTANCE - nearest) /
-          (ONBOARDING_SAFE_DISTANCE - ONBOARDING_NEAR_DISTANCE),
-      ),
-    );
-    const targetZoom =
-      ONBOARDING_BASE_ZOOM -
-      (ONBOARDING_BASE_ZOOM - ONBOARDING_MIN_ZOOM) * easeQuadInOut(crowding);
-    onboarding.cameraZoom += (targetZoom - onboarding.cameraZoom) * 0.08;
-    ctx.setZoom(onboarding.cameraZoom);
-  }
+  onboarding = createOnboarding({
+    element,
+    graph: () => currentGraph,
+    nodes: () => nodes,
+    edges,
+    ctx,
+    simState: () => simState,
+    nodePositions: () => nodePositions,
+    setNodeVisibilityFromState,
+    rebuildVisibleEdges,
+    activeVisibleNodeIds,
+    edgeKey,
+    savePhysicsSnapshot,
+  });
 
   function setupGraph(g: TheiaGraph) {
     simState?.dispose();
-    onboarding?.overlay.remove();
-    onboarding = null;
+    onboarding.cancel();
     // Clear any chain isolation from a prior graph: edge identity is
     // graph-scoped, so the previous selection is meaningless once we reload.
     clearChainSelection();
@@ -771,7 +517,7 @@ export async function mount(
     simState = createSimulationState({
       graph: g,
       kinds,
-      isOnboarding: () => Boolean(onboarding && !onboarding.complete),
+      isOnboarding: () => onboarding.isActive() && !onboarding.isComplete(),
       nodes,
       edges,
       nodePositions,
@@ -905,19 +651,19 @@ export async function mount(
   }
   loading.remove();
   setupGraph(initialGraph);
-  if (shouldRunOnboarding(initialGraph)) {
-    beginOnboarding(initialGraph);
+  if (initialGraph.nodes.length > 0 && !hasCompletedOnboarding()) {
+    onboarding.begin();
   }
 
   let disposed = false;
   function frame() {
     if (disposed) return;
     const now = performance.now();
-    updateOnboarding(now);
+    onboarding.update(now);
     keyboardNav.tick(now);
     simState.tick();
     maybeSavePhysicsSnapshot(now);
-    updateOnboardingCamera();
+    onboarding.updateCamera();
     const t = now / 1000;
     nodes.setTime(t);
     edges.setTime(t);
@@ -1081,10 +827,7 @@ export async function mount(
     (e) => {
       if ((e.target as HTMLElement).closest("[data-ui-overlay]")) return;
       lastWheelAt = performance.now();
-      if (onboarding) {
-        onboarding.cameraAutoZoomEnabled = false;
-        onboarding.cameraZoom = ctx.getZoom();
-      }
+      onboarding.onUserZoomChanged(ctx.getZoom());
       e.preventDefault();
       const delta = e.deltaY > 0 ? 1.1 : 0.9;
       ctx.setZoom(ctx.getZoom() * delta);
@@ -1154,7 +897,7 @@ export async function mount(
     destroy() {
       disposed = true;
       savePhysicsSnapshot();
-      onboarding?.overlay.remove();
+      onboarding.cancel();
       window.removeEventListener("mouseup", resetDrag);
       window.removeEventListener("keydown", onKeyDown);
       chainOverlay?.remove();

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -155,6 +155,7 @@ export async function mount(
     revealStartedAtByIndex: Map<number, number>;
     linkStartedAtByKey: Map<string, number>;
     lastRevealedCount: number;
+    lastHeavyRebuildAt: number;
     lastEase: number;
     cameraZoom: number;
     cameraAutoZoomEnabled: boolean;
@@ -560,6 +561,7 @@ export async function mount(
       revealStartedAtByIndex: new Map(),
       linkStartedAtByKey: new Map(),
       lastRevealedCount: 0,
+      lastHeavyRebuildAt: 0,
       lastEase: 0,
       cameraZoom: ONBOARDING_BASE_ZOOM,
       cameraAutoZoomEnabled: true,
@@ -643,8 +645,29 @@ export async function mount(
       ctx.setCameraState({ ...state, theta: state.theta + rotationDelta });
     }
 
-    if (revealCount !== onboarding.lastRevealedCount) {
-      onboarding.lastRevealedCount = revealCount;
+    // Heavy rebuild throttle. Each rebuild iterates all 1.6k nodes
+    // (setNodeVisibilityFromState), regenerates the entire edges
+    // geometry (rebuildVisibleEdges), and asks the worker to recreate
+    // the d3-force-3d simulation for the new active set. With reveals
+    // crossing integer boundaries multiple times per frame at 60Hz, the
+    // un-throttled version fires this on essentially every frame —
+    // which was the source of the visible reveal-period FPS drop.
+    //
+    // Throttle to ~150ms; always force a final rebuild when the last
+    // node has been revealed so the simulation gets the full active
+    // set before settling. setRevealScale on individual nodes still
+    // happens every frame inside the loop above, so the visual reveal
+    // animation continues smoothly between rebuilds.
+    const HEAVY_REBUILD_INTERVAL_MS = 150;
+    const sawNewReveals = revealCount !== onboarding.lastRevealedCount;
+    onboarding.lastRevealedCount = revealCount;
+    const finalReveal = revealCount === onboarding.order.length;
+    if (
+      sawNewReveals &&
+      (finalReveal ||
+        now - onboarding.lastHeavyRebuildAt > HEAVY_REBUILD_INTERVAL_MS)
+    ) {
+      onboarding.lastHeavyRebuildAt = now;
       setNodeVisibilityFromState();
       rebuildVisibleEdges();
       simState.replaceActive({

--- a/theia-panel/src/scene/Edges.ts
+++ b/theia-panel/src/scene/Edges.ts
@@ -44,9 +44,7 @@ const SUBAGENT_DEPTH_FALLOFF = 0.18;
 const SUBAGENT_TINT_FLOOR = 0.35;
 const CRON_TINT_FLOOR = 0.35;
 
-function computeEdgeTints(
-  graph: TheiaGraph,
-): (edge: GraphEdge) => number {
+function computeEdgeTints(graph: TheiaGraph): (edge: GraphEdge) => number {
   // Cron-chain rank-by-time within each sequence.
   // Older runs sit at the low end (rank 0); newer runs are higher.
   const cronRank = new Map<string, number>();

--- a/theia-panel/src/scene/Nodes.ts
+++ b/theia-panel/src/scene/Nodes.ts
@@ -358,10 +358,13 @@ export function createNodes(
       }
     },
     setRevealScale(i, scale) {
-      revealScales[i] = Math.max(0, scale);
+      const v = Math.max(0, scale);
+      if (revealScales[i] === v) return;
+      revealScales[i] = v;
       writeMatrix(i);
     },
     setVisible(i, visible) {
+      if (visibleFlags[i] === visible) return;
       visibleFlags[i] = visible;
       writeMatrix(i);
     },

--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -1,0 +1,366 @@
+import type { TheiaGraph } from "../data/types";
+import type { NodeLayer } from "../scene/Nodes";
+import type { EdgeLayer } from "../scene/Edges";
+import type { SceneContext } from "../scene/Scene";
+import type { SimulationState } from "./simulation";
+import { createOnboardingOverlay } from "../ui/Overlays";
+
+const ONBOARDING_STORAGE_KEY = "theia-first-load-onboarding-complete";
+const ONBOARDING_ROTATION_RADIANS = Math.PI * 1.15;
+const ONBOARDING_BLINK_MS = 3200;
+const ONBOARDING_LINK_UP_MS = 700;
+const ONBOARDING_BASE_ZOOM = 0.72;
+const ONBOARDING_MIN_ZOOM = 0.42;
+const ONBOARDING_NEAR_DISTANCE = 3.2;
+const ONBOARDING_SAFE_DISTANCE = 5.6;
+
+// Onboarding duration scales gently with node count, but capped so the
+// first-load reveal stays in the 5-18s range. Previously this was
+// `ceil(N/3) * 1000`, which produced ~9 minutes for a 1.6k-node graph.
+// Keep deterministic so the overlay can confidently advertise progress.
+const ONBOARDING_MIN_DURATION_MS = 5000;
+const ONBOARDING_MAX_DURATION_MS = 18000;
+const ONBOARDING_MS_PER_NODE = 6;
+function onboardingDurationMs(nodeCount: number): number {
+  const raw = ONBOARDING_MIN_DURATION_MS + nodeCount * ONBOARDING_MS_PER_NODE;
+  return Math.min(
+    ONBOARDING_MAX_DURATION_MS,
+    Math.max(ONBOARDING_MIN_DURATION_MS, raw),
+  );
+}
+
+// Reveal progression: a "supernova" front-loads the first third of the
+// constellation in the opening burst, then easeOutQuad eases the rest
+// in across the remaining duration.
+const SUPERNOVA_DURATION_FRAC = 0.18;
+const SUPERNOVA_NODE_FRAC = 1 / 3;
+function onboardingRevealFraction(rawProgress: number): number {
+  if (rawProgress <= 0) return 0;
+  if (rawProgress >= 1) return 1;
+  if (rawProgress < SUPERNOVA_DURATION_FRAC) {
+    // Linear ramp through the supernova window — the per-node popScale
+    // animation supplies the explosive visual on top of this.
+    return (rawProgress / SUPERNOVA_DURATION_FRAC) * SUPERNOVA_NODE_FRAC;
+  }
+  const t =
+    (rawProgress - SUPERNOVA_DURATION_FRAC) / (1 - SUPERNOVA_DURATION_FRAC);
+  // easeOutQuad: 1 - (1-t)²
+  const easedRemaining = 1 - (1 - t) * (1 - t);
+  return SUPERNOVA_NODE_FRAC + easedRemaining * (1 - SUPERNOVA_NODE_FRAC);
+}
+
+function easeQuadInOut(t: number): number {
+  return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+}
+
+function popScale(t: number): number {
+  if (t <= 0) return 0;
+  if (t >= 1) return 1;
+  const eased = easeQuadInOut(t);
+  return 1 + 0.28 * Math.sin(Math.PI * eased);
+}
+
+function revealBrightness(t: number): number {
+  if (t <= 0) return 0;
+  if (t >= 1) return 1;
+  const eased = easeQuadInOut(t);
+  return 1 + 0.5 * Math.sin(Math.PI * eased);
+}
+
+export function hasCompletedOnboarding(): boolean {
+  try {
+    return localStorage.getItem(ONBOARDING_STORAGE_KEY) === "1";
+  } catch {
+    return true;
+  }
+}
+
+function markOnboardingComplete(): void {
+  try {
+    localStorage.setItem(ONBOARDING_STORAGE_KEY, "1");
+  } catch {
+    /* quota exceeded, ignore */
+  }
+}
+
+// Heavy rebuild throttle. Each rebuild iterates all nodes
+// (setNodeVisibilityFromState), regenerates the entire edges geometry
+// (rebuildVisibleEdges), and asks the worker to recreate the
+// d3-force-3d simulation for the new active set. With reveals crossing
+// integer boundaries multiple times per frame at 60Hz, an un-throttled
+// version would fire this on essentially every frame.
+const HEAVY_REBUILD_INTERVAL_MS = 150;
+
+export interface OnboardingDeps {
+  element: HTMLElement;
+  /** Lazy accessor — graph reference changes on setupGraph. */
+  graph: () => TheiaGraph;
+  /** Lazy accessor — NodeLayer is recreated on setupGraph. */
+  nodes: () => NodeLayer;
+  edges: EdgeLayer;
+  ctx: SceneContext;
+  simState: () => SimulationState;
+  /** Lazy accessor — nodePositions buffer is recreated on setupGraph. */
+  nodePositions: () => Float32Array;
+  setNodeVisibilityFromState(): void;
+  rebuildVisibleEdges(): void;
+  activeVisibleNodeIds(): Set<string>;
+  edgeKey(edge: TheiaGraph["edges"][number]): string;
+  savePhysicsSnapshot(): void;
+}
+
+export interface OnboardingController {
+  /** Start onboarding for the current graph. */
+  begin(): void;
+  /** True if onboarding state exists (running OR still blinking). */
+  isActive(): boolean;
+  /** True after the final reveal — blink phase may still be running. */
+  isComplete(): boolean;
+  /** Set of node ids that have been revealed so far. Empty when inactive. */
+  revealedNodeIds(): Set<string>;
+  /** Per-frame update: reveal nodes, drive camera rotation, throttle rebuilds. */
+  update(now: number): void;
+  /** Per-frame camera-zoom adjustment based on crowding around revealed nodes. */
+  updateCamera(): void;
+  /** Disable auto-zoom and capture user's chosen zoom (called from input handlers). */
+  onUserZoomChanged(zoom: number): void;
+  /** Forcibly tear down — used on graph reload. */
+  cancel(): void;
+}
+
+interface OnboardingStateInternal {
+  startedAt: number;
+  durationMs: number;
+  order: number[];
+  rankByIndex: Map<number, number>;
+  revealedNodeIds: Set<string>;
+  revealStartedAtByIndex: Map<number, number>;
+  linkStartedAtByKey: Map<string, number>;
+  lastRevealedCount: number;
+  lastHeavyRebuildAt: number;
+  lastEase: number;
+  cameraZoom: number;
+  cameraAutoZoomEnabled: boolean;
+  complete: boolean;
+  overlay: { update(progress: number): void; remove(): void };
+}
+
+const EMPTY_REVEALED = new Set<string>();
+
+export function createOnboarding(deps: OnboardingDeps): OnboardingController {
+  let state: OnboardingStateInternal | null = null;
+
+  function begin() {
+    const g = deps.graph();
+    const order = g.nodes
+      .map((node, index) => ({ index, time: Date.parse(node.started_at) }))
+      .sort((a, b) => {
+        const at = Number.isFinite(a.time) ? a.time : Number.POSITIVE_INFINITY;
+        const bt = Number.isFinite(b.time) ? b.time : Number.POSITIVE_INFINITY;
+        return at - bt || a.index - b.index;
+      })
+      .map(({ index }) => index);
+    state = {
+      startedAt: performance.now(),
+      durationMs: onboardingDurationMs(g.nodes.length),
+      order,
+      rankByIndex: new Map(order.map((index, rank) => [index, rank])),
+      revealedNodeIds: new Set(),
+      revealStartedAtByIndex: new Map(),
+      linkStartedAtByKey: new Map(),
+      lastRevealedCount: 0,
+      lastHeavyRebuildAt: 0,
+      lastEase: 0,
+      cameraZoom: ONBOARDING_BASE_ZOOM,
+      cameraAutoZoomEnabled: true,
+      complete: false,
+      overlay: createOnboardingOverlay(deps.element),
+    };
+    deps.ctx.setZoom(ONBOARDING_BASE_ZOOM);
+    const nodes = deps.nodes();
+    for (let i = 0; i < g.nodes.length; i++) {
+      nodes.setRevealScale(i, 0);
+      nodes.setBrightness(i, 0);
+    }
+    deps.setNodeVisibilityFromState();
+    deps.rebuildVisibleEdges();
+    deps.simState().replaceActive({
+      activeIds: deps.activeVisibleNodeIds(),
+      animateNew: true,
+    });
+  }
+
+  function updateOnboardingLinks(now: number) {
+    const graph = deps.graph();
+    if (!state) {
+      deps.edges.setConnectionProgress(null);
+      return;
+    }
+    for (const edge of graph.edges) {
+      if (
+        state.revealedNodeIds.has(edge.source) &&
+        state.revealedNodeIds.has(edge.target)
+      ) {
+        const key = deps.edgeKey(edge);
+        if (!state.linkStartedAtByKey.has(key)) {
+          state.linkStartedAtByKey.set(key, now);
+        }
+      }
+    }
+    deps.edges.setConnectionProgress((edge) => {
+      const startedAt = state?.linkStartedAtByKey.get(deps.edgeKey(edge));
+      if (startedAt === undefined) return 0;
+      return easeQuadInOut(
+        Math.min(1, (now - startedAt) / ONBOARDING_LINK_UP_MS),
+      );
+    });
+  }
+
+  function update(now: number) {
+    if (!state) return;
+    const graph = deps.graph();
+    const nodes = deps.nodes();
+    const raw = Math.min(1, (now - state.startedAt) / state.durationMs);
+    // Camera rotation rides the smooth in-out curve; reveal rides the
+    // supernova-then-easeOutQuad curve. Decoupled so the camera doesn't
+    // lurch at the supernova→quad seam.
+    const eased = easeQuadInOut(raw);
+    const revealFloat = onboardingRevealFraction(raw) * state.order.length;
+    const revealCount = Math.min(state.order.length, Math.ceil(revealFloat));
+
+    for (let rank = state.lastRevealedCount; rank < revealCount; rank++) {
+      const idx = state.order[rank]!;
+      state.revealedNodeIds.add(graph.nodes[idx]!.id);
+      state.revealStartedAtByIndex.set(idx, now);
+    }
+
+    for (const idx of state.order) {
+      const rank = state.rankByIndex.get(idx)!;
+      const localProgress = Math.max(0, Math.min(1, revealFloat - rank));
+      nodes.setRevealScale(idx, popScale(localProgress));
+      const revealedAt = state.revealStartedAtByIndex.get(idx);
+      const blinkProgress =
+        revealedAt === undefined
+          ? 0
+          : Math.min(1, (now - revealedAt) / ONBOARDING_BLINK_MS);
+      nodes.setBrightness(idx, revealBrightness(blinkProgress));
+    }
+    updateOnboardingLinks(now);
+
+    const rotationDelta =
+      (eased - state.lastEase) * ONBOARDING_ROTATION_RADIANS;
+    if (rotationDelta !== 0) {
+      const cam = deps.ctx.getCameraState();
+      deps.ctx.setCameraState({ ...cam, theta: cam.theta + rotationDelta });
+    }
+
+    // Throttle the heavy rebuild path; always force one final rebuild
+    // when the last node has been revealed so the simulation gets the
+    // full active set before settling.
+    const sawNewReveals = revealCount !== state.lastRevealedCount;
+    state.lastRevealedCount = revealCount;
+    const finalReveal = revealCount === state.order.length;
+    if (
+      sawNewReveals &&
+      (finalReveal ||
+        now - state.lastHeavyRebuildAt > HEAVY_REBUILD_INTERVAL_MS)
+    ) {
+      state.lastHeavyRebuildAt = now;
+      deps.setNodeVisibilityFromState();
+      deps.rebuildVisibleEdges();
+      deps.simState().replaceActive({
+        activeIds: deps.activeVisibleNodeIds(),
+        animateNew: true,
+      });
+    }
+    state.lastEase = eased;
+    state.overlay.update(eased);
+
+    if (raw >= 1 && !state.complete) {
+      for (const idx of state.order) {
+        state.revealedNodeIds.add(graph.nodes[idx]!.id);
+        nodes.setRevealScale(idx, 1);
+        if (!state.revealStartedAtByIndex.has(idx)) {
+          state.revealStartedAtByIndex.set(idx, now);
+        }
+      }
+      state.complete = true;
+      markOnboardingComplete();
+      state.overlay.remove();
+      deps.setNodeVisibilityFromState();
+      deps.rebuildVisibleEdges();
+      updateOnboardingLinks(now);
+      deps.savePhysicsSnapshot();
+    }
+
+    if (state.complete) {
+      let allBlinkDone = true;
+      for (const idx of state.order) {
+        const revealedAt = state.revealStartedAtByIndex.get(idx) ?? now;
+        const blinkProgress = Math.min(
+          1,
+          (now - revealedAt) / ONBOARDING_BLINK_MS,
+        );
+        nodes.setBrightness(idx, revealBrightness(blinkProgress));
+        allBlinkDone &&= blinkProgress >= 1;
+      }
+      if (allBlinkDone) {
+        for (const idx of state.order) {
+          nodes.setBrightness(idx, 1);
+        }
+        state = null;
+        deps.edges.setConnectionProgress(null);
+      }
+    }
+  }
+
+  function updateCamera() {
+    if (!state || state.complete || !state.cameraAutoZoomEnabled) return;
+    const graph = deps.graph();
+    const nodePositions = deps.nodePositions();
+    const camPos = deps.ctx.camera.position;
+    let nearest = Number.POSITIVE_INFINITY;
+    for (const idx of state.order) {
+      if (!state.revealedNodeIds.has(graph.nodes[idx]!.id)) continue;
+      // nodePositions tracks the same per-frame smoothed values that the
+      // simulation tick writes; reading from there avoids reaching into
+      // the simulation module's private renderedPositions buffer.
+      const dx = nodePositions[idx * 3]! - camPos.x;
+      const dy = nodePositions[idx * 3 + 1]! - camPos.y;
+      const dz = nodePositions[idx * 3 + 2]! - camPos.z;
+      nearest = Math.min(nearest, Math.sqrt(dx * dx + dy * dy + dz * dz));
+    }
+    if (!Number.isFinite(nearest)) return;
+    const crowding = Math.max(
+      0,
+      Math.min(
+        1,
+        (ONBOARDING_SAFE_DISTANCE - nearest) /
+          (ONBOARDING_SAFE_DISTANCE - ONBOARDING_NEAR_DISTANCE),
+      ),
+    );
+    const targetZoom =
+      ONBOARDING_BASE_ZOOM -
+      (ONBOARDING_BASE_ZOOM - ONBOARDING_MIN_ZOOM) * easeQuadInOut(crowding);
+    state.cameraZoom += (targetZoom - state.cameraZoom) * 0.08;
+    deps.ctx.setZoom(state.cameraZoom);
+  }
+
+  return {
+    begin,
+    isActive: () => state !== null,
+    isComplete: () => state?.complete === true,
+    revealedNodeIds: () => state?.revealedNodeIds ?? EMPTY_REVEALED,
+    update,
+    updateCamera,
+    onUserZoomChanged(zoom: number) {
+      if (!state) return;
+      state.cameraAutoZoomEnabled = false;
+      state.cameraZoom = zoom;
+    },
+    cancel() {
+      state?.overlay.remove();
+      state = null;
+    },
+  };
+}

--- a/theia-panel/src/ui/Overlays.ts
+++ b/theia-panel/src/ui/Overlays.ts
@@ -108,7 +108,7 @@ export function createOnboardingOverlay(element: HTMLElement): {
   return {
     update(progress) {
       const pct = Math.max(0, Math.min(100, Math.round(progress * 100)));
-      el.textContent = `CREATING THE UNIVERSE - ${pct}%`;
+      el.textContent = `CREATING YOUR CONSTELLATION - ${pct}%`;
     },
     remove() {
       el.style.opacity = "0";

--- a/theia-panel/src/ui/SearchBar.ts
+++ b/theia-panel/src/ui/SearchBar.ts
@@ -48,6 +48,31 @@ export function createSearchBar(
   let matchedCacheQuery = "";
   let matchedCacheIds: Set<string> | null = null;
 
+  // Pre-lowercase every searchable field once at construction. The hot
+  // path used to call .toLowerCase() five times per node per keystroke
+  // (~8k allocations + GC churn at 1.6k nodes); now it does a single
+  // lowercased query + plain `.includes()` against the cache.
+  const lcTitle = new Array<string>(graph.nodes.length);
+  const lcId = new Array<string>(graph.nodes.length);
+  const lcPreview = new Array<string>(graph.nodes.length);
+  const lcSummary = new Array<string>(graph.nodes.length);
+  const lcInitialPrompt = new Array<string>(graph.nodes.length);
+  for (let i = 0; i < graph.nodes.length; i++) {
+    const node = graph.nodes[i]!;
+    lcTitle[i] = (node.title ?? "").toLowerCase();
+    lcId[i] = node.id.toLowerCase();
+    lcPreview[i] = (node.preview ?? "").toLowerCase();
+    lcSummary[i] = (node.summary ?? "").toLowerCase();
+    lcInitialPrompt[i] = (node.initial_prompt ?? "").toLowerCase();
+  }
+
+  // Cap the rendered dropdown — short queries can match hundreds of
+  // nodes, and rendering them all (with per-item event listeners and
+  // innerHTML rewrites) is what the user perceives as input lag. The
+  // matchedCacheIds set still tracks the FULL match list for the
+  // search-focus filter; only the visible UI is capped.
+  const MAX_VISIBLE_RESULTS = 50;
+
   function applyWrapperStyle() {
     wrapper.style.cssText = `
       position: absolute; top: 12px; right: calc((100% - min(320px, 50vw)) / 2); transform: none;
@@ -129,18 +154,13 @@ export function createSearchBar(
     selectedIndex = -1;
   }
 
-  function normalize(s: string) {
-    return s.toLowerCase();
-  }
-
-  function matches(node: TheiaGraph["nodes"][number], query: string) {
-    const q = normalize(query);
+  function matchesIndex(i: number, lcQuery: string): boolean {
     return (
-      normalize(node.title || "").includes(q) ||
-      normalize(node.id).includes(q) ||
-      (node.preview && normalize(node.preview).includes(q)) ||
-      (node.summary && normalize(node.summary).includes(q)) ||
-      (node.initial_prompt && normalize(node.initial_prompt).includes(q))
+      lcTitle[i]!.includes(lcQuery) ||
+      lcId[i]!.includes(lcQuery) ||
+      lcPreview[i]!.includes(lcQuery) ||
+      lcSummary[i]!.includes(lcQuery) ||
+      lcInitialPrompt[i]!.includes(lcQuery)
     );
   }
 
@@ -156,20 +176,22 @@ export function createSearchBar(
       matchedCacheIds = new Set();
       return;
     }
-    const resultByIndex = new Map<number, SearchResult>();
+    const lcQuery = query.toLowerCase();
     const matchedIds = new Set<string>();
+    const visibleResults: SearchResult[] = [];
     for (let i = 0; i < graph.nodes.length; i++) {
+      if (!matchesIndex(i, lcQuery)) continue;
       const node = graph.nodes[i]!;
-      if (matches(node, query)) {
-        matchedIds.add(node.id);
+      matchedIds.add(node.id);
+      if (visibleResults.length < MAX_VISIBLE_RESULTS) {
         if (!isVisible || isVisible(node)) {
-          resultByIndex.set(i, { node, index: i });
+          visibleResults.push({ node, index: i });
         }
       }
     }
     matchedCacheQuery = query.trim();
     matchedCacheIds = matchedIds;
-    currentResults = Array.from(resultByIndex.values());
+    currentResults = visibleResults;
     if (currentResults.length === 0) {
       dropdown.innerHTML = `<div style="padding:12px;opacity:0.4;font-size:12px;text-align:center;color:#${theme.fg2}">No results found</div>`;
       dropdown.style.display = "block";
@@ -195,22 +217,33 @@ export function createSearchBar(
         .join("");
     dropdown.style.display = "block";
     selectedIndex = -1;
-
-    for (const el of dropdown.querySelectorAll<HTMLElement>(".search-item")) {
-      el.addEventListener("mouseenter", () => {
-        const ri = Number(el.dataset.resultIndex);
-        select(ri);
-      });
-      el.addEventListener("mouseleave", () => {
-        el.style.background = "transparent";
-      });
-      el.addEventListener("mousedown", (e) => {
-        e.preventDefault();
-        const ri = Number(el.dataset.resultIndex);
-        commit(ri);
-      });
-    }
+    // Per-item listeners are attached once at construction via event
+    // delegation (see below) — re-rendering the dropdown HTML on every
+    // keystroke used to attach 3 listeners per result, which was a
+    // measurable chunk of input-lag time at 50+ results.
   }
+
+  function findItemRowFromEvent(e: Event): HTMLElement | null {
+    let el = e.target as HTMLElement | null;
+    while (el && el !== dropdown) {
+      if (el.classList?.contains("search-item")) return el;
+      el = el.parentElement;
+    }
+    return null;
+  }
+  dropdown.addEventListener("mouseover", (e) => {
+    const el = findItemRowFromEvent(e);
+    if (!el) return;
+    const ri = Number(el.dataset.resultIndex);
+    if (Number.isFinite(ri)) select(ri);
+  });
+  dropdown.addEventListener("mousedown", (e) => {
+    const el = findItemRowFromEvent(e);
+    if (!el) return;
+    e.preventDefault();
+    const ri = Number(el.dataset.resultIndex);
+    if (Number.isFinite(ri)) commit(ri);
+  });
 
   input.addEventListener("input", () => {
     selectedIndex = -1;
@@ -262,10 +295,10 @@ export function createSearchBar(
       return new Set(matchedCacheIds);
     }
     const ids = new Set<string>();
+    const lcQuery = normalizedQuery.toLowerCase();
     for (let i = 0; i < graph.nodes.length; i++) {
-      const node = graph.nodes[i]!;
-      if (matches(node, normalizedQuery)) {
-        ids.add(node.id);
+      if (matchesIndex(i, lcQuery)) {
+        ids.add(graph.nodes[i]!.id);
       }
     }
     matchedCacheQuery = normalizedQuery;


### PR DESCRIPTION
Three commits, two perf fixes plus an extraction. Stack-on-top of #85 (which is already merged into dev).

## Commits

### 1. \`1098d5c\` perf(panel): search input lag

Three causes, all fixed:

- \`matches()\` called \`.toLowerCase()\` five times per node per query (~8k string allocations + GC churn at 1.6k nodes per keystroke). **Fix:** lowercase the five searchable fields (title, id, preview, summary, initial_prompt) once at construction, stash in parallel string arrays. Hot path becomes one lowercased query + plain \`.includes()\`.
- Short queries matched 100s of nodes; rendering them all (with 3 listeners per row) dominated keystroke latency. **Fix:** cap the dropdown to 50 visible results. \`matchedCacheIds\` (used by the search-focus filter pipeline) still tracks the full match set for correctness.
- Per-result event listeners replaced with two delegated handlers (mouseover / mousedown) on the dropdown container. \`innerHTML\` rebuild does no listener work now.

### 2. \`d69f15e\` perf(panel): onboarding stutter

Two costs causing the visible FPS drop during reveal:

- The reveal-count handler called \`setNodeVisibilityFromState\` (iterates all 1.6k nodes), \`rebuildVisibleEdges\` (regenerates the full edges geometry), and \`simState.replaceActive\` (worker rebuilds the d3-force-3d sim) on essentially every frame — at 1.6k reveals over ~8s the count crossed integer boundaries multiple times per frame. **Fix:** throttle the heavy rebuild to ~150ms; always force one final rebuild when the last node reveals so the sim gets the full active set.
- \`Nodes.ts\` \`setRevealScale\` and \`setVisible\` had no value-equality short-circuit (unlike \`setBrightness\`/\`setDim\`/\`setState\`). The onboarding loop calls \`setRevealScale\` on every node every frame even after they've reached scale 1; each call rewrote the instance matrix needlessly. **Fix:** skip the \`writeMatrix\` call when the value hasn't changed.

### 3. \`87d0888\` refactor(panel): extract onboarding to state/onboarding.ts

Mechanical extraction following the same pattern as \`state/filterState.ts\`, \`state/physicsSnapshot.ts\`, \`state/simulation.ts\`. Pulls all onboarding-specific concerns out of \`index.ts\`:

- All \`ONBOARDING_*\` constants
- \`easeQuadInOut\`, \`popScale\`, \`revealBrightness\` helpers (only onboarding used them)
- \`hasCompletedOnboarding\` / \`markOnboardingComplete\` (localStorage)
- The 190-line onboarding state object
- \`beginOnboarding\`, \`updateOnboarding\`, \`updateOnboardingCamera\`, \`updateOnboardingLinks\`

\`index.ts\` now talks to a single \`OnboardingController\` handle. Lazy accessors (\`graph: () => currentGraph\`, \`nodes: () => nodes\`, \`simState: () => simState\`, \`nodePositions: () => nodePositions\`) let the controller survive \`setupGraph\` graph swaps without re-creation. \`index.ts\` shrinks by ~290 lines on this commit alone.

Also bundles three onboarding-specific changes that landed alongside the extraction:

- **Duration formula**: \`5000 + N * 6\` ms capped at 18000ms, replacing \`ceil(N/3) * 1000\` which gave ~9 minutes at 1.6k nodes. Deterministic so the percentage display stays meaningful.
- **Supernova reveal curve**: first 18% of duration linearly reveals first 1/3 of nodes (the explosive front-load), then easeOutQuad eases the remaining 2/3 in. Camera rotation keeps the smooth in-out curve so it doesn't lurch at the seam.
- **Overlay text**: \`CREATING THE UNIVERSE\` → \`CREATING YOUR CONSTELLATION\`.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` — 10/10 pass
- [x] \`vite build\` — main 110 KB, worker 43 KB
- [x] Reporter tested search input + onboarding (per pre-extraction commits)
- [ ] Re-test onboarding after the supernova rewrite — first third should explode in fast, remaining two-thirds should ease in over the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)