### PR TITLE
style(panel): chain overlay anchored to bottom, sized like search bar

### DIFF
--- a/theia-panel/src/ui/Overlays.ts
+++ b/theia-panel/src/ui/Overlays.ts
@@ -7,7 +7,7 @@
  * have to be defined inside the panel's `mount()` closure.
  */
 
-import { FONT_STACK } from "./Theme";
+import { FONT_STACK, themeBgAlpha } from "./Theme";
 import type { ThemeTokens } from "./Theme";
 
 export function createLoadingOverlay(
@@ -48,12 +48,12 @@ export function createChainOverlay(
   const el = document.createElement("div");
   el.setAttribute("data-ui-overlay", "true");
   el.style.cssText = `
-    position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
+    position: absolute; bottom: 12px; left: 50%; transform: translateX(-50%);
     display: flex; align-items: center; gap: 10px;
-    padding: 6px 10px 6px 12px; border: 1px solid #${theme.border};
-    background: rgba(7,8,13,0.78); color: #${theme.fg};
-    font: 11px/1.2 var(--theia-font, ${FONT_STACK}); letter-spacing: 0.08em;
-    text-transform: uppercase; border-radius: ${theme.radius};
+    box-sizing: border-box; padding: 8px 12px;
+    border: 1px solid #${theme.border};
+    background: ${themeBgAlpha(theme, 0.85)}; color: #${theme.fg};
+    font: 13px/1.4 var(--theia-font, ${FONT_STACK});
     z-index: 13; cursor: default; backdrop-filter: blur(4px);
   `;
   const label = document.createElement("span");


### PR DESCRIPTION
## Summary
- Moves the chain-selection overlay from `top: 14px` to `bottom: 12px` so it stops visually competing with the search bar at the top of the panel.
- Matches the search bar's typography and padding (`13px/1.4`, `8px 12px`, `box-sizing: border-box`) so the two controls read as siblings.
- Replaces the hard-coded `rgba(7,8,13,0.78)` background with `themeBgAlpha(theme, 0.85)` so the overlay tracks the active theme like the search input does.
- Drops the uppercase / `letter-spacing: 0.08em` / `border-radius` treatment that made it feel like a separate notification badge.

## Test plan
- [ ] Open the panel, click an edge to select a chain, confirm the overlay appears at the bottom, centered, with the same height/typography as the search input.
- [ ] Toggle theme (light/dark) and confirm overlay background follows the theme.
- [ ] Click the ✕ button to clear the chain — overlay disappears, no regressions in chain filter behaviour.
- [ ] Trigger the loading / onboarding flow and confirm the bottom-anchored chain overlay does not collide with the onboarding text (only one shows at a time in practice, but worth eyeballing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)