### PR TITLE
fix(panel): rotation clipping, slow pan, inverted W/S

### DIFF
--- a/theia-panel/src/scene/KeyboardNav.ts
+++ b/theia-panel/src/scene/KeyboardNav.ts
@@ -95,14 +95,16 @@ export function createKeyboardNav(ctx: SceneContext): KeyboardNav {
         ? SHIFT_MULTIPLIER
         : 1;
 
-    // Pan — WASD maps to screen-relative dx/dy in pixel units.
-    // Scene.pan treats +dy as "drag down", so W (up) sends -dy.
+    // Pan — WASD maps to screen-relative camera motion. Scene.pan
+    // moves target along +up when dyPixel > 0, which slides the camera
+    // up alongside it; so W (camera up) needs +dyPixel and S needs
+    // -dyPixel. The previous mapping had these inverted.
     let panDx = 0;
     let panDy = 0;
     if (pressed.has("KeyA")) panDx -= 1;
     if (pressed.has("KeyD")) panDx += 1;
-    if (pressed.has("KeyW")) panDy -= 1;
-    if (pressed.has("KeyS")) panDy += 1;
+    if (pressed.has("KeyW")) panDy += 1;
+    if (pressed.has("KeyS")) panDy -= 1;
     if (panDx !== 0 || panDy !== 0) {
       const m = PAN_PIXELS_PER_SEC * dt * speed;
       // Scene.pan internally negates dxPixel (mouse-drag convention),

--- a/theia-panel/src/scene/Scene.ts
+++ b/theia-panel/src/scene/Scene.ts
@@ -72,9 +72,13 @@ export function createScene(container: HTMLElement): SceneContext {
     0.01,
     100,
   );
-  // Generous extent for graph spread past the orbit target. d3 layouts
-  // settle within ~30 units; 100 leaves room for panning + outliers.
-  const SCENE_EXTENT = 100;
+  // Generous bound on the graph radius from the world origin. Used to
+  // size the far plane: camera-to-node distance is bounded by
+  // |target| + radius + SCENE_RADIUS (triangle inequality), so we can
+  // pick a constant here without plumbing live node bounds in. Bumped
+  // generously — z-buffer precision impact is small and clipping is
+  // far more user-visible than depth fighting.
+  const SCENE_RADIUS = 500;
 
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
   renderer.setPixelRatio(effectivePixelRatio());
@@ -99,13 +103,14 @@ export function createScene(container: HTMLElement): SceneContext {
     camera.position.y = target.y + radius * Math.cos(phi);
     camera.position.z = target.z + radius * Math.sin(phi) * Math.cos(theta);
     camera.lookAt(target);
-    // Adapt the depth slab to the current orbit radius so nodes/edges on
-    // the far side of the target don't clip when zoomed out, and close
-    // ones don't clip when zoomed in. Fixed near=0.01/far=100 used to
-    // line up with max-zoom-out radius (100) — anything past target
-    // disappeared into the clear color.
+    // Adapt the depth slab so nothing clips. Far bound by triangle
+    // inequality: d(W, camera) ≤ |W| + |target| + radius, and |W| is
+    // capped by SCENE_RADIUS. Without |target| in this sum, panning or
+    // search-focusing to an edge node clipped opposite-side nodes
+    // because target moved out of origin.
+    const targetDist = Math.hypot(target.x, target.y, target.z);
     const nextNear = Math.max(0.01, radius * 0.01);
-    const nextFar = radius + SCENE_EXTENT;
+    const nextFar = radius + targetDist + SCENE_RADIUS;
     if (camera.near !== nextNear || camera.far !== nextFar) {
       camera.near = nextNear;
       camera.far = nextFar;
@@ -140,7 +145,13 @@ export function createScene(container: HTMLElement): SceneContext {
     renderer,
     container,
     pan(dxPixel, dyPixel) {
-      const panSpeed = radius * 0.0015;
+      // 1:1 cursor-to-world pan: world units per CSS pixel at the
+      // target's depth = (2 * tan(fov/2) * radius) / canvasHeight. The
+      // old fixed `radius * 0.0015` multiplier was tuned for ~770px
+      // canvases and felt sluggish on taller viewports / larger graphs.
+      const canvasHeight = renderer.domElement.clientHeight || 1;
+      const fovRad = (camera.fov * Math.PI) / 180;
+      const panSpeed = (2 * Math.tan(fovRad / 2) * radius) / canvasHeight;
       right.setFromMatrixColumn(camera.matrixWorld, 0);
       up.setFromMatrixColumn(camera.matrixWorld, 1);
       target.x += (-right.x * dxPixel + up.x * dyPixel) * panSpeed;


### PR DESCRIPTION
## Summary
Three camera issues surfaced together while testing the supernova + optimize-layout work on dev:

1. **Rotation / search-focus clipping**: previous fix sized the far plane as `radius + 100` (assuming `target` stayed near origin). After search-focus pans target out to an edge node, opposite-side nodes sat further than 100 units past target and clipped into the clear color. Fix: `far = radius + |target| + SCENE_RADIUS`, derived from triangle inequality $d(W, camera) \\leq |W| + |target| + radius$. Bumped `SCENE_RADIUS` from 100 → 500 to cover plausible graph spreads.

2. **Pan felt sluggish** on tall viewports / large constellations. The fixed `radius * 0.0015` multiplier was tuned for ~770px viewports and ignored canvas size. Switched to FOV-based 1:1: `(2 * tan(fov/2) * radius) / canvasHeight`. One cursor pixel now maps to one world pixel at the target's depth, regardless of viewport size.

3. **W/S inverted** in keyboard nav. Pressing W moved the camera DOWN because `panDy = -1` ended up reducing `target.y`. Swapped the signs so W is up and S is down (matching ASDW convention).

## Test plan
- [ ] Zoom out fully, rotate freely (yaw + pitch) — no nodes/edges disappear into black.
- [ ] Search-click an edge node so the camera focuses on it — opposite-side nodes remain visible.
- [ ] Mouse-drag panning: cursor stays roughly anchored to the world content, on small *and* tall viewports.
- [ ] Hold W → camera moves up. Hold S → camera moves down. A and D unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)