### PR TITLE
feat(panel): Home button + Jump-to-node toggle in view controls

### DIFF
--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -21,7 +21,7 @@ import type { ThemeTokens } from "./ui/Theme";
 import {
   createLoadingOverlay,
   createChainOverlay,
-  createOptimizeOverlay,
+  createControlsOverlay,
 } from "./ui/Overlays";
 import {
   VALID_KINDS,
@@ -100,6 +100,7 @@ export async function mount(
   let searchFocusEnabled = saved?.searchFocus ?? false;
   let hideOrphansEnabled = saved?.hideOrphans ?? false;
   let componentFocusEnabled = saved?.componentFocus ?? false;
+  let jumpToNodeEnabled = true;
   let focusFilter: Set<string> | null = null;
   let componentFilter: Set<string> | null = null;
   let chainFilter: Set<string> | null = null;
@@ -276,7 +277,7 @@ export async function mount(
       const sn = simState.getNodePosition(idx);
       if (!sn) return;
       select(idx);
-      ctx.focusOn(sn.x, sn.y, 1.5);
+      if (jumpToNodeEnabled) ctx.focusOn(sn.x, sn.y, 1.5);
       const n = currentGraph.nodes[idx]!;
       const related = currentGraph.edges.filter(
         (e) => (e.source === n.id || e.target === n.id) && kinds.has(e.kind),
@@ -613,7 +614,7 @@ export async function mount(
         const idx = nodeIndex.get(result.node.id);
         if (idx !== undefined && activeVisibleNodeIds().has(result.node.id)) {
           const sn = simState.getNodePosition(idx);
-          if (sn) ctx.focusOn(sn.x, sn.y, 1.5);
+          if (sn && jumpToNodeEnabled) ctx.focusOn(sn.x, sn.y, 1.5);
           select(idx);
         }
         const related = currentGraph.edges.filter(
@@ -880,8 +881,13 @@ export async function mount(
     },
   );
 
-  const optimizeOverlay = createOptimizeOverlay(element, theme, () => {
-    simState.optimize();
+  const controlsOverlay = createControlsOverlay(element, theme, {
+    onOptimize: () => simState.optimize(),
+    onHome: () => ctx.resetView(),
+    onJumpToggle: (enabled) => {
+      jumpToNodeEnabled = enabled;
+    },
+    initialJumpEnabled: jumpToNodeEnabled,
   });
 
   const listeners: Record<string, Array<(...args: unknown[]) => void>> = {
@@ -910,7 +916,7 @@ export async function mount(
       window.removeEventListener("keydown", onKeyDown);
       chainOverlay?.remove();
       chainOverlay = null;
-      optimizeOverlay.remove();
+      controlsOverlay.remove();
       searchInputController?.abort();
       if (searchFocusTimer) clearTimeout(searchFocusTimer);
       stopThemeListener();

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -726,6 +726,10 @@ export async function mount(
     const idx = picker.pickAt(clientX, clientY, 1.0);
     if (idx !== null) {
       select(idx);
+      if (jumpToNodeEnabled) {
+        const sn = simState.getNodePosition(idx);
+        if (sn) ctx.focusOn(sn.x, sn.y, 1.5);
+      }
       const n = currentGraph.nodes[idx]!;
       const related = currentGraph.edges.filter(
         (e) => (e.source === n.id || e.target === n.id) && kinds.has(e.kind),

--- a/theia-panel/src/scene/Scene.ts
+++ b/theia-panel/src/scene/Scene.ts
@@ -14,6 +14,11 @@ export interface SceneContext {
   container: HTMLElement;
   pan(dxPixel: number, dyPixel: number): void;
   focusOn(x: number, y: number, targetZoom?: number): void;
+  /**
+   * Animate the camera back to the initial framing: origin target,
+   * front-on rotation, default zoom (the "fitted" view).
+   */
+  resetView(): void;
   setZoom(z: number): void;
   getZoom(): number;
   rotate(dxPixel: number, dyPixel: number): void;
@@ -159,6 +164,38 @@ export function createScene(container: HTMLElement): SceneContext {
         if (t < 1) {
           rafId = requestAnimationFrame(step);
         } else {
+          rafId = null;
+        }
+      }
+      rafId = requestAnimationFrame(step);
+    },
+    resetView() {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      const startTarget = target.clone();
+      const startRadius = radius;
+      const startTheta = theta;
+      const startPhi = phi;
+      const endZoom = 0.5; // matches initial setZoom(0.5) in mount()
+      const endRadius = baseRadius / endZoom;
+      const endTheta = 0;
+      const endPhi = Math.PI / 2;
+      const startTime = performance.now();
+      const duration = 700;
+
+      function step(now: number) {
+        const t = Math.min(1, (now - startTime) / duration);
+        const ease = 1 - Math.pow(1 - t, 3);
+        target.x = startTarget.x + (0 - startTarget.x) * ease;
+        target.y = startTarget.y + (0 - startTarget.y) * ease;
+        target.z = startTarget.z + (0 - startTarget.z) * ease;
+        theta = startTheta + (endTheta - startTheta) * ease;
+        phi = startPhi + (endPhi - startPhi) * ease;
+        radius = startRadius + (endRadius - startRadius) * ease;
+        updateCamera();
+        if (t < 1) {
+          rafId = requestAnimationFrame(step);
+        } else {
+          zoom = endZoom;
           rafId = null;
         }
       }

--- a/theia-panel/src/ui/Overlays.ts
+++ b/theia-panel/src/ui/Overlays.ts
@@ -92,46 +92,128 @@ export function createChainOverlay(
   };
 }
 
-export function createOptimizeOverlay(
+export interface ControlsOverlayHandlers {
+  onOptimize: () => void;
+  onHome: () => void;
+  onJumpToggle: (enabled: boolean) => void;
+  initialJumpEnabled: boolean;
+}
+
+export interface ControlsOverlay {
+  remove(): void;
+  setJumpEnabled(enabled: boolean): void;
+}
+
+export function createControlsOverlay(
   element: HTMLElement,
   theme: ThemeTokens,
-  onClick: () => void,
-): { remove(): void } {
-  const btn = document.createElement("button");
-  btn.type = "button";
-  btn.setAttribute("data-ui-overlay", "true");
-  btn.setAttribute("aria-label", "Optimize layout");
-  btn.textContent = "Optimize layout";
-  btn.style.cssText = `
+  handlers: ControlsOverlayHandlers,
+): ControlsOverlay {
+  const bar = document.createElement("div");
+  bar.setAttribute("data-ui-overlay", "true");
+  bar.style.cssText = `
     position: absolute; bottom: 12px; right: 12px;
+    display: flex; align-items: stretch; gap: 6px;
+    z-index: 13;
+  `;
+
+  const baseButtonCss = `
     appearance: none; box-sizing: border-box;
-    padding: 8px 12px;
     border: 1px solid #${theme.border};
     background: ${themeBgAlpha(theme, 0.85)}; color: #${theme.fg};
     font: 13px/1.4 var(--theia-font, ${FONT_STACK});
-    cursor: pointer; z-index: 13; backdrop-filter: blur(4px);
-    transition: border-color 100ms, color 100ms;
+    cursor: pointer; backdrop-filter: blur(4px);
+    transition: border-color 100ms, color 100ms, background 100ms;
   `;
-  btn.onmouseenter = () => {
-    btn.style.borderColor = `#${theme.accent}`;
-    btn.style.color = `#${theme.accent}`;
-  };
-  btn.onmouseleave = () => {
-    btn.style.borderColor = `#${theme.border}`;
-    btn.style.color = `#${theme.fg}`;
-  };
-  btn.onclick = (e) => {
+
+  function styleHover(btn: HTMLButtonElement) {
+    btn.onmouseenter = () => {
+      if (btn.dataset.active === "true") return;
+      btn.style.borderColor = `#${theme.accent}`;
+      btn.style.color = `#${theme.accent}`;
+    };
+    btn.onmouseleave = () => {
+      if (btn.dataset.active === "true") return;
+      btn.style.borderColor = `#${theme.border}`;
+      btn.style.color = `#${theme.fg}`;
+    };
+  }
+
+  const optimize = document.createElement("button");
+  optimize.type = "button";
+  optimize.setAttribute("aria-label", "Optimize layout");
+  optimize.textContent = "Optimize layout";
+  optimize.style.cssText = baseButtonCss + `padding: 8px 12px;`;
+  styleHover(optimize);
+  optimize.onclick = (e) => {
     e.stopPropagation();
-    onClick();
+    handlers.onOptimize();
   };
-  element.appendChild(btn);
+
+  const home = document.createElement("button");
+  home.type = "button";
+  home.setAttribute("aria-label", "Reset to fitted view");
+  home.title = "Reset view";
+  home.textContent = "⌂";
+  home.style.cssText =
+    baseButtonCss +
+    `width: 36px; padding: 0; display: inline-flex;
+     align-items: center; justify-content: center;
+     font-size: 16px;`;
+  styleHover(home);
+  home.onclick = (e) => {
+    e.stopPropagation();
+    handlers.onHome();
+  };
+
+  const jump = document.createElement("button");
+  jump.type = "button";
+  jump.setAttribute("role", "switch");
+  jump.setAttribute("aria-label", "Jump to node on selection");
+  jump.title = "Jump to node on selection";
+  jump.textContent = "◎";
+  jump.style.cssText =
+    baseButtonCss +
+    `width: 36px; padding: 0; display: inline-flex;
+     align-items: center; justify-content: center;
+     font-size: 16px;`;
+  styleHover(jump);
+
+  function applyJumpState(enabled: boolean) {
+    jump.setAttribute("aria-checked", String(enabled));
+    jump.dataset.active = enabled ? "true" : "false";
+    if (enabled) {
+      jump.style.borderColor = `#${theme.accent}`;
+      jump.style.color = `#${theme.accent}`;
+      jump.style.background = themeBgAlpha(theme, 0.95);
+    } else {
+      jump.style.borderColor = `#${theme.border}`;
+      jump.style.color = `#${theme.fg2}`;
+      jump.style.background = themeBgAlpha(theme, 0.85);
+    }
+  }
+  applyJumpState(handlers.initialJumpEnabled);
+
+  jump.onclick = (e) => {
+    e.stopPropagation();
+    const next = jump.dataset.active !== "true";
+    applyJumpState(next);
+    handlers.onJumpToggle(next);
+  };
+
+  bar.append(optimize, home, jump);
+  element.appendChild(bar);
+
   return {
     remove() {
       try {
-        element.removeChild(btn);
+        element.removeChild(bar);
       } catch {
         /* container may have been destroyed */
       }
+    },
+    setJumpEnabled(enabled: boolean) {
+      applyJumpState(enabled);
     },
   };
 }


### PR DESCRIPTION
## Summary
- Adds two buttons next to **Optimize layout** in the bottom-right control bar:
  - **⌂ Home** — animates the camera back to the initial fitted view (target=origin, zoom=0.5, front-on rotation). Backed by a new \`ctx.resetView()\` on Scene.
  - **◎ Jump-to-node** — toggle (default **on**). Gates the existing camera focus when picking a search result or navigating from the side panel; turn it off to inspect nodes without losing your current view.
- Replaces \`createOptimizeOverlay\` with \`createControlsOverlay\` so all three buttons share one flex bar + consistent styling.

## Test plan
- [ ] Pan/rotate/zoom around, then click ⌂ — camera should ease back to the origin, default zoom, front-on rotation.
- [ ] With ◎ **on** (default), pick a search result and use side-panel navigate — camera animates onto the node.
- [ ] Toggle ◎ **off**; same actions select the node but leave the camera untouched.
- [ ] Toggle ◎ back **on** — focus behavior returns.
- [ ] Destroy panel — no leftover bar or console errors.