### PR TITLE
fix(panel): jump-to-node preserves zoom when user is closer than 1.5x

### DIFF
--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -277,7 +277,8 @@ export async function mount(
       const sn = simState.getNodePosition(idx);
       if (!sn) return;
       select(idx);
-      if (jumpToNodeEnabled) ctx.focusOn(sn.x, sn.y, 1.5);
+      if (jumpToNodeEnabled)
+        ctx.focusOn(sn.x, sn.y, Math.max(1.5, ctx.getZoom()));
       const n = currentGraph.nodes[idx]!;
       const related = currentGraph.edges.filter(
         (e) => (e.source === n.id || e.target === n.id) && kinds.has(e.kind),
@@ -614,7 +615,8 @@ export async function mount(
         const idx = nodeIndex.get(result.node.id);
         if (idx !== undefined && activeVisibleNodeIds().has(result.node.id)) {
           const sn = simState.getNodePosition(idx);
-          if (sn && jumpToNodeEnabled) ctx.focusOn(sn.x, sn.y, 1.5);
+          if (sn && jumpToNodeEnabled)
+            ctx.focusOn(sn.x, sn.y, Math.max(1.5, ctx.getZoom()));
           select(idx);
         }
         const related = currentGraph.edges.filter(
@@ -728,7 +730,7 @@ export async function mount(
       select(idx);
       if (jumpToNodeEnabled) {
         const sn = simState.getNodePosition(idx);
-        if (sn) ctx.focusOn(sn.x, sn.y, 1.5);
+        if (sn) ctx.focusOn(sn.x, sn.y, Math.max(1.5, ctx.getZoom()));
       }
       const n = currentGraph.nodes[idx]!;
       const related = currentGraph.edges.filter(


### PR DESCRIPTION
## Summary
All three jump-to-node call sites (search hit, side-panel navigate, canvas tap) passed a hardcoded `targetZoom=1.5` to `focusOn`, which made the camera dolly OUT to `radius=baseRadius/1.5 ≈ 3.33` even when the user had scrolled in to zoom=5+ for a closer look.

Most obvious with the dummy graph where the cluster is small and the lateral `target` shift is tiny — the dolly-out is the only motion the user perceives, so it reads as the camera "jumping past" the node. With real spread-out graphs the lateral move masks it, but the same overshoot happens.

Fix: clamp the requested zoom against the current zoom (`Math.max(1.5, ctx.getZoom())`). Jump-to-node now only zooms IN if the user was further out than 1.5x; it never zooms out from the user's chosen view.

## Test plan
- [ ] At default zoom (≤1.5x), clicking a search result still zooms in to a comfortable framing as before.
- [ ] After scrolling in to zoom=3 or higher, clicking a search result jumps to the node without dollying out.
- [ ] Side-panel "navigate to neighbor" and canvas tap-select behave identically.
- [ ] Onboarding (start zoom 0.72) unaffected — jump-to-node still increases zoom to 1.5x because user zoom < 1.5x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)