### PR TITLE
feat(panel): slow easeQuadInOut warmup before onboarding reveal

### DIFF
--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -31,27 +31,34 @@ function onboardingDurationMs(nodeCount: number): number {
   );
 }
 
-// Reveal progression: a "supernova" pops the first 10% of the
-// constellation in a single burst at t=0, then easeInOutCubic eases
-// the remaining 90% in across the full duration. Front-loading the
-// burst as a simultaneous pop (instead of a fast linear ramp) keeps
-// the visual punchy — the previous ramp still spawned nodes one by
-// one, just faster.
-const SUPERNOVA_NODE_FRAC = 0.1;
+function easeQuadInOut(t: number): number {
+  return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+}
+
 function easeInOutCubic(t: number): number {
   return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
 }
+
+// Reveal progression: an easeQuadInOut warmup eases the first
+// WARMUP_NODE_FRAC of nodes in across WARMUP_DURATION_FRAC of duration,
+// then easeInOutCubic takes over for the rest. The previous version
+// popped 10% of nodes in a single frame at t=0, which slammed the
+// worker with one big replaceActive (full sim rebuild) plus dozens of
+// concurrent popScale animations — a visible FPS dip right at the
+// moment the user starts watching. The warmup spreads that startup
+// cost over ~1-2s. Both easings have zero derivative at the seam, so
+// the rate transition is smooth.
+const WARMUP_DURATION_FRAC = 0.1;
+const WARMUP_NODE_FRAC = 0.1;
 function onboardingRevealFraction(rawProgress: number): number {
   if (rawProgress <= 0) return 0;
   if (rawProgress >= 1) return 1;
-  return (
-    SUPERNOVA_NODE_FRAC +
-    easeInOutCubic(rawProgress) * (1 - SUPERNOVA_NODE_FRAC)
-  );
-}
-
-function easeQuadInOut(t: number): number {
-  return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+  if (rawProgress < WARMUP_DURATION_FRAC) {
+    const t = rawProgress / WARMUP_DURATION_FRAC;
+    return easeQuadInOut(t) * WARMUP_NODE_FRAC;
+  }
+  const t = (rawProgress - WARMUP_DURATION_FRAC) / (1 - WARMUP_DURATION_FRAC);
+  return WARMUP_NODE_FRAC + easeInOutCubic(t) * (1 - WARMUP_NODE_FRAC);
 }
 
 function popScale(t: number): number {


### PR DESCRIPTION
## Summary
The previous onboarding curve popped 10% of nodes in a single frame at t=0 (the supernova burst). On 1.6k-node graphs this slammed the worker with one big `replaceActive` (full d3 sim rebuild) plus 160+ concurrent popScale animations — a visible FPS dip the moment the user starts watching, before the system has warmed up.

New shape:
- **First 10% of duration**: `easeQuadInOut` warmup eases the first 10% of nodes in. Reveal rate starts at zero and ramps up smoothly, spreading the simulation/animation startup cost over ~1-2s.
- **Remaining 90%**: the existing `easeInOutCubic` curve takes over and reveals the rest from 10% → 100%.

Both easings have zero derivative at `rawProgress = WARMUP_DURATION_FRAC`, so the rate transition between phases is C¹-continuous (no perceptible kink).

Also moved the easing helpers above the reveal function and reused the existing `easeQuadInOut` rather than adding a duplicate `easeInOutQuad`.

## Test plan
- [ ] First ~1-2 seconds of onboarding: nodes fade in slowly, no FPS dip at t=0.
- [ ] Mid-reveal pace matches the previous easeInOutCubic curve (the bulk of nodes reveal during the second half of duration).
- [ ] Final reveal still completes at exactly the duration cap (5-22s range based on node count).
- [ ] Existing perf gates still apply: 400ms heavy-rebuild throttle + min-delta gate (PR #95) keep worker resyncs sparse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)