### PR TITLE
fix(panel): linear group reveal rate — fix empty start + bursty middle

### DIFF
--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -11,8 +11,8 @@ const ONBOARDING_BLINK_MS = 3200;
 const ONBOARDING_LINK_UP_MS = 700;
 // Camera zoom progressively retreats across the reveal so the user can
 // watch the constellation expand into view. Driven by raw time progress
-// (not reveal fraction) so the zoom-out feels steady regardless of how
-// the supernova-burst-then-easeInOutCubic reveal lands nodes.
+// (not reveal fraction) so the zoom-out feels steady regardless of the
+// reveal cadence.
 const ONBOARDING_START_ZOOM = 0.72;
 const ONBOARDING_END_ZOOM = 0.32;
 
@@ -35,19 +35,21 @@ function easeQuadInOut(t: number): number {
   return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
 }
 
-function easeInOutCubic(t: number): number {
-  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
-}
-
-// Group reveal rate: easeInOutCubic across the full duration. The
-// supernova-burst at t=0 was retired in favor of a smooth start —
-// dropping it removes the FPS hit from popping ~10% of nodes in a
-// single frame. With the per-node ease-in below, individual nodes
-// already get a slow visual entry as they're revealed.
+// Group reveal rate: linear. Cubic looked great in the abstract but
+// in practice produced two bad behaviors at 1.6k nodes:
+//   - slope=0 at t=0 meant the first ~10% of duration revealed
+//     basically nothing (cubic(0.1) ≈ 0.004 → ~6 nodes), then
+//   - the steep middle (peak rate ~1.5×N/duration) flooded the
+//     worker with rapid-succession `replaceActive` calls and dozens
+//     of concurrent per-node animations — the perceived "burst" that
+//     tanked FPS.
+// Linear gives a uniform spawn rate (~N/duration nodes per second)
+// from the very first frame. Per-node easeQuadInOut still smooths
+// each individual node's visual appearance.
 function onboardingRevealFraction(rawProgress: number): number {
   if (rawProgress <= 0) return 0;
   if (rawProgress >= 1) return 1;
-  return easeInOutCubic(rawProgress);
+  return rawProgress;
 }
 
 // Per-node entry animation. Driven by wall-clock time since the node
@@ -242,9 +244,9 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
     const graph = deps.graph();
     const nodes = deps.nodes();
     const raw = Math.min(1, (now - state.startedAt) / state.durationMs);
-    // Camera rotation rides easeQuadInOut; reveal rides the
-    // supernova-burst-then-easeInOutCubic curve. Decoupled so the
-    // camera motion stays smooth even as nodes pop in.
+    // Camera rotation rides easeQuadInOut; group reveal rate is
+    // linear (per-node ease handles individual entry smoothness).
+    // Decoupled so camera motion stays smooth as nodes appear.
     const eased = easeQuadInOut(raw);
     const revealFloat = onboardingRevealFraction(raw) * state.order.length;
     const revealCount = Math.min(state.order.length, Math.ceil(revealFloat));


### PR DESCRIPTION
## Summary
The cubic group rate from PR #98 produced the exact two symptoms the user reported:

- **Empty first phase**: `easeInOutCubic(0.1) ≈ 0.004` — only ~6 of 1600 nodes are revealed in the first 10% of duration. The user sees nothing happening for the first ~2 seconds, then a flood.
- **Bursty middle**: peak rate is `1.5 × N / duration` around `t=0.5` (~109 nodes/sec at 1.6k/22s). This concentrated arrival rate fires `replaceActive` rebuilds rapid-succession on the worker and stacks dozens of concurrent per-node animations — the FPS-tanking "burst."

Linear group rate gives a uniform `N / duration` reveal rate from the first frame onward (~73 nodes/sec at 1.6k/22s, ~1.2 per frame at 60Hz). No empty start, no concentrated mid-flood.

Per-node `popScale` (easeQuadInOut over 600ms wall-clock) is unchanged — it still smooths each individual node's visual entry.

Removed the now-unused `easeInOutCubic` helper and updated stale comments referring to the supernova/cubic curves.

## Test plan
- [ ] Nodes start spawning immediately at t=0 — no dead first phase.
- [ ] Spawn rate stays roughly constant throughout — no perceptible mid-onboarding flood.
- [ ] FPS stays stable across the full reveal (no dips at the previous "burst" moment).
- [ ] Each individual node still eases in smoothly over ~600ms.
- [ ] Total duration unchanged (5-22s based on node count); overlay percent climbs evenly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)