### PR TITLE
Merge dev → main: layout controls, onboarding polish, camera fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Dates use ISO 8601.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-05-03
+
+First tagged release. Pulls together the chain-isolation, keyboard-nav,
+touch-tap, perf, and module-split work landed during the recent feature
+window.
+
 ### Added
 - **Edge-click chain isolation.** Click any visible edge to isolate the full
   connected chain (depth ≥ 1) over currently-enabled edge kinds. A floating
@@ -71,4 +77,5 @@ Dates use ISO 8601.
   separately)* — these landed during the same window through other PRs and
   are listed here for completeness; see `git log` for primary authorship.
 
-[Unreleased]: https://github.com/arm64be/theia/compare/19b71cc...dev
+[Unreleased]: https://github.com/arm64be/theia/compare/v0.1.0...dev
+[0.1.0]: https://github.com/arm64be/theia/compare/19b71cc...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+All notable changes to the theia-panel and supporting code are recorded here.
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Dates use ISO 8601.
+
+## [Unreleased]
+
+### Added
+- **Edge-click chain isolation.** Click any visible edge to isolate the full
+  connected chain (depth ≥ 1) over currently-enabled edge kinds. A floating
+  chip at top center shows `chain · {kind} · N nodes, M edges`; **Esc**, the
+  ✕ button, clicking empty space, or changing edge-kind filters clears it.
+  Pure-BFS is unit-tested headlessly (`scene/chain.test.ts`, 8 cases).
+  *(`scene/Edges.ts` `pickAt`, `scene/chain.ts`, `ui/Overlays.ts`
+  `createChainOverlay`, integration in `index.ts`.)*
+- **Keyboard navigation for the 3D camera.** WASD pans (screen-relative),
+  arrow keys orbit (yaw/pitch), Space zooms in, Ctrl zooms out, Shift held
+  triples the speed. Frame-rate-independent integration on the existing
+  render tick; ignores key events while text inputs are focused; clears
+  pressed-state on `window blur` to prevent stuck keys.
+  *(`scene/KeyboardNav.ts`.)*
+- **Touch tap-to-select.** Single-finger tap (no drag, < 500 ms) picks
+  nodes and edges via the same `runTapSelection` path as mouse click.
+  `preventDefault` on a recognized tap suppresses the synthetic mouse
+  chain so selection doesn't fire twice.
+- **Depth-based edge tint for subagent trees + cron chains.** Visual depth
+  cue for hierarchical edges. *(Authored separately, included for context.)*
+- **Per-node topology metadata + orphan/component filters.** New filter-bar
+  toggles `Hide orphans` and `Component focus`. *(Authored separately.)*
+- **Edge hover highlight + dim non-related nodes on hover/select.** Hovering
+  a node dims edges and nodes outside its 1-hop neighborhood; hovering an
+  edge highlights it. *(Authored separately.)*
+- **Stellar age coloring for nodes + search-select dimming.** Nodes are
+  tinted by recency on a B/A/F/G/K/M-class color ramp; search-select dims
+  non-matches. *(Authored separately.)*
+
+### Changed
+- **`index.ts` split into focused modules.** Reduced from 1,573 → ~1,200
+  lines by extracting:
+  - `state/filterState.ts` (119 lines) — `VALID_KINDS`, `DEFAULT_KINDS`,
+    `STORAGE_KEY`, `loadFilterState`, `saveFilterState`,
+    `computeVisibleNodeIds`. Pure functions.
+  - `state/physicsSnapshot.ts` (144 lines) — `createPhysicsSnapshotIO()`
+    factory owns the throttle state; caller passes graphUrl, simNodes, and
+    a camera-state getter.
+  - `ui/Overlays.ts` (124 lines) — `createLoadingOverlay`,
+    `createChainOverlay`, `createOnboardingOverlay`. The container element
+    (and theme for the chain chip) become explicit parameters.
+  - `state/simulation.ts` (331 lines) — simulation orchestration extracted
+    out of `mount()`. *(Authored separately as `d6d3def`.)*
+
+  Pure restructuring; no behavior change. Typecheck, all tests, and
+  format-check stayed green at every step.
+- **Simulation moved to a Web Worker.** Physics now runs off the main
+  thread, freeing render budget for the camera tick and shaders.
+  *(Authored separately as `8f3c550`.)*
+- **Picker hover raycast throttled to ~50 ms (≈20 fps).** Below the
+  perceptual hover-feedback threshold and matches the threejs-interaction
+  skill convention. With a few thousand nodes the per-move raycast adds
+  up; this is cheap insurance.
+- **Shader twinkle/dim moved into the node shader; idle physics gate; DPR
+  cap; force rewrites.** Several rendering perf improvements bundled.
+  *(Authored separately as `9c467d8`.)*
+
+### Fixed
+- *(none in this window)*
+
+### Notes
+- Several entries under **Added** and **Changed** are marked *(Authored
+  separately)* — these landed during the same window through other PRs and
+  are listed here for completeness; see `git log` for primary authorship.
+
+[Unreleased]: https://github.com/arm64be/theia/compare/19b71cc...dev

--- a/schemas/graph.schema.json
+++ b/schemas/graph.schema.json
@@ -49,7 +49,19 @@
               { "type": "array", "items": { "type": "number" } }
             ]
           },
-          "parent_id": { "type": ["string", "null"] }
+          "parent_id": { "type": ["string", "null"] },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "component_id": { "type": ["integer", "null"] },
+              "hub_score": { "type": "number", "minimum": 0, "maximum": 1 },
+              "hierarchy_depth": { "type": "integer", "minimum": 0 },
+              "descendant_count": { "type": "integer", "minimum": 0 },
+              "is_orphan": { "type": "boolean" },
+              "cron_sequence_id": { "type": ["integer", "null"] }
+            }
+          }
         }
       }
     },

--- a/theia-core/pyproject.toml
+++ b/theia-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "theia-core"
-version = "0.0.1"
+version = "0.1.0"
 description = "Hermes session JSON → theia graph.json"
 requires-python = ">=3.11"
 dependencies = [

--- a/theia-core/theia_core/__main__.py
+++ b/theia-core/theia_core/__main__.py
@@ -12,6 +12,7 @@ from theia_core.detect.cross_search import detect_cross_search
 from theia_core.detect.memory_share import detect_memory_share
 from theia_core.detect.subagent import detect_subagent
 from theia_core.detect.tool_overlap import detect_tool_overlap
+from theia_core.detect.topology import detect_topology
 from theia_core.emit import build_graph, write_graph
 from theia_core.features import build_feature_matrix
 from theia_core.ingest import load_sessions
@@ -52,12 +53,14 @@ def _build(
     positions = project_to_2d(
         matrix, method=cast("Literal['pca', 'umap', 'tool-vector']", projection)
     )
+    topology = detect_topology(sessions, edges)
     graph = build_graph(
         sessions=sessions,
         edges=edges,
         positions=positions,
         projection=projection,
         feature_dim=len(feature_names),
+        metadata=topology,
     )
     if include_features:
         for i, node in enumerate(graph["nodes"]):

--- a/theia-core/theia_core/detect/topology.py
+++ b/theia-core/theia_core/detect/topology.py
@@ -154,9 +154,7 @@ def _subagent_tree_metrics(
     return depth, desc
 
 
-def _cron_sequence_ids(
-    node_ids: set[str], edges: list[Edge]
-) -> dict[str, int | None]:
+def _cron_sequence_ids(node_ids: set[str], edges: list[Edge]) -> dict[str, int | None]:
     """Group cron-chain edges with gap ≤ 48h into connected sequences."""
     cron_adj: dict[str, set[str]] = {nid: set() for nid in node_ids}
     for e in edges:
@@ -197,9 +195,7 @@ def _cron_sequence_ids(
     return out
 
 
-def detect_topology(
-    sessions: list[Session], edges: list[Edge]
-) -> dict[str, dict[str, Any]]:
+def detect_topology(sessions: list[Session], edges: list[Edge]) -> dict[str, dict[str, Any]]:
     """Compute per-node topology metadata.
 
     Returns a mapping ``{node_id: metadata_dict}`` where every value contains

--- a/theia-core/theia_core/detect/topology.py
+++ b/theia-core/theia_core/detect/topology.py
@@ -1,0 +1,227 @@
+"""Per-node graph topology metadata.
+
+Computes six fields for every session node from the candidate edge list:
+
+* ``component_id``      — connected-component ID (only assigned to components
+  larger than three nodes; smaller components are ``None``).
+* ``hub_score``         — ``1.0`` if degree exceeds ``mean + 2*std`` or
+  ``>= 10``; otherwise ``0.0``.
+* ``hierarchy_depth``   — distance from the subagent-tree root (roots = 0).
+* ``descendant_count``  — number of transitive subagent descendants.
+* ``is_orphan``         — degree across **all** edge kinds is zero.
+* ``cron_sequence_id``  — sequence ID for chains of ``cron-chain`` edges
+  whose consecutive runs are within 48h of each other.
+
+The detector runs against the full session universe so its output stays in
+sync with the edge-validation step in :func:`theia_core.emit.build_graph`.
+No new dependencies — pure Python collections.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict, deque
+from typing import Any
+
+from theia_core.detect import Edge
+from theia_core.ingest import Session
+
+_HUB_DEGREE_FLOOR = 10
+_HUB_STD_MULTIPLIER = 2.0
+_MIN_LABELED_COMPONENT_SIZE = 4  # spec: only components with > 3 nodes get an id
+_CRON_GAP_HOURS = 48.0
+
+
+def _undirected_adjacency(
+    node_ids: set[str],
+    edges: list[Edge],
+    kinds: set[str] | None = None,
+) -> dict[str, set[str]]:
+    adj: dict[str, set[str]] = {nid: set() for nid in node_ids}
+    for e in edges:
+        if kinds is not None and e.kind not in kinds:
+            continue
+        if e.source not in node_ids or e.target not in node_ids:
+            continue
+        if e.source == e.target:
+            continue
+        adj[e.source].add(e.target)
+        adj[e.target].add(e.source)
+    return adj
+
+
+def _bfs_components(adj: dict[str, set[str]]) -> list[list[str]]:
+    seen: set[str] = set()
+    out: list[list[str]] = []
+    for start in sorted(adj):
+        if start in seen:
+            continue
+        comp: list[str] = []
+        q: deque[str] = deque([start])
+        seen.add(start)
+        while q:
+            cur = q.popleft()
+            comp.append(cur)
+            for nxt in adj[cur]:
+                if nxt not in seen:
+                    seen.add(nxt)
+                    q.append(nxt)
+        out.append(comp)
+    return out
+
+
+def _component_ids(adj: dict[str, set[str]]) -> dict[str, int | None]:
+    """Assign contiguous IDs to components with more than 3 nodes."""
+    comps = _bfs_components(adj)
+    # Larger first, lex-min as tiebreaker → deterministic across runs.
+    comps.sort(key=lambda c: (-len(c), min(c)))
+    out: dict[str, int | None] = {}
+    next_id = 0
+    for comp in comps:
+        cid: int | None
+        if len(comp) >= _MIN_LABELED_COMPONENT_SIZE:
+            cid = next_id
+            next_id += 1
+        else:
+            cid = None
+        for n in comp:
+            out[n] = cid
+    return out
+
+
+def _hub_scores(adj: dict[str, set[str]]) -> dict[str, float]:
+    if not adj:
+        return {}
+    degrees = {n: len(neigh) for n, neigh in adj.items()}
+    vals = list(degrees.values())
+    n = len(vals)
+    mean = sum(vals) / n
+    var = sum((d - mean) ** 2 for d in vals) / n
+    std = math.sqrt(var)
+    threshold = mean + _HUB_STD_MULTIPLIER * std
+    out: dict[str, float] = {}
+    for node, deg in degrees.items():
+        is_hub = deg >= _HUB_DEGREE_FLOOR or (std > 0 and deg > threshold)
+        out[node] = 1.0 if is_hub else 0.0
+    return out
+
+
+def _subagent_tree_metrics(
+    node_ids: set[str], edges: list[Edge]
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Return ``(hierarchy_depth, descendant_count)`` per node.
+
+    Subagent edges are parent → child (see :mod:`theia_core.detect.subagent`).
+    Nodes outside any subagent tree get depth 0 and 0 descendants.
+    """
+    children: dict[str, set[str]] = defaultdict(set)
+    has_parent: set[str] = set()
+    for e in edges:
+        if e.kind != "subagent":
+            continue
+        if e.source not in node_ids or e.target not in node_ids:
+            continue
+        if e.source == e.target:
+            continue
+        children[e.source].add(e.target)
+        has_parent.add(e.target)
+
+    roots = [n for n in node_ids if n not in has_parent]
+    depth: dict[str, int] = dict.fromkeys(node_ids, 0)
+    desc: dict[str, int] = dict.fromkeys(node_ids, 0)
+
+    for root in roots:
+        # BFS to assign depth and capture traversal order for the post-order
+        # descendant count.
+        order: list[str] = []
+        visited = {root}
+        q: deque[tuple[str, int]] = deque([(root, 0)])
+        while q:
+            cur, d = q.popleft()
+            depth[cur] = d
+            order.append(cur)
+            for child in children.get(cur, ()):
+                if child in visited:
+                    continue
+                visited.add(child)
+                q.append((child, d + 1))
+        for node in reversed(order):
+            total = 0
+            for child in children.get(node, ()):
+                total += 1 + desc[child]
+            desc[node] = total
+
+    return depth, desc
+
+
+def _cron_sequence_ids(
+    node_ids: set[str], edges: list[Edge]
+) -> dict[str, int | None]:
+    """Group cron-chain edges with gap ≤ 48h into connected sequences."""
+    cron_adj: dict[str, set[str]] = {nid: set() for nid in node_ids}
+    for e in edges:
+        if e.kind != "cron-chain":
+            continue
+        if e.source not in node_ids or e.target not in node_ids:
+            continue
+        if e.source == e.target:
+            continue
+        gap = (e.evidence or {}).get("interval_hours")
+        # Missing gap means the chain detector still grouped them together,
+        # so trust it rather than dropping the edge.
+        if isinstance(gap, (int, float)) and gap > _CRON_GAP_HOURS:
+            continue
+        cron_adj[e.source].add(e.target)
+        cron_adj[e.target].add(e.source)
+
+    out: dict[str, int | None] = dict.fromkeys(node_ids, None)
+    seen: set[str] = set()
+    next_id = 0
+    for start in sorted(node_ids):
+        if start in seen or not cron_adj[start]:
+            continue
+        comp: list[str] = []
+        q: deque[str] = deque([start])
+        seen.add(start)
+        while q:
+            cur = q.popleft()
+            comp.append(cur)
+            for nxt in cron_adj[cur]:
+                if nxt not in seen:
+                    seen.add(nxt)
+                    q.append(nxt)
+        if len(comp) >= 2:
+            for n in comp:
+                out[n] = next_id
+            next_id += 1
+    return out
+
+
+def detect_topology(
+    sessions: list[Session], edges: list[Edge]
+) -> dict[str, dict[str, Any]]:
+    """Compute per-node topology metadata.
+
+    Returns a mapping ``{node_id: metadata_dict}`` where every value contains
+    the six fields documented at the top of this module.
+    """
+    node_ids = {s.id for s in sessions}
+    full_adj = _undirected_adjacency(node_ids, edges)
+
+    components = _component_ids(full_adj)
+    hubs = _hub_scores(full_adj)
+    depth, descendants = _subagent_tree_metrics(node_ids, edges)
+    cron_ids = _cron_sequence_ids(node_ids, edges)
+
+    metadata: dict[str, dict[str, Any]] = {}
+    for nid in node_ids:
+        deg = len(full_adj.get(nid, ()))
+        metadata[nid] = {
+            "component_id": components.get(nid),
+            "hub_score": hubs.get(nid, 0.0),
+            "hierarchy_depth": depth.get(nid, 0),
+            "descendant_count": descendants.get(nid, 0),
+            "is_orphan": deg == 0,
+            "cron_sequence_id": cron_ids.get(nid),
+        }
+    return metadata

--- a/theia-core/theia_core/emit.py
+++ b/theia-core/theia_core/emit.py
@@ -54,6 +54,7 @@ def build_graph(
     positions: np.ndarray,
     projection: str,
     feature_dim: int,
+    metadata: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     if positions.shape != (len(sessions), 2):
         raise ValueError(
@@ -61,23 +62,24 @@ def build_graph(
         )
     nodes = []
     for sess, (x, y) in zip(sessions, positions, strict=True):
-        nodes.append(
-            {
-                "id": sess.id,
-                "title": sess.title,
-                "preview": sess.preview,
-                "started_at": sess.started_at.astimezone(UTC).isoformat().replace("+00:00", "Z"),
-                "duration_sec": sess.duration_sec,
-                "tool_count": len(sess.tool_calls),
-                "message_count": sess.message_count,
-                "model": sess.model,
-                "summary": _extract_summary(sess),
-                "initial_prompt": _extract_initial_prompt(sess),
-                "position": {"x": float(x), "y": float(y)},
-                "features": None,
-                "parent_id": sess.parent_id,
-            }
-        )
+        node: dict[str, Any] = {
+            "id": sess.id,
+            "title": sess.title,
+            "preview": sess.preview,
+            "started_at": sess.started_at.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+            "duration_sec": sess.duration_sec,
+            "tool_count": len(sess.tool_calls),
+            "message_count": sess.message_count,
+            "model": sess.model,
+            "summary": _extract_summary(sess),
+            "initial_prompt": _extract_initial_prompt(sess),
+            "position": {"x": float(x), "y": float(y)},
+            "features": None,
+            "parent_id": sess.parent_id,
+        }
+        if metadata is not None and sess.id in metadata:
+            node["metadata"] = metadata[sess.id]
+        nodes.append(node)
     session_ids = {sess.id for sess in sessions}
     valid_edges: list[Edge] = []
     dropped: list[tuple[Edge, list[str]]] = []

--- a/theia-core/uv.lock
+++ b/theia-core/uv.lock
@@ -678,7 +678,7 @@ wheels = [
 
 [[package]]
 name = "theia-core"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },

--- a/theia-panel/package-lock.json
+++ b/theia-panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "theia-panel",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "theia-panel",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "d3-force-3d": "^3.0.5",
         "three": "^0.163.0"

--- a/theia-panel/package.json
+++ b/theia-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theia-panel",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/theia-panel/src/data/types.ts
+++ b/theia-panel/src/data/types.ts
@@ -29,6 +29,14 @@ export interface TheiaGraph {
     };
     features?: null | number[];
     parent_id?: string | null;
+    metadata?: {
+      component_id?: number | null;
+      hub_score?: number;
+      hierarchy_depth?: number;
+      descendant_count?: number;
+      is_orphan?: boolean;
+      cron_sequence_id?: number | null;
+    };
   }[];
   edges: {
     source: string;

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -117,6 +117,8 @@ function loadFilterState(): {
   kinds: Set<TheiaGraph["edges"][number]["kind"]>;
   model: string | null;
   searchFocus: boolean;
+  hideOrphans: boolean;
+  componentFocus: boolean;
 } | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -132,6 +134,8 @@ function loadFilterState(): {
       kinds: new Set(parsedKinds.length > 0 ? parsedKinds : DEFAULT_KINDS),
       model: typeof parsed?.model === "string" ? parsed.model : null,
       searchFocus: parsed?.searchFocus === true,
+      hideOrphans: parsed?.hideOrphans === true,
+      componentFocus: parsed?.componentFocus === true,
     };
   } catch {
     return null;
@@ -142,11 +146,19 @@ function saveFilterState(
   kinds: Set<string>,
   model: string | null,
   searchFocus: boolean,
+  hideOrphans: boolean,
+  componentFocus: boolean,
 ): void {
   try {
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ kinds: Array.from(kinds), model, searchFocus }),
+      JSON.stringify({
+        kinds: Array.from(kinds),
+        model,
+        searchFocus,
+        hideOrphans,
+        componentFocus,
+      }),
     );
   } catch {
     /* quota exceeded, ignore */
@@ -191,7 +203,10 @@ export async function mount(
   }
   let focusEnabled = false;
   let searchFocusEnabled = saved?.searchFocus ?? false;
+  let hideOrphansEnabled = saved?.hideOrphans ?? false;
+  let componentFocusEnabled = saved?.componentFocus ?? false;
   let focusFilter: Set<string> | null = null;
+  let componentFilter: Set<string> | null = null;
   let chainFilter: Set<string> | null = null;
   let chainEdge: TheiaGraph["edges"][number] | null = null;
   let chainOverlay: {
@@ -449,10 +464,52 @@ export async function mount(
 
   function onSearchFocusToggle(enabled: boolean) {
     searchFocusEnabled = enabled;
-    saveFilterState(kinds, modelFilter, searchFocusEnabled);
+    saveFilterState(
+      kinds,
+      modelFilter,
+      searchFocusEnabled,
+      hideOrphansEnabled,
+      componentFocusEnabled,
+    );
     const searchMatchesChanged = updateVisibility();
     const id = sidePanel.currentNodeId();
     if (id && searchMatchesChanged) applyFocusModeIfEnabled(id);
+  }
+
+  function onHideOrphansToggle(enabled: boolean) {
+    hideOrphansEnabled = enabled;
+    saveFilterState(
+      kinds,
+      modelFilter,
+      searchFocusEnabled,
+      hideOrphansEnabled,
+      componentFocusEnabled,
+    );
+    // Hiding/un-hiding orphans changes the visible-edge subgraph, so the chain
+    // filter (depth-N from a clicked edge) may now reference hidden nodes.
+    clearChainSelection();
+    updateVisibility();
+    const id = sidePanel.currentNodeId();
+    if (id) applyFocusModeIfEnabled(id);
+  }
+
+  function onComponentFocusToggle(enabled: boolean) {
+    componentFocusEnabled = enabled;
+    saveFilterState(
+      kinds,
+      modelFilter,
+      searchFocusEnabled,
+      hideOrphansEnabled,
+      componentFocusEnabled,
+    );
+    if (!componentFocusEnabled) {
+      componentFilter = null;
+      setNodeVisibilityFromState();
+      rebuildVisibleEdges();
+    } else {
+      const id = sidePanel.currentNodeId();
+      if (id) applyFocusModeIfEnabled(id);
+    }
   }
 
   const sidePanel = createSidePanel(element, theme, {
@@ -493,6 +550,7 @@ export async function mount(
     graph: TheiaGraph,
     enabledKinds: Set<string>,
     modelFilter?: string | null,
+    hideOrphans = false,
   ): Set<string> {
     const kindVisible = new Set<string>();
     if (enabledKinds.has("subagent")) {
@@ -525,6 +583,11 @@ export async function mount(
         }
       }
     }
+    if (hideOrphans) {
+      for (const node of graph.nodes) {
+        if (node.metadata?.is_orphan) kindVisible.delete(node.id);
+      }
+    }
     if (modelFilter) {
       const modelMatch = new Set<string>();
       for (const node of graph.nodes) {
@@ -548,6 +611,9 @@ export async function mount(
     } else if (focusFilter) {
       ids = new Set([...ids].filter((id) => focusFilter!.has(id)));
     }
+    if (componentFilter) {
+      ids = new Set([...ids].filter((id) => componentFilter!.has(id)));
+    }
     if (onboarding) {
       ids = new Set(
         [...ids].filter((id) => onboarding!.revealedNodeIds.has(id)),
@@ -557,7 +623,12 @@ export async function mount(
   }
 
   function updateVisibility(): boolean {
-    visibleNodeIds = computeVisibleNodeIds(currentGraph, kinds, modelFilter);
+    visibleNodeIds = computeVisibleNodeIds(
+      currentGraph,
+      kinds,
+      modelFilter,
+      hideOrphansEnabled,
+    );
     let searchMatchesChanged = false;
     if (searchFocusEnabled && searchBar) {
       const query = searchBar.input.value.trim();
@@ -658,23 +729,49 @@ export async function mount(
   }
 
   function applyFocusModeIfEnabled(selectedNodeId: string) {
-    if (!focusEnabled) {
-      focusFilter = null;
-      return;
-    }
-    const neighbors = new Set<string>();
-    neighbors.add(selectedNodeId);
-    for (const edge of currentGraph.edges) {
-      if (!kinds.has(edge.kind)) continue;
-      if (edge.source === selectedNodeId) {
-        neighbors.add(edge.target);
-      } else if (edge.target === selectedNodeId) {
-        neighbors.add(edge.source);
+    let touched = false;
+    if (focusEnabled) {
+      const neighbors = new Set<string>();
+      neighbors.add(selectedNodeId);
+      for (const edge of currentGraph.edges) {
+        if (!kinds.has(edge.kind)) continue;
+        if (edge.source === selectedNodeId) {
+          neighbors.add(edge.target);
+        } else if (edge.target === selectedNodeId) {
+          neighbors.add(edge.source);
+        }
       }
+      focusFilter = neighbors;
+      touched = true;
+    } else if (focusFilter) {
+      focusFilter = null;
+      touched = true;
     }
-    focusFilter = neighbors;
-    setNodeVisibilityFromState();
-    rebuildVisibleEdges();
+
+    if (componentFocusEnabled) {
+      const selected = currentGraph.nodes.find((n) => n.id === selectedNodeId);
+      const cid = selected?.metadata?.component_id;
+      if (cid !== undefined && cid !== null) {
+        const sameComponent = new Set<string>();
+        for (const node of currentGraph.nodes) {
+          if (node.metadata?.component_id === cid) sameComponent.add(node.id);
+        }
+        componentFilter = sameComponent;
+      } else {
+        // Selected node has no labeled component (small fragment) — don't
+        // collapse the canvas to a single point; just clear the filter.
+        componentFilter = null;
+      }
+      touched = true;
+    } else if (componentFilter) {
+      componentFilter = null;
+      touched = true;
+    }
+
+    if (touched) {
+      setNodeVisibilityFromState();
+      rebuildVisibleEdges();
+    }
   }
 
   function shouldRunOnboarding(g: TheiaGraph): boolean {
@@ -890,7 +987,12 @@ export async function mount(
       syncRenderedPositionsFromSimulation();
     }
 
-    visibleNodeIds = computeVisibleNodeIds(g, kinds, modelFilter);
+    visibleNodeIds = computeVisibleNodeIds(
+      g,
+      kinds,
+      modelFilter,
+      hideOrphansEnabled,
+    );
     setNodeVisibilityFromState();
     rebuildVisibleEdges();
     post.resize();
@@ -1250,7 +1352,13 @@ export async function mount(
     (state) => {
       kinds = state.kinds;
       modelFilter = state.model;
-      saveFilterState(kinds, modelFilter, searchFocusEnabled);
+      saveFilterState(
+        kinds,
+        modelFilter,
+        searchFocusEnabled,
+        hideOrphansEnabled,
+        componentFocusEnabled,
+      );
       focusFilter = null;
       // Filter changes can invalidate the chain (an edge kind we traversed
       // through may now be hidden); drop the chain rather than recompute it.
@@ -1270,6 +1378,10 @@ export async function mount(
       initialFocusEnabled: focusEnabled,
       onSearchFocusToggle,
       initialSearchFocusEnabled: searchFocusEnabled,
+      onHideOrphansToggle,
+      initialHideOrphansEnabled: hideOrphansEnabled,
+      onComponentFocusToggle,
+      initialComponentFocusEnabled: componentFocusEnabled,
     },
   );
 

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -18,11 +18,7 @@ import { createSearchBar } from "./ui/SearchBar";
 import { createSidePanel } from "./ui/SidePanel";
 import { readTheme, applyTheme, onThemeMessage } from "./ui/Theme";
 import type { ThemeTokens } from "./ui/Theme";
-import {
-  createLoadingOverlay,
-  createChainOverlay,
-  createOnboardingOverlay,
-} from "./ui/Overlays";
+import { createLoadingOverlay, createChainOverlay } from "./ui/Overlays";
 import {
   VALID_KINDS,
   DEFAULT_KINDS,
@@ -31,6 +27,11 @@ import {
   computeVisibleNodeIds,
 } from "./state/filterState";
 import { createPhysicsSnapshotIO } from "./state/physicsSnapshot";
+import {
+  createOnboarding,
+  hasCompletedOnboarding,
+  type OnboardingController,
+} from "./state/onboarding";
 
 export interface PanelOptions {
   edgeKinds?: TheiaGraph["edges"][number]["kind"][];
@@ -43,33 +44,6 @@ export interface Controller {
   reload(graphUrl?: string): Promise<void>;
 }
 
-const ONBOARDING_STORAGE_KEY = "theia-first-load-onboarding-complete";
-const ONBOARDING_ROTATION_RADIANS = Math.PI * 1.15;
-const ONBOARDING_BLINK_MS = 3200;
-const ONBOARDING_LINK_UP_MS = 700;
-const ONBOARDING_BASE_ZOOM = 0.72;
-const ONBOARDING_MIN_ZOOM = 0.42;
-const ONBOARDING_NEAR_DISTANCE = 3.2;
-const ONBOARDING_SAFE_DISTANCE = 5.6;
-
-function easeQuadInOut(t: number): number {
-  return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
-}
-
-function popScale(t: number): number {
-  if (t <= 0) return 0;
-  if (t >= 1) return 1;
-  const eased = easeQuadInOut(t);
-  return 1 + 0.28 * Math.sin(Math.PI * eased);
-}
-
-function revealBrightness(t: number): number {
-  if (t <= 0) return 0;
-  if (t >= 1) return 1;
-  const eased = easeQuadInOut(t);
-  return 1 + 0.5 * Math.sin(Math.PI * eased);
-}
-
 const edgeKeyCache = new WeakMap<TheiaGraph["edges"][number], string>();
 function edgeKey(edge: TheiaGraph["edges"][number]): string {
   let key = edgeKeyCache.get(edge);
@@ -80,22 +54,6 @@ function edgeKey(edge: TheiaGraph["edges"][number]): string {
       : `${edge.target}|${edge.source}|${edge.kind}`;
   edgeKeyCache.set(edge, key);
   return key;
-}
-
-function hasCompletedOnboarding(): boolean {
-  try {
-    return localStorage.getItem(ONBOARDING_STORAGE_KEY) === "1";
-  } catch {
-    return true;
-  }
-}
-
-function markOnboardingComplete(): void {
-  try {
-    localStorage.setItem(ONBOARDING_STORAGE_KEY, "1");
-  } catch {
-    /* quota exceeded, ignore */
-  }
 }
 
 export async function mount(
@@ -146,22 +104,7 @@ export async function mount(
     update(nodeCount: number, edgeCount: number, label: string): void;
     remove(): void;
   } | null = null;
-  let onboarding: {
-    startedAt: number;
-    durationMs: number;
-    order: number[];
-    rankByIndex: Map<number, number>;
-    revealedNodeIds: Set<string>;
-    revealStartedAtByIndex: Map<number, number>;
-    linkStartedAtByKey: Map<string, number>;
-    lastRevealedCount: number;
-    lastHeavyRebuildAt: number;
-    lastEase: number;
-    cameraZoom: number;
-    cameraAutoZoomEnabled: boolean;
-    complete: boolean;
-    overlay: { update(progress: number): void; remove(): void };
-  } | null = null;
+  let onboarding: OnboardingController;
   let searchFocusMatchKey = "";
   let searchInputController: AbortController | null = null;
   let searchFocusTimer: ReturnType<typeof setTimeout> | null = null;
@@ -181,7 +124,7 @@ export async function mount(
 
   function canSavePhysicsSnapshot(): boolean {
     if (!currentGraph || !hasCompletedOnboarding()) return false;
-    if (onboarding && !onboarding.complete) return false;
+    if (onboarding.isActive() && !onboarding.isComplete()) return false;
     return true;
   }
 
@@ -370,10 +313,9 @@ export async function mount(
     if (componentFilter) {
       ids = new Set([...ids].filter((id) => componentFilter!.has(id)));
     }
-    if (onboarding) {
-      ids = new Set(
-        [...ids].filter((id) => onboarding!.revealedNodeIds.has(id)),
-      );
+    if (onboarding.isActive()) {
+      const revealed = onboarding.revealedNodeIds();
+      ids = new Set([...ids].filter((id) => revealed.has(id)));
     }
     return ids;
   }
@@ -412,7 +354,7 @@ export async function mount(
 
     // Start at equilibrium to prevent jittery readjustment.
     simState.replaceActive({
-      activeIds: onboarding ? activeVisibleNodeIds() : null,
+      activeIds: onboarding.isActive() ? activeVisibleNodeIds() : null,
     });
 
     rebuildVisibleEdges();
@@ -539,220 +481,24 @@ export async function mount(
     }
   }
 
-  function shouldRunOnboarding(g: TheiaGraph): boolean {
-    return g.nodes.length > 0 && !hasCompletedOnboarding();
-  }
-
-  function beginOnboarding(g: TheiaGraph) {
-    const order = g.nodes
-      .map((node, index) => ({ index, time: Date.parse(node.started_at) }))
-      .sort((a, b) => {
-        const at = Number.isFinite(a.time) ? a.time : Number.POSITIVE_INFINITY;
-        const bt = Number.isFinite(b.time) ? b.time : Number.POSITIVE_INFINITY;
-        return at - bt || a.index - b.index;
-      })
-      .map(({ index }) => index);
-    onboarding = {
-      startedAt: performance.now(),
-      durationMs: Math.max(1, Math.ceil(g.nodes.length / 3)) * 1000,
-      order,
-      rankByIndex: new Map(order.map((index, rank) => [index, rank])),
-      revealedNodeIds: new Set(),
-      revealStartedAtByIndex: new Map(),
-      linkStartedAtByKey: new Map(),
-      lastRevealedCount: 0,
-      lastHeavyRebuildAt: 0,
-      lastEase: 0,
-      cameraZoom: ONBOARDING_BASE_ZOOM,
-      cameraAutoZoomEnabled: true,
-      complete: false,
-      overlay: createOnboardingOverlay(element),
-    };
-    ctx.setZoom(ONBOARDING_BASE_ZOOM);
-    for (let i = 0; i < g.nodes.length; i++) {
-      nodes.setRevealScale(i, 0);
-      nodes.setBrightness(i, 0);
-    }
-    setNodeVisibilityFromState();
-    rebuildVisibleEdges();
-    simState.replaceActive({
-      activeIds: activeVisibleNodeIds(),
-      animateNew: true,
-    });
-  }
-
-  function updateOnboardingLinks(now: number) {
-    if (!onboarding) {
-      edges.setConnectionProgress(null);
-      return;
-    }
-    for (const edge of currentGraph.edges) {
-      if (
-        onboarding.revealedNodeIds.has(edge.source) &&
-        onboarding.revealedNodeIds.has(edge.target)
-      ) {
-        const key = edgeKey(edge);
-        if (!onboarding.linkStartedAtByKey.has(key)) {
-          onboarding.linkStartedAtByKey.set(key, now);
-        }
-      }
-    }
-    edges.setConnectionProgress((edge) => {
-      const startedAt = onboarding?.linkStartedAtByKey.get(edgeKey(edge));
-      if (startedAt === undefined) return 0;
-      return easeQuadInOut(
-        Math.min(1, (now - startedAt) / ONBOARDING_LINK_UP_MS),
-      );
-    });
-  }
-
-  function updateOnboarding(now: number) {
-    if (!onboarding) return;
-    const raw = Math.min(
-      1,
-      (now - onboarding.startedAt) / onboarding.durationMs,
-    );
-    const eased = easeQuadInOut(raw);
-    const revealFloat = eased * onboarding.order.length;
-    const revealCount = Math.min(
-      onboarding.order.length,
-      Math.ceil(revealFloat),
-    );
-
-    for (let rank = onboarding.lastRevealedCount; rank < revealCount; rank++) {
-      const idx = onboarding.order[rank]!;
-      onboarding.revealedNodeIds.add(currentGraph.nodes[idx]!.id);
-      onboarding.revealStartedAtByIndex.set(idx, now);
-    }
-
-    for (const idx of onboarding.order) {
-      const rank = onboarding.rankByIndex.get(idx)!;
-      const localProgress = Math.max(0, Math.min(1, revealFloat - rank));
-      nodes.setRevealScale(idx, popScale(localProgress));
-      const revealedAt = onboarding.revealStartedAtByIndex.get(idx);
-      const blinkProgress =
-        revealedAt === undefined
-          ? 0
-          : Math.min(1, (now - revealedAt) / ONBOARDING_BLINK_MS);
-      nodes.setBrightness(idx, revealBrightness(blinkProgress));
-    }
-    updateOnboardingLinks(now);
-
-    const rotationDelta =
-      (eased - onboarding.lastEase) * ONBOARDING_ROTATION_RADIANS;
-    if (rotationDelta !== 0) {
-      const state = ctx.getCameraState();
-      ctx.setCameraState({ ...state, theta: state.theta + rotationDelta });
-    }
-
-    // Heavy rebuild throttle. Each rebuild iterates all 1.6k nodes
-    // (setNodeVisibilityFromState), regenerates the entire edges
-    // geometry (rebuildVisibleEdges), and asks the worker to recreate
-    // the d3-force-3d simulation for the new active set. With reveals
-    // crossing integer boundaries multiple times per frame at 60Hz, the
-    // un-throttled version fires this on essentially every frame —
-    // which was the source of the visible reveal-period FPS drop.
-    //
-    // Throttle to ~150ms; always force a final rebuild when the last
-    // node has been revealed so the simulation gets the full active
-    // set before settling. setRevealScale on individual nodes still
-    // happens every frame inside the loop above, so the visual reveal
-    // animation continues smoothly between rebuilds.
-    const HEAVY_REBUILD_INTERVAL_MS = 150;
-    const sawNewReveals = revealCount !== onboarding.lastRevealedCount;
-    onboarding.lastRevealedCount = revealCount;
-    const finalReveal = revealCount === onboarding.order.length;
-    if (
-      sawNewReveals &&
-      (finalReveal ||
-        now - onboarding.lastHeavyRebuildAt > HEAVY_REBUILD_INTERVAL_MS)
-    ) {
-      onboarding.lastHeavyRebuildAt = now;
-      setNodeVisibilityFromState();
-      rebuildVisibleEdges();
-      simState.replaceActive({
-        activeIds: activeVisibleNodeIds(),
-        animateNew: true,
-      });
-    }
-    onboarding.lastEase = eased;
-    onboarding.overlay.update(eased);
-
-    if (raw >= 1 && !onboarding.complete) {
-      for (const idx of onboarding.order) {
-        onboarding.revealedNodeIds.add(currentGraph.nodes[idx]!.id);
-        nodes.setRevealScale(idx, 1);
-        if (!onboarding.revealStartedAtByIndex.has(idx)) {
-          onboarding.revealStartedAtByIndex.set(idx, now);
-        }
-      }
-      onboarding.complete = true;
-      markOnboardingComplete();
-      onboarding.overlay.remove();
-      setNodeVisibilityFromState();
-      rebuildVisibleEdges();
-      updateOnboardingLinks(now);
-      savePhysicsSnapshot();
-    }
-
-    if (onboarding.complete) {
-      let allBlinkDone = true;
-      for (const idx of onboarding.order) {
-        const revealedAt = onboarding.revealStartedAtByIndex.get(idx) ?? now;
-        const blinkProgress = Math.min(
-          1,
-          (now - revealedAt) / ONBOARDING_BLINK_MS,
-        );
-        nodes.setBrightness(idx, revealBrightness(blinkProgress));
-        allBlinkDone &&= blinkProgress >= 1;
-      }
-      if (allBlinkDone) {
-        for (const idx of onboarding.order) {
-          nodes.setBrightness(idx, 1);
-        }
-        onboarding = null;
-        edges.setConnectionProgress(null);
-      }
-    }
-  }
-
-  function updateOnboardingCamera() {
-    if (!onboarding || onboarding.complete || !onboarding.cameraAutoZoomEnabled)
-      return;
-    let nearest = Number.POSITIVE_INFINITY;
-    for (const idx of onboarding.order) {
-      if (!onboarding.revealedNodeIds.has(currentGraph.nodes[idx]!.id)) {
-        continue;
-      }
-      // nodePositions tracks the same per-frame smoothed values that the
-      // simulation tick writes; reading from there avoids reaching into
-      // the simulation module's private renderedPositions buffer.
-      const dx = nodePositions[idx * 3]! - ctx.camera.position.x;
-      const dy = nodePositions[idx * 3 + 1]! - ctx.camera.position.y;
-      const dz = nodePositions[idx * 3 + 2]! - ctx.camera.position.z;
-      nearest = Math.min(nearest, Math.sqrt(dx * dx + dy * dy + dz * dz));
-    }
-    if (!Number.isFinite(nearest)) return;
-
-    const crowding = Math.max(
-      0,
-      Math.min(
-        1,
-        (ONBOARDING_SAFE_DISTANCE - nearest) /
-          (ONBOARDING_SAFE_DISTANCE - ONBOARDING_NEAR_DISTANCE),
-      ),
-    );
-    const targetZoom =
-      ONBOARDING_BASE_ZOOM -
-      (ONBOARDING_BASE_ZOOM - ONBOARDING_MIN_ZOOM) * easeQuadInOut(crowding);
-    onboarding.cameraZoom += (targetZoom - onboarding.cameraZoom) * 0.08;
-    ctx.setZoom(onboarding.cameraZoom);
-  }
+  onboarding = createOnboarding({
+    element,
+    graph: () => currentGraph,
+    nodes: () => nodes,
+    edges,
+    ctx,
+    simState: () => simState,
+    nodePositions: () => nodePositions,
+    setNodeVisibilityFromState,
+    rebuildVisibleEdges,
+    activeVisibleNodeIds,
+    edgeKey,
+    savePhysicsSnapshot,
+  });
 
   function setupGraph(g: TheiaGraph) {
     simState?.dispose();
-    onboarding?.overlay.remove();
-    onboarding = null;
+    onboarding.cancel();
     // Clear any chain isolation from a prior graph: edge identity is
     // graph-scoped, so the previous selection is meaningless once we reload.
     clearChainSelection();
@@ -771,7 +517,7 @@ export async function mount(
     simState = createSimulationState({
       graph: g,
       kinds,
-      isOnboarding: () => Boolean(onboarding && !onboarding.complete),
+      isOnboarding: () => onboarding.isActive() && !onboarding.isComplete(),
       nodes,
       edges,
       nodePositions,
@@ -905,19 +651,19 @@ export async function mount(
   }
   loading.remove();
   setupGraph(initialGraph);
-  if (shouldRunOnboarding(initialGraph)) {
-    beginOnboarding(initialGraph);
+  if (initialGraph.nodes.length > 0 && !hasCompletedOnboarding()) {
+    onboarding.begin();
   }
 
   let disposed = false;
   function frame() {
     if (disposed) return;
     const now = performance.now();
-    updateOnboarding(now);
+    onboarding.update(now);
     keyboardNav.tick(now);
     simState.tick();
     maybeSavePhysicsSnapshot(now);
-    updateOnboardingCamera();
+    onboarding.updateCamera();
     const t = now / 1000;
     nodes.setTime(t);
     edges.setTime(t);
@@ -1081,10 +827,7 @@ export async function mount(
     (e) => {
       if ((e.target as HTMLElement).closest("[data-ui-overlay]")) return;
       lastWheelAt = performance.now();
-      if (onboarding) {
-        onboarding.cameraAutoZoomEnabled = false;
-        onboarding.cameraZoom = ctx.getZoom();
-      }
+      onboarding.onUserZoomChanged(ctx.getZoom());
       e.preventDefault();
       const delta = e.deltaY > 0 ? 1.1 : 0.9;
       ctx.setZoom(ctx.getZoom() * delta);
@@ -1154,7 +897,7 @@ export async function mount(
     destroy() {
       disposed = true;
       savePhysicsSnapshot();
-      onboarding?.overlay.remove();
+      onboarding.cancel();
       window.removeEventListener("mouseup", resetDrag);
       window.removeEventListener("keydown", onKeyDown);
       chainOverlay?.remove();

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -13,8 +13,24 @@ import { createTooltip } from "./ui/Tooltip";
 import { createFilterBar } from "./ui/FilterBar";
 import { createSearchBar } from "./ui/SearchBar";
 import { createSidePanel } from "./ui/SidePanel";
-import { readTheme, applyTheme, onThemeMessage, FONT_STACK } from "./ui/Theme";
+import { readTheme, applyTheme, onThemeMessage } from "./ui/Theme";
 import type { ThemeTokens } from "./ui/Theme";
+import {
+  createLoadingOverlay,
+  createChainOverlay,
+  createOnboardingOverlay,
+} from "./ui/Overlays";
+import {
+  VALID_KINDS,
+  DEFAULT_KINDS,
+  loadFilterState,
+  saveFilterState,
+  computeVisibleNodeIds,
+} from "./state/filterState";
+import {
+  createPhysicsSnapshotIO,
+  type PhysicsSnapshotNode,
+} from "./state/physicsSnapshot";
 import { hashN11 } from "./util/hash";
 
 export interface PanelOptions {
@@ -28,23 +44,10 @@ export interface Controller {
   reload(graphUrl?: string): Promise<void>;
 }
 
-const VALID_KINDS: TheiaGraph["edges"][number]["kind"][] = [
-  "memory-share",
-  "cross-search",
-  "tool-overlap",
-  "subagent",
-  "cron-chain",
-];
-
-const DEFAULT_KINDS: TheiaGraph["edges"][number]["kind"][] = VALID_KINDS;
-
-const STORAGE_KEY = "theia-constellation-filter";
 const ONBOARDING_STORAGE_KEY = "theia-first-load-onboarding-complete";
-const PHYSICS_SNAPSHOT_KEY_PREFIX = "theia-physics-snapshot:";
 const ONBOARDING_ROTATION_RADIANS = Math.PI * 1.15;
 const ONBOARDING_BLINK_MS = 3200;
 const ONBOARDING_LINK_UP_MS = 700;
-const PHYSICS_SNAPSHOT_INTERVAL_MS = 5000;
 const ONBOARDING_BASE_ZOOM = 0.72;
 const ONBOARDING_MIN_ZOOM = 0.42;
 const ONBOARDING_NEAR_DISTANCE = 3.2;
@@ -91,76 +94,6 @@ function hasCompletedOnboarding(): boolean {
 function markOnboardingComplete(): void {
   try {
     localStorage.setItem(ONBOARDING_STORAGE_KEY, "1");
-  } catch {
-    /* quota exceeded, ignore */
-  }
-}
-
-type PhysicsSnapshotNode = {
-  x: number;
-  y: number;
-  z: number;
-  vx: number;
-  vy: number;
-  vz: number;
-};
-
-function physicsSnapshotKey(graphUrl: string): string {
-  return `${PHYSICS_SNAPSHOT_KEY_PREFIX}${graphUrl}`;
-}
-
-type PhysicsSnapshot = {
-  nodes: Map<string, PhysicsSnapshotNode>;
-  camera: ReturnType<ReturnType<typeof createScene>["getCameraState"]> | null;
-};
-
-function loadFilterState(): {
-  kinds: Set<TheiaGraph["edges"][number]["kind"]>;
-  model: string | null;
-  searchFocus: boolean;
-  hideOrphans: boolean;
-  componentFocus: boolean;
-} | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    const parsedKinds = Array.isArray(parsed?.kinds)
-      ? parsed.kinds.filter(
-          (k: unknown): k is TheiaGraph["edges"][number]["kind"] =>
-            (VALID_KINDS as readonly unknown[]).includes(k),
-        )
-      : DEFAULT_KINDS;
-    return {
-      kinds: new Set(parsedKinds.length > 0 ? parsedKinds : DEFAULT_KINDS),
-      model: typeof parsed?.model === "string" ? parsed.model : null,
-      searchFocus: parsed?.searchFocus === true,
-      hideOrphans: parsed?.hideOrphans === true,
-      componentFocus: parsed?.componentFocus === true,
-    };
-  } catch {
-    return null;
-  }
-}
-
-function saveFilterState(
-  kinds: Set<string>,
-  model: string | null,
-  searchFocus: boolean,
-  hideOrphans: boolean,
-  componentFocus: boolean,
-): void {
-  try {
-    localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({
-        kinds: Array.from(kinds),
-        model,
-        searchFocus,
-        hideOrphans,
-        componentFocus,
-      }),
-    );
   } catch {
     /* quota exceeded, ignore */
   }
@@ -246,7 +179,7 @@ export async function mount(
   let searchBar: ReturnType<typeof createSearchBar>;
   let selectedIdx: number | null = null;
   let currentGraphUrl = graphUrl;
-  let lastPhysicsSnapshotAt = 0;
+  const physicsSnapshotIO = createPhysicsSnapshotIO();
 
   function simulationGraphFor(activeIds: Set<string> | null): TheiaGraph {
     if (!activeIds) return currentGraph;
@@ -337,95 +270,25 @@ export async function mount(
     edges.updatePositions(nodePositions);
   }
 
-  function loadPhysicsSnapshot(): PhysicsSnapshot {
-    try {
-      const raw = localStorage.getItem(physicsSnapshotKey(currentGraphUrl));
-      if (!raw) return { nodes: new Map(), camera: null };
-      const parsed = JSON.parse(raw);
-      const nodesById = parsed?.nodes;
-      if (!nodesById || typeof nodesById !== "object") {
-        return { nodes: new Map(), camera: null };
-      }
-      const snapshot = new Map<string, PhysicsSnapshotNode>();
-      for (const [id, value] of Object.entries(nodesById)) {
-        if (!value || typeof value !== "object") continue;
-        const node = value as Record<string, unknown>;
-        const x = Number(node.x);
-        const y = Number(node.y);
-        const z = Number(node.z);
-        const vx = Number(node.vx ?? 0);
-        const vy = Number(node.vy ?? 0);
-        const vz = Number(node.vz ?? 0);
-        if ([x, y, z, vx, vy, vz].every(Number.isFinite)) {
-          snapshot.set(id, { x, y, z, vx, vy, vz });
-        }
-      }
-      const cameraRaw = parsed?.camera;
-      const targetRaw = cameraRaw?.target;
-      const camera =
-        cameraRaw &&
-        targetRaw &&
-        [
-          targetRaw.x,
-          targetRaw.y,
-          targetRaw.z,
-          cameraRaw.theta,
-          cameraRaw.phi,
-          cameraRaw.zoom,
-        ]
-          .map(Number)
-          .every(Number.isFinite)
-          ? {
-              target: {
-                x: Number(targetRaw.x),
-                y: Number(targetRaw.y),
-                z: Number(targetRaw.z),
-              },
-              theta: Number(cameraRaw.theta),
-              phi: Number(cameraRaw.phi),
-              zoom: Number(cameraRaw.zoom),
-            }
-          : null;
-      return { nodes: snapshot, camera };
-    } catch {
-      return { nodes: new Map(), camera: null };
-    }
+  function canSavePhysicsSnapshot(): boolean {
+    if (!currentGraph || !hasCompletedOnboarding()) return false;
+    if (onboarding && !onboarding.complete) return false;
+    return true;
   }
 
   function savePhysicsSnapshot() {
-    if (!currentGraph || !hasCompletedOnboarding()) return;
-    if (onboarding && !onboarding.complete) return;
-    const nodesById: Record<string, PhysicsSnapshotNode> = {};
-    for (const sn of simNodes) {
-      if (!sn) continue;
-      nodesById[sn.id] = {
-        x: sn.x,
-        y: sn.y,
-        z: sn.z,
-        vx: sn.vx ?? 0,
-        vy: sn.vy ?? 0,
-        vz: sn.vz ?? 0,
-      };
-    }
-    try {
-      localStorage.setItem(
-        physicsSnapshotKey(currentGraphUrl),
-        JSON.stringify({
-          version: 1,
-          saved_at: Date.now(),
-          nodes: nodesById,
-          camera: ctx.getCameraState(),
-        }),
-      );
-    } catch {
-      /* quota exceeded, ignore */
-    }
+    if (!canSavePhysicsSnapshot()) return;
+    physicsSnapshotIO.save(currentGraphUrl, simNodes, ctx.getCameraState());
   }
 
   function maybeSavePhysicsSnapshot(now: number) {
-    if (now - lastPhysicsSnapshotAt < PHYSICS_SNAPSHOT_INTERVAL_MS) return;
-    lastPhysicsSnapshotAt = now;
-    savePhysicsSnapshot();
+    physicsSnapshotIO.maybeSave(
+      now,
+      currentGraphUrl,
+      simNodes,
+      () => ctx.getCameraState(),
+      canSavePhysicsSnapshot(),
+    );
   }
 
   const tooltip = createTooltip(element, theme);
@@ -580,60 +443,6 @@ export async function mount(
   const isInteracting = () =>
     isMouseDown || performance.now() - lastWheelAt < 200;
 
-  function computeVisibleNodeIds(
-    graph: TheiaGraph,
-    enabledKinds: Set<string>,
-    modelFilter?: string | null,
-    hideOrphans = false,
-  ): Set<string> {
-    const kindVisible = new Set<string>();
-    if (enabledKinds.has("subagent")) {
-      for (const node of graph.nodes) {
-        kindVisible.add(node.id);
-      }
-    } else {
-      const subagentIds = new Set<string>();
-      const hasNonSubagentConnection = new Map<string, boolean>();
-      for (const node of graph.nodes) {
-        if (node.parent_id) {
-          subagentIds.add(node.id);
-        } else {
-          hasNonSubagentConnection.set(node.id, true);
-        }
-      }
-      for (const edge of graph.edges) {
-        if (edge.kind === "subagent") continue;
-        if (!enabledKinds.has(edge.kind)) continue;
-        if (!subagentIds.has(edge.source)) {
-          hasNonSubagentConnection.set(edge.source, true);
-        }
-        if (!subagentIds.has(edge.target)) {
-          hasNonSubagentConnection.set(edge.target, true);
-        }
-      }
-      for (const node of graph.nodes) {
-        if (hasNonSubagentConnection.get(node.id)) {
-          kindVisible.add(node.id);
-        }
-      }
-    }
-    if (hideOrphans) {
-      for (const node of graph.nodes) {
-        if (node.metadata?.is_orphan) kindVisible.delete(node.id);
-      }
-    }
-    if (modelFilter) {
-      const modelMatch = new Set<string>();
-      for (const node of graph.nodes) {
-        if (node.model === modelFilter && kindVisible.has(node.id)) {
-          modelMatch.add(node.id);
-        }
-      }
-      return modelMatch;
-    }
-    return kindVisible;
-  }
-
   let visibleNodeIds = new Set<string>();
 
   function activeVisibleNodeIds(): Set<string> {
@@ -758,7 +567,9 @@ export async function mount(
     kindLabel: string,
   ) {
     if (!chainOverlay)
-      chainOverlay = createChainOverlay(() => clearChainSelection());
+      chainOverlay = createChainOverlay(element, theme, () =>
+        clearChainSelection(),
+      );
     chainOverlay.update(nodeCount, edgeCount, kindLabel);
   }
 
@@ -834,7 +645,7 @@ export async function mount(
       cameraZoom: ONBOARDING_BASE_ZOOM,
       cameraAutoZoomEnabled: true,
       complete: false,
-      overlay: createOnboardingOverlay(),
+      overlay: createOnboardingOverlay(element),
     };
     ctx.setZoom(ONBOARDING_BASE_ZOOM);
     for (let i = 0; i < g.nodes.length; i++) {
@@ -1009,7 +820,7 @@ export async function mount(
     nodeIndex = new Map(g.nodes.map((n, i) => [n.id, i]));
 
     if (hasCompletedOnboarding()) {
-      const snapshot = loadPhysicsSnapshot();
+      const snapshot = physicsSnapshotIO.load(currentGraphUrl);
       replaceSimulation(null, true, false, snapshot.nodes);
       syncRenderedPositionsFromSimulation();
       if (snapshot.camera) {
@@ -1121,113 +932,7 @@ export async function mount(
     );
   }
 
-  function createLoadingOverlay(text: string): { remove(): void } {
-    const el = document.createElement("div");
-    el.style.cssText = `
-      position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
-      background: rgba(7,8,13,0.8); color: rgba(255,255,255,0.6);
-      font: 13px/1.4 var(--theia-font, ${FONT_STACK});
-      letter-spacing: 0.05em; z-index: 20; transition: opacity 300ms;
-    `;
-    el.textContent = text;
-    element.appendChild(el);
-    return {
-      remove() {
-        el.style.opacity = "0";
-        setTimeout(() => {
-          try {
-            element.removeChild(el);
-          } catch {
-            /* container may have been destroyed during load */
-          }
-        }, 300);
-      },
-    };
-  }
-
-  function createChainOverlay(onClear: () => void): {
-    update(nodeCount: number, edgeCount: number, label: string): void;
-    remove(): void;
-  } {
-    const el = document.createElement("div");
-    el.setAttribute("data-ui-overlay", "true");
-    el.style.cssText = `
-      position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
-      display: flex; align-items: center; gap: 10px;
-      padding: 6px 10px 6px 12px; border: 1px solid #${theme.border};
-      background: rgba(7,8,13,0.78); color: #${theme.fg};
-      font: 11px/1.2 var(--theia-font, ${FONT_STACK}); letter-spacing: 0.08em;
-      text-transform: uppercase; border-radius: ${theme.radius};
-      z-index: 13; cursor: default; backdrop-filter: blur(4px);
-    `;
-    const label = document.createElement("span");
-    el.appendChild(label);
-    const btn = document.createElement("button");
-    btn.type = "button";
-    btn.textContent = "✕";
-    btn.setAttribute("aria-label", "Clear chain selection");
-    btn.style.cssText = `
-      appearance: none; border: 0; background: transparent; cursor: pointer;
-      color: #${theme.fg2}; font: inherit; padding: 0 2px; line-height: 1;
-    `;
-    btn.onmouseenter = () => {
-      btn.style.color = `#${theme.accent}`;
-    };
-    btn.onmouseleave = () => {
-      btn.style.color = `#${theme.fg2}`;
-    };
-    btn.onclick = (e) => {
-      e.stopPropagation();
-      onClear();
-    };
-    el.appendChild(btn);
-    element.appendChild(el);
-    return {
-      update(nodeCount, edgeCount, kindLabel) {
-        label.textContent = `chain · ${kindLabel} · ${nodeCount} node${nodeCount === 1 ? "" : "s"}, ${edgeCount} edge${edgeCount === 1 ? "" : "s"}`;
-      },
-      remove() {
-        try {
-          element.removeChild(el);
-        } catch {
-          /* container may have been destroyed */
-        }
-      },
-    };
-  }
-
-  function createOnboardingOverlay(): {
-    update(progress: number): void;
-    remove(): void;
-  } {
-    const el = document.createElement("div");
-    el.setAttribute("data-ui-overlay", "true");
-    el.style.cssText = `
-      position: absolute; left: 50%; bottom: 28px; transform: translateX(-50%);
-      color: rgba(255,255,255,0.58); font: 11px/1.2 var(--theia-font, ${FONT_STACK});
-      letter-spacing: 0.18em; text-transform: uppercase; z-index: 12;
-      pointer-events: none; text-align: center; transition: opacity 450ms;
-    `;
-    element.appendChild(el);
-    return {
-      update(progress) {
-        const pct = Math.max(0, Math.min(100, Math.round(progress * 100)));
-        el.textContent = `CREATING THE UNIVERSE - ${pct}%`;
-      },
-      remove() {
-        el.style.opacity = "0";
-        setTimeout(() => {
-          try {
-            element.removeChild(el);
-          } catch {
-            /* container may have been destroyed */
-          }
-        }, 450);
-      },
-    };
-  }
-
-  const loading = createLoadingOverlay("Loading constellation\u2026");
+  const loading = createLoadingOverlay(element, "Loading constellation\u2026");
   let initialGraph: TheiaGraph;
   try {
     initialGraph = await loadGraph(graphUrl);
@@ -1538,7 +1243,7 @@ export async function mount(
       const targetUrl = url ?? graphUrl;
       currentGraphUrl = targetUrl;
 
-      const loading = createLoadingOverlay("Reloading\u2026");
+      const loading = createLoadingOverlay(element, "Reloading\u2026");
       let newGraph: TheiaGraph;
       try {
         newGraph = await loadGraph(targetUrl);

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -7,6 +7,7 @@ import { createEdges } from "./scene/Edges";
 import { createPost } from "./scene/Post";
 import { createSimulation } from "./physics/Simulation";
 import { createPicker } from "./scene/Picker";
+import { computeEdgeChain } from "./scene/chain";
 import { createTooltip } from "./ui/Tooltip";
 import { createFilterBar } from "./ui/FilterBar";
 import { createSearchBar } from "./ui/SearchBar";
@@ -191,6 +192,12 @@ export async function mount(
   let focusEnabled = false;
   let searchFocusEnabled = saved?.searchFocus ?? false;
   let focusFilter: Set<string> | null = null;
+  let chainFilter: Set<string> | null = null;
+  let chainEdge: TheiaGraph["edges"][number] | null = null;
+  let chainOverlay: {
+    update(nodeCount: number, edgeCount: number, label: string): void;
+    remove(): void;
+  } | null = null;
   let onboarding: {
     startedAt: number;
     durationMs: number;
@@ -534,7 +541,11 @@ export async function mount(
 
   function activeVisibleNodeIds(): Set<string> {
     let ids = visibleNodeIds;
-    if (focusFilter) {
+    // chainFilter (depth-N isolation from a clicked edge) takes precedence
+    // over the depth-1 focusFilter; the two are conceptually different modes.
+    if (chainFilter) {
+      ids = new Set([...ids].filter((id) => chainFilter!.has(id)));
+    } else if (focusFilter) {
       ids = new Set([...ids].filter((id) => focusFilter!.has(id)));
     }
     if (onboarding) {
@@ -596,6 +607,54 @@ export async function mount(
       nodes.setVisible(i, activeIds.has(currentGraph.nodes[i]!.id));
     }
     nodes.flush();
+  }
+
+  const EDGE_KIND_LABELS: Record<TheiaGraph["edges"][number]["kind"], string> =
+    {
+      "memory-share": "memory share",
+      "cross-search": "cross-search",
+      "tool-overlap": "tool overlap",
+      subagent: "subagent",
+      "cron-chain": "cron chain",
+    };
+
+  function applyChainSelection(edge: TheiaGraph["edges"][number]) {
+    const { nodes: chainNodes, edgeCount } = computeEdgeChain(
+      currentGraph,
+      [edge.source, edge.target],
+      kinds,
+      visibleNodeIds,
+    );
+    if (chainNodes.size === 0) return;
+    chainEdge = edge;
+    chainFilter = chainNodes;
+    // Drop any stale 1-hop focus filter — focusFilter is bound to a selected
+    // node, and chain mode has no selected node. Leaving it would resurface
+    // a stale neighbor set when the chain is cleared.
+    focusFilter = null;
+    setNodeVisibilityFromState();
+    rebuildVisibleEdges();
+    showChainOverlay(chainNodes.size, edgeCount, EDGE_KIND_LABELS[edge.kind]);
+  }
+
+  function clearChainSelection() {
+    if (!chainFilter && !chainEdge && !chainOverlay) return;
+    chainFilter = null;
+    chainEdge = null;
+    chainOverlay?.remove();
+    chainOverlay = null;
+    setNodeVisibilityFromState();
+    rebuildVisibleEdges();
+  }
+
+  function showChainOverlay(
+    nodeCount: number,
+    edgeCount: number,
+    kindLabel: string,
+  ) {
+    if (!chainOverlay)
+      chainOverlay = createChainOverlay(() => clearChainSelection());
+    chainOverlay.update(nodeCount, edgeCount, kindLabel);
   }
 
   function applyFocusModeIfEnabled(selectedNodeId: string) {
@@ -801,6 +860,9 @@ export async function mount(
     simulation?.stop();
     onboarding?.overlay.remove();
     onboarding = null;
+    // Clear any chain isolation from a prior graph: edge identity is
+    // graph-scoped, so the previous selection is meaningless once we reload.
+    clearChainSelection();
 
     if (nodes) {
       ctx.scene.remove(nodes.mesh);
@@ -926,6 +988,57 @@ export async function mount(
             /* container may have been destroyed during load */
           }
         }, 300);
+      },
+    };
+  }
+
+  function createChainOverlay(onClear: () => void): {
+    update(nodeCount: number, edgeCount: number, label: string): void;
+    remove(): void;
+  } {
+    const el = document.createElement("div");
+    el.setAttribute("data-ui-overlay", "true");
+    el.style.cssText = `
+      position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
+      display: flex; align-items: center; gap: 10px;
+      padding: 6px 10px 6px 12px; border: 1px solid #${theme.border};
+      background: rgba(7,8,13,0.78); color: #${theme.fg};
+      font: 11px/1.2 var(--theia-font, ${FONT_STACK}); letter-spacing: 0.08em;
+      text-transform: uppercase; border-radius: ${theme.radius};
+      z-index: 13; cursor: default; backdrop-filter: blur(4px);
+    `;
+    const label = document.createElement("span");
+    el.appendChild(label);
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.textContent = "✕";
+    btn.setAttribute("aria-label", "Clear chain selection");
+    btn.style.cssText = `
+      appearance: none; border: 0; background: transparent; cursor: pointer;
+      color: #${theme.fg2}; font: inherit; padding: 0 2px; line-height: 1;
+    `;
+    btn.onmouseenter = () => {
+      btn.style.color = `#${theme.accent}`;
+    };
+    btn.onmouseleave = () => {
+      btn.style.color = `#${theme.fg2}`;
+    };
+    btn.onclick = (e) => {
+      e.stopPropagation();
+      onClear();
+    };
+    el.appendChild(btn);
+    element.appendChild(el);
+    return {
+      update(nodeCount, edgeCount, kindLabel) {
+        label.textContent = `chain · ${kindLabel} · ${nodeCount} node${nodeCount === 1 ? "" : "s"}, ${edgeCount} edge${edgeCount === 1 ? "" : "s"}`;
+      },
+      remove() {
+        try {
+          element.removeChild(el);
+        } catch {
+          /* container may have been destroyed */
+        }
       },
     };
   }
@@ -1076,8 +1189,21 @@ export async function mount(
         applyFocusModeIfEnabled(n.id);
         emit("node-click", n.id);
       } else {
-        clearSelected();
-        sidePanel.hide();
+        const pickedEdge = edges.pickAt(
+          ctx.camera,
+          element,
+          e.clientX,
+          e.clientY,
+        );
+        if (pickedEdge && kinds.has(pickedEdge.kind)) {
+          clearSelected();
+          sidePanel.hide();
+          applyChainSelection(pickedEdge);
+        } else {
+          clearChainSelection();
+          clearSelected();
+          sidePanel.hide();
+        }
       }
     }
     resetDrag();
@@ -1089,6 +1215,13 @@ export async function mount(
   element.addEventListener("contextmenu", (e) => {
     e.preventDefault();
   });
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape" && chainFilter) {
+      clearChainSelection();
+    }
+  };
+  window.addEventListener("keydown", onKeyDown);
 
   // Wheel zoom — let overlay UI (side panel, filter bar, search bar) scroll naturally
   element.addEventListener(
@@ -1117,6 +1250,9 @@ export async function mount(
       modelFilter = state.model;
       saveFilterState(kinds, modelFilter, searchFocusEnabled);
       focusFilter = null;
+      // Filter changes can invalidate the chain (an edge kind we traversed
+      // through may now be hidden); drop the chain rather than recompute it.
+      clearChainSelection();
       updateVisibility();
       const id = sidePanel.currentNodeId();
       if (id) applyFocusModeIfEnabled(id);
@@ -1158,6 +1294,9 @@ export async function mount(
       savePhysicsSnapshot();
       onboarding?.overlay.remove();
       window.removeEventListener("mouseup", resetDrag);
+      window.removeEventListener("keydown", onKeyDown);
+      chainOverlay?.remove();
+      chainOverlay = null;
       searchInputController?.abort();
       if (searchFocusTimer) clearTimeout(searchFocusTimer);
       stopThemeListener();

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -255,9 +255,32 @@ export async function mount(
     }
     simNodes = nextNodes;
     simulation.alpha(animateNew ? 0.22 : simulation.alphaTarget());
+    wakePhysics();
+  }
+
+  // Settled-physics gate: skip the per-frame sim/lerp/edge-rewrite when
+  // the layout has stabilised. The lerp drives matrix uploads and a full
+  // edge-position attribute rewrite every frame; with 1.6k nodes that's
+  // most of the per-frame cost once the simulation has converged.
+  let settledFrames = 0;
+  const SETTLED_THRESHOLD = 30;
+  // Threshold ≈ 0.001² in world units — well below visible motion at any
+  // reasonable zoom, since node sizes top out at 0.18 (see Nodes.ts).
+  const SETTLE_EPSILON_SQ = 1e-6;
+  // Energy injected on wake so filter/visibility changes actually produce
+  // a visible re-equilibration. Without this, alpha sits at alphaTarget
+  // (0.012, see Simulation.ts) which makes wake invisible — sub-pixel
+  // motion that re-settles within a few ticks.
+  const WAKE_ALPHA = 0.18;
+  function wakePhysics() {
+    settledFrames = 0;
+    if (simulation && simulation.alpha() < WAKE_ALPHA) {
+      simulation.alpha(WAKE_ALPHA);
+    }
   }
 
   function syncRenderedPositionsFromSimulation() {
+    wakePhysics();
     for (let i = 0; i < simNodes.length; i++) {
       const sn = simNodes[i];
       if (!sn) continue;
@@ -521,6 +544,11 @@ export async function mount(
       nodes.setVisible(i, activeIds.has(currentGraph.nodes[i]!.id));
     }
     nodes.flush();
+    // Filter/focus toggles change the active set without going through
+    // replaceSimulation; wake physics so the layout can re-equilibrate
+    // for the new visible node set. The gate will re-arm after the
+    // simulation re-settles.
+    wakePhysics();
   }
 
   const EDGE_KIND_LABELS: Record<TheiaGraph["edges"][number]["kind"], string> =
@@ -947,17 +975,24 @@ export async function mount(
   }
 
   function tick() {
+    if (settledFrames >= SETTLED_THRESHOLD) return;
     simulation.tick(1);
     const smoothing = onboarding ? 0.14 : 0.34;
+    let maxDeltaSq = 0;
     for (let i = 0; i < simNodes.length; i++) {
       const sn = simNodes[i];
       if (!sn) continue;
       const px = renderedPositions[i * 3]!;
       const py = renderedPositions[i * 3 + 1]!;
       const pz = renderedPositions[i * 3 + 2]!;
-      const x = px + (sn.x - px) * smoothing;
-      const y = py + (sn.y - py) * smoothing;
-      const z = pz + (sn.z - pz) * smoothing;
+      const dx = (sn.x - px) * smoothing;
+      const dy = (sn.y - py) * smoothing;
+      const dz = (sn.z - pz) * smoothing;
+      const x = px + dx;
+      const y = py + dy;
+      const z = pz + dz;
+      const deltaSq = dx * dx + dy * dy + dz * dz;
+      if (deltaSq > maxDeltaSq) maxDeltaSq = deltaSq;
       renderedPositions[i * 3] = x;
       renderedPositions[i * 3 + 1] = y;
       renderedPositions[i * 3 + 2] = z;
@@ -965,6 +1000,8 @@ export async function mount(
     }
     nodes.flush();
     edges.updatePositions(nodePositions);
+    if (maxDeltaSq < SETTLE_EPSILON_SQ) settledFrames++;
+    else settledFrames = 0;
   }
 
   let disposed = false;
@@ -979,7 +1016,6 @@ export async function mount(
     const t = now / 1000;
     nodes.setTime(t);
     edges.setTime(t);
-    nodes.setCameraPosition(ctx.camera.position);
     post.renderEdges(edgesScene, ctx.camera);
     post.render();
     requestAnimationFrame(frame);

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -1325,6 +1325,31 @@ export async function mount(
     }
   });
 
+  function runTapSelection(clientX: number, clientY: number) {
+    const idx = picker.pickAt(clientX, clientY, 1.0);
+    if (idx !== null) {
+      select(idx);
+      const n = currentGraph.nodes[idx]!;
+      const related = currentGraph.edges.filter(
+        (e) => (e.source === n.id || e.target === n.id) && kinds.has(e.kind),
+      );
+      enterPanelMode(n, related);
+      applyFocusModeIfEnabled(n.id);
+      emit("node-click", n.id);
+      return;
+    }
+    const pickedEdge = edges.pickAt(ctx.camera, element, clientX, clientY);
+    if (pickedEdge && kinds.has(pickedEdge.kind)) {
+      clearSelected();
+      sidePanel.hide();
+      applyChainSelection(pickedEdge);
+    } else {
+      clearChainSelection();
+      clearSelected();
+      sidePanel.hide();
+    }
+  }
+
   element.addEventListener("mouseup", (e) => {
     const target = e.target as HTMLElement;
     if (target.closest("aside") || target.closest("[data-ui-overlay]")) {
@@ -1332,39 +1357,66 @@ export async function mount(
       return;
     }
     if (isMouseDown && !hasDragged && performance.now() - lastWheelAt >= 200) {
-      const idx = picker.pickAt(e.clientX, e.clientY, 1.0);
-      if (idx !== null) {
-        select(idx);
-        const n = currentGraph.nodes[idx]!;
-        const related = currentGraph.edges.filter(
-          (e) => (e.source === n.id || e.target === n.id) && kinds.has(e.kind),
-        );
-        enterPanelMode(n, related);
-        applyFocusModeIfEnabled(n.id);
-        emit("node-click", n.id);
-      } else {
-        const pickedEdge = edges.pickAt(
-          ctx.camera,
-          element,
-          e.clientX,
-          e.clientY,
-        );
-        if (pickedEdge && kinds.has(pickedEdge.kind)) {
-          clearSelected();
-          sidePanel.hide();
-          applyChainSelection(pickedEdge);
-        } else {
-          clearChainSelection();
-          clearSelected();
-          sidePanel.hide();
-        }
-      }
+      runTapSelection(e.clientX, e.clientY);
     }
     resetDrag();
   });
 
   // Catch mouseup outside the element/viewport to prevent stuck drag states
   window.addEventListener("mouseup", resetDrag);
+
+  // Touch tap-to-select. We do not synthesize pan/orbit from touch — that's
+  // a future enhancement. preventDefault on a recognized tap suppresses the
+  // synthetic mouse event chain so we don't double-select.
+  let touchStartPos: { x: number; y: number } | null = null;
+  let touchStartAt = 0;
+  const TAP_MAX_MOVE_PX = 10;
+  const TAP_MAX_DURATION_MS = 500;
+
+  element.addEventListener(
+    "touchstart",
+    (e) => {
+      const target = e.target as HTMLElement;
+      if (target.closest("aside") || target.closest("[data-ui-overlay]")) {
+        touchStartPos = null;
+        return;
+      }
+      if (e.touches.length !== 1) {
+        touchStartPos = null;
+        return;
+      }
+      const t = e.touches[0]!;
+      touchStartPos = { x: t.clientX, y: t.clientY };
+      touchStartAt = performance.now();
+    },
+    { passive: true },
+  );
+
+  element.addEventListener("touchmove", (e) => {
+    if (!touchStartPos || e.touches.length !== 1) return;
+    const t = e.touches[0]!;
+    const dx = t.clientX - touchStartPos.x;
+    const dy = t.clientY - touchStartPos.y;
+    if (Math.abs(dx) > TAP_MAX_MOVE_PX || Math.abs(dy) > TAP_MAX_MOVE_PX) {
+      touchStartPos = null;
+    }
+  });
+
+  element.addEventListener("touchend", (e) => {
+    if (!touchStartPos) return;
+    const elapsed = performance.now() - touchStartAt;
+    const startPos = touchStartPos;
+    touchStartPos = null;
+    if (elapsed > TAP_MAX_DURATION_MS) return;
+    // Suppress synthetic mouse events so the mouseup handler doesn't re-run
+    // the same selection a moment later.
+    e.preventDefault();
+    runTapSelection(startPos.x, startPos.y);
+  });
+
+  element.addEventListener("touchcancel", () => {
+    touchStartPos = null;
+  });
 
   element.addEventListener("contextmenu", (e) => {
     e.preventDefault();

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -427,12 +427,42 @@ export async function mount(
   }
 
   const tooltip = createTooltip(element, theme);
+
+  function selectedNodeId(): string | null {
+    return selectedIdx === null ? null : currentGraph.nodes[selectedIdx]!.id;
+  }
+
+  function relatedNodeIds(nodeId: string): Set<string> {
+    const related = new Set<string>([nodeId]);
+    for (const edge of currentGraph.edges) {
+      if (!kinds.has(edge.kind)) continue;
+      if (edge.source === nodeId) related.add(edge.target);
+      else if (edge.target === nodeId) related.add(edge.source);
+    }
+    return related;
+  }
+
+  function applyDimAround(nodeId: string | null) {
+    if (nodeId === null) {
+      for (let i = 0; i < nodes.count; i++) nodes.setDim(i, false);
+      nodes.flush();
+      return;
+    }
+    const related = relatedNodeIds(nodeId);
+    for (let i = 0; i < nodes.count; i++) {
+      nodes.setDim(i, !related.has(currentGraph.nodes[i]!.id));
+    }
+    nodes.flush();
+  }
+
   function clearSelected() {
     if (selectedIdx !== null) {
       nodes.setSelected(selectedIdx, false);
       nodes.setHighlight(selectedIdx, false);
       selectedIdx = null;
     }
+    edges.setHoverNode(null);
+    applyDimAround(null);
   }
 
   function select(idx: number) {
@@ -440,6 +470,8 @@ export async function mount(
     selectedIdx = idx;
     nodes.setSelected(idx, true);
     nodes.setHighlight(idx, false);
+    edges.setHoverNode(currentGraph.nodes[idx]!.id);
+    if (!focusEnabled) applyDimAround(currentGraph.nodes[idx]!.id);
   }
 
   function enterPanelMode(
@@ -1007,17 +1039,24 @@ export async function mount(
           return false;
         return true;
       },
+      getEdges: () => edges.visibleEdges(),
     });
     picker.onHover((idx) => {
       const nodeId = idx === null ? null : currentGraph.nodes[idx]!.id;
       element.style.cursor = idx === null ? "" : "pointer";
-      edges.setHoverNode(nodeId);
+      const focusId = nodeId ?? selectedNodeId();
+      edges.setHoverNode(focusId);
       for (let i = 0; i < nodes.count; i++) {
         if (i === idx) {
           nodes.setHighlight(i, true);
         } else if (i !== selectedIdx) {
           nodes.setHighlight(i, false);
         }
+      }
+      if (focusEnabled) {
+        applyDimAround(null);
+      } else {
+        applyDimAround(focusId);
       }
       if (idx !== null) {
         tooltip.show(currentGraph.nodes[idx]!, lastMouse.x, lastMouse.y);
@@ -1026,6 +1065,14 @@ export async function mount(
       }
       nodes.flush();
       emit("node-hover", idx === null ? null : currentGraph.nodes[idx]!.id);
+    });
+    picker.onHoverEdge((edge) => {
+      edges.setHoverEdge(edge);
+      if (edge !== null) {
+        element.style.cursor = "pointer";
+      } else if (picker.currentHovered() === null) {
+        element.style.cursor = "";
+      }
     });
 
     searchInputController?.abort();

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -648,9 +648,9 @@ export async function mount(
       setNodeVisibilityFromState();
       rebuildVisibleEdges();
       simState.replaceActive({
-      activeIds: activeVisibleNodeIds(),
-      animateNew: true,
-    });
+        activeIds: activeVisibleNodeIds(),
+        animateNew: true,
+      });
     }
     onboarding.lastEase = eased;
     onboarding.overlay.update(eased);

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -21,7 +21,7 @@ import type { ThemeTokens } from "./ui/Theme";
 import {
   createLoadingOverlay,
   createChainOverlay,
-  createOptimizeOverlay,
+  createControlsOverlay,
 } from "./ui/Overlays";
 import {
   VALID_KINDS,
@@ -100,6 +100,7 @@ export async function mount(
   let searchFocusEnabled = saved?.searchFocus ?? false;
   let hideOrphansEnabled = saved?.hideOrphans ?? false;
   let componentFocusEnabled = saved?.componentFocus ?? false;
+  let jumpToNodeEnabled = true;
   let focusFilter: Set<string> | null = null;
   let componentFilter: Set<string> | null = null;
   let chainFilter: Set<string> | null = null;
@@ -276,7 +277,7 @@ export async function mount(
       const sn = simState.getNodePosition(idx);
       if (!sn) return;
       select(idx);
-      ctx.focusOn(sn.x, sn.y, 1.5);
+      if (jumpToNodeEnabled) ctx.focusOn(sn.x, sn.y, 1.5);
       const n = currentGraph.nodes[idx]!;
       const related = currentGraph.edges.filter(
         (e) => (e.source === n.id || e.target === n.id) && kinds.has(e.kind),
@@ -613,7 +614,7 @@ export async function mount(
         const idx = nodeIndex.get(result.node.id);
         if (idx !== undefined && activeVisibleNodeIds().has(result.node.id)) {
           const sn = simState.getNodePosition(idx);
-          if (sn) ctx.focusOn(sn.x, sn.y, 1.5);
+          if (sn && jumpToNodeEnabled) ctx.focusOn(sn.x, sn.y, 1.5);
           select(idx);
         }
         const related = currentGraph.edges.filter(
@@ -880,8 +881,13 @@ export async function mount(
     },
   );
 
-  const optimizeOverlay = createOptimizeOverlay(element, theme, () => {
-    simState.optimize();
+  const controlsOverlay = createControlsOverlay(element, theme, {
+    onOptimize: () => simState.optimize(),
+    onHome: () => ctx.resetView(),
+    onJumpToggle: (enabled) => {
+      jumpToNodeEnabled = enabled;
+    },
+    initialJumpEnabled: jumpToNodeEnabled,
   });
 
   const listeners: Record<string, Array<(...args: unknown[]) => void>> = {
@@ -910,7 +916,7 @@ export async function mount(
       window.removeEventListener("keydown", onKeyDown);
       chainOverlay?.remove();
       chainOverlay = null;
-      optimizeOverlay.remove();
+      controlsOverlay.remove();
       searchInputController?.abort();
       if (searchFocusTimer) clearTimeout(searchFocusTimer);
       stopThemeListener();

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -155,6 +155,7 @@ export async function mount(
     revealStartedAtByIndex: Map<number, number>;
     linkStartedAtByKey: Map<string, number>;
     lastRevealedCount: number;
+    lastHeavyRebuildAt: number;
     lastEase: number;
     cameraZoom: number;
     cameraAutoZoomEnabled: boolean;
@@ -560,6 +561,7 @@ export async function mount(
       revealStartedAtByIndex: new Map(),
       linkStartedAtByKey: new Map(),
       lastRevealedCount: 0,
+      lastHeavyRebuildAt: 0,
       lastEase: 0,
       cameraZoom: ONBOARDING_BASE_ZOOM,
       cameraAutoZoomEnabled: true,
@@ -643,8 +645,29 @@ export async function mount(
       ctx.setCameraState({ ...state, theta: state.theta + rotationDelta });
     }
 
-    if (revealCount !== onboarding.lastRevealedCount) {
-      onboarding.lastRevealedCount = revealCount;
+    // Heavy rebuild throttle. Each rebuild iterates all 1.6k nodes
+    // (setNodeVisibilityFromState), regenerates the entire edges
+    // geometry (rebuildVisibleEdges), and asks the worker to recreate
+    // the d3-force-3d simulation for the new active set. With reveals
+    // crossing integer boundaries multiple times per frame at 60Hz, the
+    // un-throttled version fires this on essentially every frame —
+    // which was the source of the visible reveal-period FPS drop.
+    //
+    // Throttle to ~150ms; always force a final rebuild when the last
+    // node has been revealed so the simulation gets the full active
+    // set before settling. setRevealScale on individual nodes still
+    // happens every frame inside the loop above, so the visual reveal
+    // animation continues smoothly between rebuilds.
+    const HEAVY_REBUILD_INTERVAL_MS = 150;
+    const sawNewReveals = revealCount !== onboarding.lastRevealedCount;
+    onboarding.lastRevealedCount = revealCount;
+    const finalReveal = revealCount === onboarding.order.length;
+    if (
+      sawNewReveals &&
+      (finalReveal ||
+        now - onboarding.lastHeavyRebuildAt > HEAVY_REBUILD_INTERVAL_MS)
+    ) {
+      onboarding.lastHeavyRebuildAt = now;
       setNodeVisibilityFromState();
       rebuildVisibleEdges();
       simState.replaceActive({

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -877,6 +877,7 @@ export async function mount(
         if (idx !== undefined && activeVisibleNodeIds().has(result.node.id)) {
           const sn = simNodes[idx];
           if (sn) ctx.focusOn(sn.x, sn.y, 1.5);
+          select(idx);
         }
         const related = currentGraph.edges.filter(
           (e) =>
@@ -884,6 +885,7 @@ export async function mount(
             kinds.has(e.kind),
         );
         enterPanelMode(result.node, related);
+        applyFocusModeIfEnabled(result.node.id);
       },
       theme,
       (node) => activeVisibleNodeIds().has(node.id),

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -5,8 +5,11 @@ import { createScene } from "./scene/Scene";
 import { createNodes, type NodeLayer } from "./scene/Nodes";
 import { createEdges } from "./scene/Edges";
 import { createPost } from "./scene/Post";
-import { createSimulation } from "./physics/Simulation";
 import { createPicker } from "./scene/Picker";
+import {
+  createSimulationState,
+  type SimulationState,
+} from "./state/simulation";
 import { createKeyboardNav } from "./scene/KeyboardNav";
 import { computeEdgeChain } from "./scene/chain";
 import { createTooltip } from "./ui/Tooltip";
@@ -27,11 +30,7 @@ import {
   saveFilterState,
   computeVisibleNodeIds,
 } from "./state/filterState";
-import {
-  createPhysicsSnapshotIO,
-  type PhysicsSnapshotNode,
-} from "./state/physicsSnapshot";
-import { hashN11 } from "./util/hash";
+import { createPhysicsSnapshotIO } from "./state/physicsSnapshot";
 
 export interface PanelOptions {
   edgeKinds?: TheiaGraph["edges"][number]["kind"][];
@@ -171,127 +170,13 @@ export async function mount(
   let nodes: NodeLayer;
   let nodeIndex = new Map<string, number>();
   let nodePositions = new Float32Array(0);
-  let simNodes: ReturnType<typeof createSimulation>["nodes"] = [];
-  let simulation: ReturnType<typeof createSimulation>["simulation"];
-  let renderedPositions = new Float32Array(0);
+  let simState: SimulationState;
   let picker: ReturnType<typeof createPicker>;
   const keyboardNav = createKeyboardNav(ctx);
   let searchBar: ReturnType<typeof createSearchBar>;
   let selectedIdx: number | null = null;
   let currentGraphUrl = graphUrl;
   const physicsSnapshotIO = createPhysicsSnapshotIO();
-
-  function simulationGraphFor(activeIds: Set<string> | null): TheiaGraph {
-    if (!activeIds) return currentGraph;
-    return {
-      ...currentGraph,
-      nodes: currentGraph.nodes.filter((node) => activeIds.has(node.id)),
-      edges: currentGraph.edges.filter(
-        (edge) => activeIds.has(edge.source) && activeIds.has(edge.target),
-      ),
-    };
-  }
-
-  function replaceSimulation(
-    activeIds: Set<string> | null,
-    animateNew = false,
-    preserveExisting = true,
-    seedPositions = new Map<string, PhysicsSnapshotNode>(),
-  ) {
-    const oldPositions = new Map<
-      string,
-      { x: number; y: number; z: number; vx?: number; vy?: number; vz?: number }
-    >();
-    for (const sn of simNodes) {
-      if (sn) {
-        oldPositions.set(sn.id, {
-          x: sn.x,
-          y: sn.y,
-          z: sn.z,
-          vx: sn.vx,
-          vy: sn.vy,
-          vz: sn.vz,
-        });
-      }
-    }
-
-    simulation?.stop();
-    const simResult = createSimulation(
-      simulationGraphFor(activeIds),
-      kinds,
-      onboarding && !onboarding.complete ? "onboarding" : "normal",
-    );
-    simulation = simResult.simulation;
-    simulation.stop();
-
-    const nextNodes = new Array(currentGraph.nodes.length) as typeof simNodes;
-    for (const sn of simResult.nodes) {
-      const idx = nodeIndex.get(sn.id);
-      if (idx === undefined) continue;
-      const old = preserveExisting ? oldPositions.get(sn.id) : undefined;
-      const seed = seedPositions.get(sn.id);
-      if (old || seed) {
-        const source = old ?? seed!;
-        sn.x = source.x;
-        sn.y = source.y;
-        sn.z = source.z;
-        sn.vx = source.vx ?? 0;
-        sn.vy = source.vy ?? 0;
-        sn.vz = source.vz ?? 0;
-      } else if (animateNew) {
-        const jitter = 0.08;
-        sn.x = sn.anchorX * 0.55 + hashN11(`${sn.id}:x`) * jitter;
-        sn.y = sn.anchorY * 0.55 + hashN11(`${sn.id}:y`) * jitter;
-        sn.z = sn.anchorZ * 0.55 + hashN11(`${sn.id}:z`) * jitter;
-        sn.vx = (sn.anchorX - sn.x) * 0.006;
-        sn.vy = (sn.anchorY - sn.y) * 0.006;
-        sn.vz = (sn.anchorZ - sn.z) * 0.006;
-        renderedPositions[idx * 3] = sn.x;
-        renderedPositions[idx * 3 + 1] = sn.y;
-        renderedPositions[idx * 3 + 2] = sn.z;
-        nodes?.setPosition(idx, sn.x, sn.y, sn.z);
-      }
-      nextNodes[idx] = sn;
-    }
-    simNodes = nextNodes;
-    simulation.alpha(animateNew ? 0.22 : simulation.alphaTarget());
-    wakePhysics();
-  }
-
-  // Settled-physics gate: skip the per-frame sim/lerp/edge-rewrite when
-  // the layout has stabilised. The lerp drives matrix uploads and a full
-  // edge-position attribute rewrite every frame; with 1.6k nodes that's
-  // most of the per-frame cost once the simulation has converged.
-  let settledFrames = 0;
-  const SETTLED_THRESHOLD = 30;
-  // Threshold ≈ 0.001² in world units — well below visible motion at any
-  // reasonable zoom, since node sizes top out at 0.18 (see Nodes.ts).
-  const SETTLE_EPSILON_SQ = 1e-6;
-  // Energy injected on wake so filter/visibility changes actually produce
-  // a visible re-equilibration. Without this, alpha sits at alphaTarget
-  // (0.012, see Simulation.ts) which makes wake invisible — sub-pixel
-  // motion that re-settles within a few ticks.
-  const WAKE_ALPHA = 0.18;
-  function wakePhysics() {
-    settledFrames = 0;
-    if (simulation && simulation.alpha() < WAKE_ALPHA) {
-      simulation.alpha(WAKE_ALPHA);
-    }
-  }
-
-  function syncRenderedPositionsFromSimulation() {
-    wakePhysics();
-    for (let i = 0; i < simNodes.length; i++) {
-      const sn = simNodes[i];
-      if (!sn) continue;
-      renderedPositions[i * 3] = sn.x;
-      renderedPositions[i * 3 + 1] = sn.y;
-      renderedPositions[i * 3 + 2] = sn.z;
-      nodes.setPosition(i, sn.x, sn.y, sn.z);
-    }
-    nodes.flush();
-    edges.updatePositions(nodePositions);
-  }
 
   function canSavePhysicsSnapshot(): boolean {
     if (!currentGraph || !hasCompletedOnboarding()) return false;
@@ -301,14 +186,18 @@ export async function mount(
 
   function savePhysicsSnapshot() {
     if (!canSavePhysicsSnapshot()) return;
-    physicsSnapshotIO.save(currentGraphUrl, simNodes, ctx.getCameraState());
+    physicsSnapshotIO.save(
+      currentGraphUrl,
+      simState.getSimNodes(),
+      ctx.getCameraState(),
+    );
   }
 
   function maybeSavePhysicsSnapshot(now: number) {
     physicsSnapshotIO.maybeSave(
       now,
       currentGraphUrl,
-      simNodes,
+      simState.getSimNodes(),
       () => ctx.getCameraState(),
       canSavePhysicsSnapshot(),
     );
@@ -436,7 +325,7 @@ export async function mount(
     onNavigate: (targetId) => {
       const idx = nodeIndex.get(targetId);
       if (idx === undefined || !activeVisibleNodeIds().has(targetId)) return;
-      const sn = simNodes[idx];
+      const sn = simState.getNodePosition(idx);
       if (!sn) return;
       select(idx);
       ctx.focusOn(sn.x, sn.y, 1.5);
@@ -521,7 +410,9 @@ export async function mount(
     setNodeVisibilityFromState();
 
     // Start at equilibrium to prevent jittery readjustment.
-    replaceSimulation(onboarding ? activeVisibleNodeIds() : null);
+    simState.replaceActive({
+      activeIds: onboarding ? activeVisibleNodeIds() : null,
+    });
 
     rebuildVisibleEdges();
     return searchMatchesChanged;
@@ -545,10 +436,10 @@ export async function mount(
     }
     nodes.flush();
     // Filter/focus toggles change the active set without going through
-    // replaceSimulation; wake physics so the layout can re-equilibrate
-    // for the new visible node set. The gate will re-arm after the
+    // replaceActive; wake physics so the layout can re-equilibrate for
+    // the new visible node set. The gate will re-arm after the
     // simulation re-settles.
-    wakePhysics();
+    simState.wakePhysics();
   }
 
   const EDGE_KIND_LABELS: Record<TheiaGraph["edges"][number]["kind"], string> =
@@ -682,7 +573,10 @@ export async function mount(
     }
     setNodeVisibilityFromState();
     rebuildVisibleEdges();
-    replaceSimulation(activeVisibleNodeIds(), true);
+    simState.replaceActive({
+      activeIds: activeVisibleNodeIds(),
+      animateNew: true,
+    });
   }
 
   function updateOnboardingLinks(now: number) {
@@ -753,7 +647,10 @@ export async function mount(
       onboarding.lastRevealedCount = revealCount;
       setNodeVisibilityFromState();
       rebuildVisibleEdges();
-      replaceSimulation(activeVisibleNodeIds(), true);
+      simState.replaceActive({
+      activeIds: activeVisibleNodeIds(),
+      animateNew: true,
+    });
     }
     onboarding.lastEase = eased;
     onboarding.overlay.update(eased);
@@ -804,9 +701,12 @@ export async function mount(
       if (!onboarding.revealedNodeIds.has(currentGraph.nodes[idx]!.id)) {
         continue;
       }
-      const dx = renderedPositions[idx * 3]! - ctx.camera.position.x;
-      const dy = renderedPositions[idx * 3 + 1]! - ctx.camera.position.y;
-      const dz = renderedPositions[idx * 3 + 2]! - ctx.camera.position.z;
+      // nodePositions tracks the same per-frame smoothed values that the
+      // simulation tick writes; reading from there avoids reaching into
+      // the simulation module's private renderedPositions buffer.
+      const dx = nodePositions[idx * 3]! - ctx.camera.position.x;
+      const dy = nodePositions[idx * 3 + 1]! - ctx.camera.position.y;
+      const dz = nodePositions[idx * 3 + 2]! - ctx.camera.position.z;
       nearest = Math.min(nearest, Math.sqrt(dx * dx + dy * dy + dz * dz));
     }
     if (!Number.isFinite(nearest)) return;
@@ -827,7 +727,7 @@ export async function mount(
   }
 
   function setupGraph(g: TheiaGraph) {
-    simulation?.stop();
+    simState?.dispose();
     onboarding?.overlay.remove();
     onboarding = null;
     // Clear any chain isolation from a prior graph: edge identity is
@@ -841,23 +741,35 @@ export async function mount(
 
     currentGraph = g;
     nodePositions = new Float32Array(g.nodes.length * 3);
-    renderedPositions = new Float32Array(g.nodes.length * 3);
     nodes = createNodes(g, nodePositions);
     ctx.scene.add(nodes.mesh);
 
     nodeIndex = new Map(g.nodes.map((n, i) => [n.id, i]));
+    simState = createSimulationState({
+      graph: g,
+      kinds,
+      isOnboarding: () => Boolean(onboarding && !onboarding.complete),
+      nodes,
+      edges,
+      nodePositions,
+    });
 
     if (hasCompletedOnboarding()) {
       const snapshot = physicsSnapshotIO.load(currentGraphUrl);
-      replaceSimulation(null, true, false, snapshot.nodes);
-      syncRenderedPositionsFromSimulation();
+      simState.replaceActive({
+        activeIds: null,
+        animateNew: true,
+        preserveExisting: false,
+        seedPositions: snapshot.nodes,
+      });
+      simState.syncRenderedPositionsFromSimulation();
       if (snapshot.camera) {
         ctx.setCameraState(snapshot.camera);
       }
     } else {
-      replaceSimulation(null);
-      simulation.tick(1);
-      syncRenderedPositionsFromSimulation();
+      simState.replaceActive({ activeIds: null });
+      simState.primeOnce();
+      simState.syncRenderedPositionsFromSimulation();
     }
 
     visibleNodeIds = computeVisibleNodeIds(
@@ -927,7 +839,7 @@ export async function mount(
       (result) => {
         const idx = nodeIndex.get(result.node.id);
         if (idx !== undefined && activeVisibleNodeIds().has(result.node.id)) {
-          const sn = simNodes[idx];
+          const sn = simState.getNodePosition(idx);
           if (sn) ctx.focusOn(sn.x, sn.y, 1.5);
           select(idx);
         }
@@ -974,43 +886,13 @@ export async function mount(
     beginOnboarding(initialGraph);
   }
 
-  function tick() {
-    if (settledFrames >= SETTLED_THRESHOLD) return;
-    simulation.tick(1);
-    const smoothing = onboarding ? 0.14 : 0.34;
-    let maxDeltaSq = 0;
-    for (let i = 0; i < simNodes.length; i++) {
-      const sn = simNodes[i];
-      if (!sn) continue;
-      const px = renderedPositions[i * 3]!;
-      const py = renderedPositions[i * 3 + 1]!;
-      const pz = renderedPositions[i * 3 + 2]!;
-      const dx = (sn.x - px) * smoothing;
-      const dy = (sn.y - py) * smoothing;
-      const dz = (sn.z - pz) * smoothing;
-      const x = px + dx;
-      const y = py + dy;
-      const z = pz + dz;
-      const deltaSq = dx * dx + dy * dy + dz * dz;
-      if (deltaSq > maxDeltaSq) maxDeltaSq = deltaSq;
-      renderedPositions[i * 3] = x;
-      renderedPositions[i * 3 + 1] = y;
-      renderedPositions[i * 3 + 2] = z;
-      nodes.setPosition(i, x, y, z);
-    }
-    nodes.flush();
-    edges.updatePositions(nodePositions);
-    if (maxDeltaSq < SETTLE_EPSILON_SQ) settledFrames++;
-    else settledFrames = 0;
-  }
-
   let disposed = false;
   function frame() {
     if (disposed) return;
     const now = performance.now();
     updateOnboarding(now);
     keyboardNav.tick(now);
-    tick();
+    simState.tick();
     maybeSavePhysicsSnapshot(now);
     updateOnboardingCamera();
     const t = now / 1000;
@@ -1257,7 +1139,7 @@ export async function mount(
       searchInputController?.abort();
       if (searchFocusTimer) clearTimeout(searchFocusTimer);
       stopThemeListener();
-      simulation.stop();
+      simState.dispose();
       nodes.dispose();
       edges.dispose();
       post.edgesTarget.dispose();

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -663,7 +663,7 @@ export async function mount(
     keyboardNav.tick(now);
     simState.tick();
     maybeSavePhysicsSnapshot(now);
-    onboarding.updateCamera();
+    onboarding.updateCamera(now);
     const t = now / 1000;
     nodes.setTime(t);
     edges.setTime(t);

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -18,7 +18,11 @@ import { createSearchBar } from "./ui/SearchBar";
 import { createSidePanel } from "./ui/SidePanel";
 import { readTheme, applyTheme, onThemeMessage } from "./ui/Theme";
 import type { ThemeTokens } from "./ui/Theme";
-import { createLoadingOverlay, createChainOverlay } from "./ui/Overlays";
+import {
+  createLoadingOverlay,
+  createChainOverlay,
+  createOptimizeOverlay,
+} from "./ui/Overlays";
 import {
   VALID_KINDS,
   DEFAULT_KINDS,
@@ -876,6 +880,10 @@ export async function mount(
     },
   );
 
+  const optimizeOverlay = createOptimizeOverlay(element, theme, () => {
+    simState.optimize();
+  });
+
   const listeners: Record<string, Array<(...args: unknown[]) => void>> = {
     "node-click": [],
     "node-hover": [],
@@ -902,6 +910,7 @@ export async function mount(
       window.removeEventListener("keydown", onKeyDown);
       chainOverlay?.remove();
       chainOverlay = null;
+      optimizeOverlay.remove();
       searchInputController?.abort();
       if (searchFocusTimer) clearTimeout(searchFocusTimer);
       stopThemeListener();

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -726,6 +726,10 @@ export async function mount(
     const idx = picker.pickAt(clientX, clientY, 1.0);
     if (idx !== null) {
       select(idx);
+      if (jumpToNodeEnabled) {
+        const sn = simState.getNodePosition(idx);
+        if (sn) ctx.focusOn(sn.x, sn.y, 1.5);
+      }
       const n = currentGraph.nodes[idx]!;
       const related = currentGraph.edges.filter(
         (e) => (e.source === n.id || e.target === n.id) && kinds.has(e.kind),

--- a/theia-panel/src/index.ts
+++ b/theia-panel/src/index.ts
@@ -7,6 +7,7 @@ import { createEdges } from "./scene/Edges";
 import { createPost } from "./scene/Post";
 import { createSimulation } from "./physics/Simulation";
 import { createPicker } from "./scene/Picker";
+import { createKeyboardNav } from "./scene/KeyboardNav";
 import { computeEdgeChain } from "./scene/chain";
 import { createTooltip } from "./ui/Tooltip";
 import { createFilterBar } from "./ui/FilterBar";
@@ -241,6 +242,7 @@ export async function mount(
   let simulation: ReturnType<typeof createSimulation>["simulation"];
   let renderedPositions = new Float32Array(0);
   let picker: ReturnType<typeof createPicker>;
+  const keyboardNav = createKeyboardNav(ctx);
   let searchBar: ReturnType<typeof createSearchBar>;
   let selectedIdx: number | null = null;
   let currentGraphUrl = graphUrl;
@@ -1265,6 +1267,7 @@ export async function mount(
     if (disposed) return;
     const now = performance.now();
     updateOnboarding(now);
+    keyboardNav.tick(now);
     tick();
     maybeSavePhysicsSnapshot(now);
     updateOnboardingCamera();
@@ -1471,6 +1474,7 @@ export async function mount(
       ctx.dispose();
       tooltip.dispose();
       picker.dispose();
+      keyboardNav.dispose();
       sidePanel.dispose();
       filterBar.dispose();
       searchBar.dispose();

--- a/theia-panel/src/physics/Simulation.ts
+++ b/theia-panel/src/physics/Simulation.ts
@@ -30,8 +30,9 @@ interface PhysicsLink {
 }
 
 /** Custom force: pulls each node toward its semantic anchor. */
-function forceAnchor(strength = 0.15) {
+function forceAnchor(initialStrength = 0.15) {
   let nodes: PhysicsNode[] = [];
+  let strength = initialStrength;
   function force(alpha: number) {
     for (const n of nodes) {
       n.vx = (n.vx ?? 0) + (n.anchorX - n.x) * strength * alpha;
@@ -41,6 +42,10 @@ function forceAnchor(strength = 0.15) {
   }
   force.initialize = (n: PhysicsNode[]) => {
     nodes = n;
+  };
+  force.strength = (s: number) => {
+    strength = s;
+    return force;
   };
   return force;
 }
@@ -54,9 +59,10 @@ function forceAnchor(strength = 0.15) {
  * given simulation; rebuilding the adjacency map every tick was pure
  * GC churn at 1.6k nodes (thousands of Map/Set allocations per tick).
  */
-function forceCluster(links: PhysicsLink[], strength = 0.03) {
+function forceCluster(links: PhysicsLink[], initialStrength = 0.03) {
   let nodes: PhysicsNode[] = [];
   let neighborIdx: Int32Array[] = [];
+  let strength = initialStrength;
   function force(alpha: number) {
     for (let i = 0; i < nodes.length; i++) {
       const n = nodes[i]!;
@@ -93,6 +99,10 @@ function forceCluster(links: PhysicsLink[], strength = 0.03) {
       tmp[ti]!.push(si);
     }
     neighborIdx = tmp.map((a) => Int32Array.from(a));
+  };
+  force.strength = (s: number) => {
+    strength = s;
+    return force;
   };
   return force;
 }

--- a/theia-panel/src/physics/Simulation.ts
+++ b/theia-panel/src/physics/Simulation.ts
@@ -48,83 +48,130 @@ function forceAnchor(strength = 0.15) {
 /**
  * Custom force: mild attraction toward the centroid of each node's
  * immediate neighbors. Keeps clusters coherent without exploding.
+ *
+ * Adjacency is resolved once per simulation in initialize(), not per
+ * tick. Links and node identities don't change between ticks for a
+ * given simulation; rebuilding the adjacency map every tick was pure
+ * GC churn at 1.6k nodes (thousands of Map/Set allocations per tick).
  */
 function forceCluster(links: PhysicsLink[], strength = 0.03) {
   let nodes: PhysicsNode[] = [];
+  let neighborIdx: Int32Array[] = [];
   function force(alpha: number) {
-    const adj = new Map<string, Set<string>>();
-    const nodeMap = new Map<string, PhysicsNode>();
-    for (const n of nodes) {
-      adj.set(n.id, new Set());
-      nodeMap.set(n.id, n);
-    }
-    for (const l of links) {
-      adj.get(l.source)?.add(l.target);
-      adj.get(l.target)?.add(l.source);
-    }
-
-    for (const n of nodes) {
-      const neighbors = adj.get(n.id);
-      if (!neighbors || neighbors.size === 0) continue;
+    for (let i = 0; i < nodes.length; i++) {
+      const n = nodes[i]!;
+      const idx = neighborIdx[i]!;
+      const count = idx.length;
+      if (count === 0) continue;
       let cx = 0;
       let cy = 0;
       let cz = 0;
-      let count = 0;
-      for (const nid of neighbors) {
-        const neighbor = nodeMap.get(nid);
-        if (neighbor) {
-          cx += neighbor.x;
-          cy += neighbor.y;
-          cz += neighbor.z;
-          count++;
-        }
+      for (let k = 0; k < count; k++) {
+        const neighbor = nodes[idx[k]!]!;
+        cx += neighbor.x;
+        cy += neighbor.y;
+        cz += neighbor.z;
       }
-      if (count > 0) {
-        cx /= count;
-        cy /= count;
-        cz /= count;
-        n.vx = (n.vx ?? 0) + (cx - n.x) * strength * alpha;
-        n.vy = (n.vy ?? 0) + (cy - n.y) * strength * alpha;
-        n.vz = (n.vz ?? 0) + (cz - n.z) * strength * alpha;
-      }
+      cx /= count;
+      cy /= count;
+      cz /= count;
+      n.vx = (n.vx ?? 0) + (cx - n.x) * strength * alpha;
+      n.vy = (n.vy ?? 0) + (cy - n.y) * strength * alpha;
+      n.vz = (n.vz ?? 0) + (cz - n.z) * strength * alpha;
     }
   }
   force.initialize = (n: PhysicsNode[]) => {
     nodes = n;
+    const idxById = new Map<string, number>();
+    for (let i = 0; i < n.length; i++) idxById.set(n[i]!.id, i);
+    const tmp: number[][] = n.map(() => []);
+    for (const l of links) {
+      const si = idxById.get(l.source);
+      const ti = idxById.get(l.target);
+      if (si === undefined || ti === undefined) continue;
+      tmp[si]!.push(ti);
+      tmp[ti]!.push(si);
+    }
+    neighborIdx = tmp.map((a) => Int32Array.from(a));
   };
   return force;
 }
 
-/** Custom 3D collision force. */
+/**
+ * Custom 3D collision force, spatial-hashed.
+ *
+ * The previous O(N²) all-pairs check did ~1.28M pair tests per tick at
+ * 1.6k nodes — the dominant cost in the entire simulation. Now we bin
+ * nodes into a uniform cubic grid sized to the maximum collision
+ * distance, so each node only checks its own cell + 26 neighbors.
+ * Average candidate set drops from N to a small constant (proportional
+ * to local density), giving ~O(N) per tick at typical layouts.
+ */
 function forceCollide(strength = 0.5) {
   let nodes: PhysicsNode[] = [];
+  let cellSize = 0.4;
+  const grid = new Map<number, number[]>();
+  // Pack 3 signed ints into a single key. ±2¹⁰ cells per axis covers
+  // layouts spanning a few world units at our scale.
+  const key3 = (cx: number, cy: number, cz: number) =>
+    ((cx + 1024) << 20) | ((cy + 1024) << 10) | (cz + 1024);
   function force(alpha: number) {
+    grid.clear();
+    const inv = 1 / cellSize;
+    for (let i = 0; i < nodes.length; i++) {
+      const n = nodes[i]!;
+      const k = key3(
+        Math.floor(n.x * inv),
+        Math.floor(n.y * inv),
+        Math.floor(n.z * inv),
+      );
+      const bucket = grid.get(k);
+      if (bucket) bucket.push(i);
+      else grid.set(k, [i]);
+    }
     for (let i = 0; i < nodes.length; i++) {
       const a = nodes[i]!;
-      for (let j = i + 1; j < nodes.length; j++) {
-        const b = nodes[j]!;
-        const dx = a.x - b.x;
-        const dy = a.y - b.y;
-        const dz = a.z - b.z;
-        const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
-        const minDist = a.radius + b.radius + 0.02;
-        if (dist > 0 && dist < minDist) {
-          const overlap = minDist - dist;
-          const fx = (dx / dist) * overlap * strength * alpha;
-          const fy = (dy / dist) * overlap * strength * alpha;
-          const fz = (dz / dist) * overlap * strength * alpha;
-          a.vx = (a.vx ?? 0) + fx;
-          a.vy = (a.vy ?? 0) + fy;
-          a.vz = (a.vz ?? 0) + fz;
-          b.vx = (b.vx ?? 0) - fx;
-          b.vy = (b.vy ?? 0) - fy;
-          b.vz = (b.vz ?? 0) - fz;
+      const cx = Math.floor(a.x * inv);
+      const cy = Math.floor(a.y * inv);
+      const cz = Math.floor(a.z * inv);
+      for (let dx = -1; dx <= 1; dx++) {
+        for (let dy = -1; dy <= 1; dy++) {
+          for (let dz = -1; dz <= 1; dz++) {
+            const bucket = grid.get(key3(cx + dx, cy + dy, cz + dz));
+            if (!bucket) continue;
+            for (let bi = 0; bi < bucket.length; bi++) {
+              const j = bucket[bi]!;
+              if (j <= i) continue;
+              const b = nodes[j]!;
+              const ddx = a.x - b.x;
+              const ddy = a.y - b.y;
+              const ddz = a.z - b.z;
+              const distSq = ddx * ddx + ddy * ddy + ddz * ddz;
+              const minDist = a.radius + b.radius + 0.02;
+              if (distSq > 0 && distSq < minDist * minDist) {
+                const dist = Math.sqrt(distSq);
+                const overlap = minDist - dist;
+                const fx = (ddx / dist) * overlap * strength * alpha;
+                const fy = (ddy / dist) * overlap * strength * alpha;
+                const fz = (ddz / dist) * overlap * strength * alpha;
+                a.vx = (a.vx ?? 0) + fx;
+                a.vy = (a.vy ?? 0) + fy;
+                a.vz = (a.vz ?? 0) + fz;
+                b.vx = (b.vx ?? 0) - fx;
+                b.vy = (b.vy ?? 0) - fy;
+                b.vz = (b.vz ?? 0) - fz;
+              }
+            }
+          }
         }
       }
     }
   }
   force.initialize = (n: PhysicsNode[]) => {
     nodes = n;
+    let maxR = 0;
+    for (const node of n) if (node.radius > maxR) maxR = node.radius;
+    cellSize = Math.max(0.05, maxR * 2 + 0.02);
   };
   return force;
 }

--- a/theia-panel/src/physics/SimulationWorker.ts
+++ b/theia-panel/src/physics/SimulationWorker.ts
@@ -1,0 +1,323 @@
+/// <reference lib="webworker" />
+/**
+ * Physics simulation worker. Runs the d3-force-3d simulation off the
+ * main thread so render frames don't stall during the convergence
+ * period.
+ *
+ * Protocol (see state/simulation.ts for the main-thread side):
+ *   main → worker:
+ *     init           — build simulation for the supplied graph
+ *     replaceActive  — rebuild simulation for a new active node set
+ *     wake           — bump alpha + start posting again
+ *     dispose        — stop simulation, exit
+ *
+ *   worker → main:
+ *     positions      — buffer of [x0,y0,z0, x1,y1,z1, ...] for each
+ *                      node, indexed by graph node order
+ *     snapshot       — full {id, x, y, z, vx, vy, vz} array on demand
+ *
+ * The worker self-throttles: ticks at ~60Hz internally (setTimeout
+ * loop), but stops posting once it detects the layout has settled.
+ * Wake messages restart posting. Main thread keeps rendering at full
+ * refresh rate independent of the worker; positions arrive
+ * asynchronously and are interpolated via a lerp on the main side.
+ */
+
+import { createSimulation } from "./Simulation";
+import { hashN11 } from "../util/hash";
+import type { TheiaGraph } from "../data/types";
+
+type SimNodes = ReturnType<typeof createSimulation>["nodes"];
+
+export type SnapshotPayloadNode = {
+  id: string;
+  x: number;
+  y: number;
+  z: number;
+  vx: number;
+  vy: number;
+  vz: number;
+};
+
+export type SeedNode = {
+  id: string;
+  x: number;
+  y: number;
+  z: number;
+  vx?: number;
+  vy?: number;
+  vz?: number;
+};
+
+export type WorkerInMsg =
+  | {
+      type: "init";
+      graph: TheiaGraph;
+      kinds: string[];
+      isOnboarding: boolean;
+      seedNodes?: SeedNode[];
+      animateNew?: boolean;
+    }
+  | {
+      type: "replaceActive";
+      activeIds: string[] | null;
+      animateNew: boolean;
+      preserveExisting: boolean;
+      seedNodes?: SeedNode[];
+      isOnboarding: boolean;
+    }
+  | { type: "wake" }
+  | { type: "snapshotRequest"; requestId: number }
+  | { type: "dispose" };
+
+export type WorkerOutMsg =
+  | {
+      type: "positions";
+      buffer: ArrayBuffer; // Float32Array of length n*3, x/y/z per node in graph order
+      settled: boolean;
+    }
+  | {
+      type: "ready";
+      // Sent once after init completes — main thread treats this as a
+      // signal that subsequent position messages can be expected.
+    }
+  | {
+      type: "snapshot";
+      requestId: number;
+      nodes: SnapshotPayloadNode[];
+    };
+
+const TICK_INTERVAL_MS = 1000 / 60;
+
+// Settled-physics gate (worker side): stop posting positions when the
+// per-tick max squared displacement is below threshold for N consecutive
+// ticks. Wake messages reset the counter.
+const SETTLED_THRESHOLD = 30;
+const SETTLE_EPSILON_SQ = 1e-6;
+const WAKE_ALPHA = 0.18;
+
+let graph: TheiaGraph | null = null;
+let nodeIndexById = new Map<string, number>();
+let simNodes: SimNodes = [];
+let simulation: ReturnType<typeof createSimulation>["simulation"] | null = null;
+let kinds = new Set<string>();
+let onboarding = false;
+let settledTicks = 0;
+let lastPositions: Float32Array | null = null; // n*3
+let tickHandle: ReturnType<typeof setTimeout> | null = null;
+let disposed = false;
+
+function simulationGraphFor(activeIds: Set<string> | null): TheiaGraph {
+  if (!graph) throw new Error("worker not initialized");
+  if (!activeIds) return graph;
+  return {
+    ...graph,
+    nodes: graph.nodes.filter((node) => activeIds.has(node.id)),
+    edges: graph.edges.filter(
+      (edge) => activeIds.has(edge.source) && activeIds.has(edge.target),
+    ),
+  };
+}
+
+function applyReplaceActive(opts: {
+  activeIds: string[] | null;
+  animateNew: boolean;
+  preserveExisting: boolean;
+  seedNodes?: SeedNode[];
+  isOnboarding: boolean;
+}) {
+  if (!graph) return;
+  const activeIdSet = opts.activeIds ? new Set(opts.activeIds) : null;
+  onboarding = opts.isOnboarding;
+
+  const oldPositions = new Map<
+    string,
+    {
+      x: number;
+      y: number;
+      z: number;
+      vx?: number;
+      vy?: number;
+      vz?: number;
+    }
+  >();
+  if (opts.preserveExisting) {
+    for (const sn of simNodes) {
+      if (sn) {
+        oldPositions.set(sn.id, {
+          x: sn.x,
+          y: sn.y,
+          z: sn.z,
+          vx: sn.vx,
+          vy: sn.vy,
+          vz: sn.vz,
+        });
+      }
+    }
+  }
+  const seedById = new Map<string, SeedNode>();
+  for (const seed of opts.seedNodes ?? []) seedById.set(seed.id, seed);
+
+  simulation?.stop();
+  const simResult = createSimulation(
+    simulationGraphFor(activeIdSet),
+    kinds,
+    opts.isOnboarding ? "onboarding" : "normal",
+  );
+  simulation = simResult.simulation;
+  simulation.stop();
+
+  const nextNodes = new Array(graph.nodes.length) as SimNodes;
+  for (const sn of simResult.nodes) {
+    const idx = nodeIndexById.get(sn.id);
+    if (idx === undefined) continue;
+    const old = opts.preserveExisting ? oldPositions.get(sn.id) : undefined;
+    const seed = seedById.get(sn.id);
+    if (old || seed) {
+      const source = old ?? seed!;
+      sn.x = source.x;
+      sn.y = source.y;
+      sn.z = source.z;
+      sn.vx = source.vx ?? 0;
+      sn.vy = source.vy ?? 0;
+      sn.vz = source.vz ?? 0;
+    } else if (opts.animateNew) {
+      const jitter = 0.08;
+      sn.x = sn.anchorX * 0.55 + hashN11(`${sn.id}:x`) * jitter;
+      sn.y = sn.anchorY * 0.55 + hashN11(`${sn.id}:y`) * jitter;
+      sn.z = sn.anchorZ * 0.55 + hashN11(`${sn.id}:z`) * jitter;
+      sn.vx = (sn.anchorX - sn.x) * 0.006;
+      sn.vy = (sn.anchorY - sn.y) * 0.006;
+      sn.vz = (sn.anchorZ - sn.z) * 0.006;
+    }
+    nextNodes[idx] = sn;
+  }
+  simNodes = nextNodes;
+  simulation.alpha(opts.animateNew ? 0.22 : simulation.alphaTarget());
+  settledTicks = 0;
+  scheduleTick();
+}
+
+function scheduleTick() {
+  if (disposed) return;
+  if (tickHandle !== null) return;
+  tickHandle = setTimeout(runTick, TICK_INTERVAL_MS);
+}
+
+function runTick() {
+  tickHandle = null;
+  if (disposed || !simulation || !graph) return;
+
+  // Even when settled we still need to listen for wake; just skip the
+  // sim+post cycle. Re-arm cheaply so we wake quickly on incoming
+  // messages.
+  if (settledTicks >= SETTLED_THRESHOLD) {
+    return;
+  }
+
+  simulation.tick(1);
+
+  const n = graph.nodes.length;
+  if (!lastPositions || lastPositions.length !== n * 3) {
+    lastPositions = new Float32Array(n * 3);
+  }
+  const out = new Float32Array(n * 3);
+  let maxDeltaSq = 0;
+  for (let i = 0; i < n; i++) {
+    const sn = simNodes[i];
+    if (!sn) {
+      out[i * 3 + 0] = lastPositions[i * 3 + 0]!;
+      out[i * 3 + 1] = lastPositions[i * 3 + 1]!;
+      out[i * 3 + 2] = lastPositions[i * 3 + 2]!;
+      continue;
+    }
+    const dx = sn.x - lastPositions[i * 3 + 0]!;
+    const dy = sn.y - lastPositions[i * 3 + 1]!;
+    const dz = sn.z - lastPositions[i * 3 + 2]!;
+    const deltaSq = dx * dx + dy * dy + dz * dz;
+    if (deltaSq > maxDeltaSq) maxDeltaSq = deltaSq;
+    out[i * 3 + 0] = sn.x;
+    out[i * 3 + 1] = sn.y;
+    out[i * 3 + 2] = sn.z;
+  }
+  lastPositions.set(out);
+
+  if (maxDeltaSq < SETTLE_EPSILON_SQ) settledTicks++;
+  else settledTicks = 0;
+
+  const buffer = out.buffer;
+  const msg: WorkerOutMsg = {
+    type: "positions",
+    buffer,
+    settled: settledTicks >= SETTLED_THRESHOLD,
+  };
+  (self as unknown as Worker).postMessage(msg, [buffer]);
+
+  scheduleTick();
+}
+
+function applyWake() {
+  settledTicks = 0;
+  if (simulation && simulation.alpha() < WAKE_ALPHA) {
+    simulation.alpha(WAKE_ALPHA);
+  }
+  scheduleTick();
+}
+
+function applySnapshot(requestId: number) {
+  const nodes: SnapshotPayloadNode[] = [];
+  for (const sn of simNodes) {
+    if (!sn) continue;
+    nodes.push({
+      id: sn.id,
+      x: sn.x,
+      y: sn.y,
+      z: sn.z,
+      vx: sn.vx ?? 0,
+      vy: sn.vy ?? 0,
+      vz: sn.vz ?? 0,
+    });
+  }
+  const msg: WorkerOutMsg = { type: "snapshot", requestId, nodes };
+  (self as unknown as Worker).postMessage(msg);
+}
+
+self.addEventListener("message", (e: MessageEvent<WorkerInMsg>) => {
+  const msg = e.data;
+  switch (msg.type) {
+    case "init": {
+      graph = msg.graph;
+      kinds = new Set(msg.kinds);
+      onboarding = msg.isOnboarding;
+      nodeIndexById = new Map(graph.nodes.map((n, i) => [n.id, i]));
+      lastPositions = new Float32Array(graph.nodes.length * 3);
+      applyReplaceActive({
+        activeIds: null,
+        animateNew: msg.animateNew ?? false,
+        preserveExisting: false,
+        seedNodes: msg.seedNodes,
+        isOnboarding: msg.isOnboarding,
+      });
+      const ready: WorkerOutMsg = { type: "ready" };
+      (self as unknown as Worker).postMessage(ready);
+      return;
+    }
+    case "replaceActive":
+      applyReplaceActive(msg);
+      return;
+    case "wake":
+      applyWake();
+      return;
+    case "snapshotRequest":
+      applySnapshot(msg.requestId);
+      return;
+    case "dispose":
+      disposed = true;
+      simulation?.stop();
+      if (tickHandle !== null) {
+        clearTimeout(tickHandle);
+        tickHandle = null;
+      }
+      return;
+  }
+});

--- a/theia-panel/src/physics/SimulationWorker.ts
+++ b/theia-panel/src/physics/SimulationWorker.ts
@@ -266,13 +266,31 @@ function applyWake() {
 }
 
 // Re-tune the existing forces and bump alpha so the layout reorganizes
-// in place: stronger many-body repulsion pushes nodes apart, stronger
-// neighbor clustering pulls connected groups tight, and a much weaker
-// anchor force lets nodes leave their original seed positions. The next
-// replaceActive (filter change, reload, etc.) recreates the simulation
-// from defaults, so we don't need to restore these strengths.
+// in place. The bias is toward the cluster (neighbor-centroid) force —
+// that's what gives the cozy, centroid-y grouping — with only a mild
+// repulsion bump and a softened (but still meaningful) anchor pull so
+// nodes drift to better positions without blowing apart.
+//
+// Charge is scaled gently by active node count: small graphs settle
+// fine near baseline, larger graphs need a bit more total push to
+// avoid clumps. Capped to bound blow-up.
+//
+// The next replaceActive (filter change, reload, etc.) recreates the
+// simulation from defaults, so no need to restore these strengths.
 function applyRelayout() {
   if (!simulation) return;
+  let activeCount = 0;
+  for (const sn of simNodes) if (sn) activeCount++;
+
+  // Defaults: charge -0.045, cluster 0.032, anchor 0.14.
+  // ~-0.046 at N=100, ~-0.06 at N=500, ~-0.07 at N=1000, capped at -0.075.
+  const chargeStrength = -Math.min(
+    0.075,
+    0.035 + Math.sqrt(activeCount) * 0.0011,
+  );
+  const clusterStrength = 0.07;
+  const anchorStrength = 0.06;
+
   const charge = simulation.force("charge") as
     | { strength: (s: number) => unknown }
     | undefined;
@@ -282,9 +300,10 @@ function applyRelayout() {
   const anchor = simulation.force("anchor") as
     | { strength: (s: number) => unknown }
     | undefined;
-  charge?.strength(-0.13);
-  cluster?.strength(0.08);
-  anchor?.strength(0.02);
+  charge?.strength(chargeStrength);
+  cluster?.strength(clusterStrength);
+  anchor?.strength(anchorStrength);
+
   for (const sn of simNodes) {
     if (!sn) continue;
     sn.vx = 0;

--- a/theia-panel/src/physics/SimulationWorker.ts
+++ b/theia-panel/src/physics/SimulationWorker.ts
@@ -67,6 +67,7 @@ export type WorkerInMsg =
       isOnboarding: boolean;
     }
   | { type: "wake" }
+  | { type: "relayout" }
   | { type: "snapshotRequest"; requestId: number }
   | { type: "dispose" };
 
@@ -264,6 +265,28 @@ function applyWake() {
   scheduleTick();
 }
 
+// Re-seed every active simNode back to its anchor (with deterministic
+// per-node jitter) and bump alpha to 1.0 so the simulation converges
+// from a perturbed start. The default layout otherwise stays close to
+// whatever local minimum the first run found; this gives the user a way
+// to trigger a fresh convergence pass.
+function applyRelayout() {
+  if (!simulation) return;
+  const jitter = 0.35;
+  for (const sn of simNodes) {
+    if (!sn) continue;
+    sn.x = sn.anchorX + hashN11(`${sn.id}:relayout-x`) * jitter;
+    sn.y = sn.anchorY + hashN11(`${sn.id}:relayout-y`) * jitter;
+    sn.z = sn.anchorZ + hashN11(`${sn.id}:relayout-z`) * jitter;
+    sn.vx = 0;
+    sn.vy = 0;
+    sn.vz = 0;
+  }
+  simulation.alpha(1.0);
+  settledTicks = 0;
+  scheduleTick();
+}
+
 function applySnapshot(requestId: number) {
   const nodes: SnapshotPayloadNode[] = [];
   for (const sn of simNodes) {
@@ -307,6 +330,9 @@ self.addEventListener("message", (e: MessageEvent<WorkerInMsg>) => {
       return;
     case "wake":
       applyWake();
+      return;
+    case "relayout":
+      applyRelayout();
       return;
     case "snapshotRequest":
       applySnapshot(msg.requestId);

--- a/theia-panel/src/physics/SimulationWorker.ts
+++ b/theia-panel/src/physics/SimulationWorker.ts
@@ -265,19 +265,28 @@ function applyWake() {
   scheduleTick();
 }
 
-// Re-seed every active simNode back to its anchor (with deterministic
-// per-node jitter) and bump alpha to 1.0 so the simulation converges
-// from a perturbed start. The default layout otherwise stays close to
-// whatever local minimum the first run found; this gives the user a way
-// to trigger a fresh convergence pass.
+// Re-tune the existing forces and bump alpha so the layout reorganizes
+// in place: stronger many-body repulsion pushes nodes apart, stronger
+// neighbor clustering pulls connected groups tight, and a much weaker
+// anchor force lets nodes leave their original seed positions. The next
+// replaceActive (filter change, reload, etc.) recreates the simulation
+// from defaults, so we don't need to restore these strengths.
 function applyRelayout() {
   if (!simulation) return;
-  const jitter = 0.35;
+  const charge = simulation.force("charge") as
+    | { strength: (s: number) => unknown }
+    | undefined;
+  const cluster = simulation.force("cluster") as
+    | { strength: (s: number) => unknown }
+    | undefined;
+  const anchor = simulation.force("anchor") as
+    | { strength: (s: number) => unknown }
+    | undefined;
+  charge?.strength(-0.13);
+  cluster?.strength(0.08);
+  anchor?.strength(0.02);
   for (const sn of simNodes) {
     if (!sn) continue;
-    sn.x = sn.anchorX + hashN11(`${sn.id}:relayout-x`) * jitter;
-    sn.y = sn.anchorY + hashN11(`${sn.id}:relayout-y`) * jitter;
-    sn.z = sn.anchorZ + hashN11(`${sn.id}:relayout-z`) * jitter;
     sn.vx = 0;
     sn.vy = 0;
     sn.vz = 0;

--- a/theia-panel/src/scene/Edges.ts
+++ b/theia-panel/src/scene/Edges.ts
@@ -9,13 +9,16 @@ const VERT = `
 attribute float aOpacity;
 attribute float aPhase;
 attribute float aReveal;
+attribute float aTint;
 varying float vOpacity;
 varying float vPhase;
 varying float vReveal;
+varying float vTint;
 void main() {
   vOpacity = aOpacity;
   vPhase = aPhase;
   vReveal = aReveal;
+  vTint = aTint;
   gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
 }
 `;
@@ -24,14 +27,87 @@ const FRAG = `
 varying float vOpacity;
 varying float vPhase;
 varying float vReveal;
+varying float vTint;
 uniform vec3 color;
 uniform float uTime;
 void main() {
   float pulse = 0.85 + 0.15 * sin(uTime * 3.0 + vPhase);
   float alpha = vOpacity * vReveal * pulse;
-  gl_FragColor = vec4(color, alpha);
+  gl_FragColor = vec4(color * vTint, alpha);
 }
 `;
+
+// Per-edge brightness modulation based on node metadata.
+// - subagent: brighter at the root (low parent depth), darker for deeper edges
+// - cron-chain: brighter for newer edges (later in sequence), darker for older
+const SUBAGENT_DEPTH_FALLOFF = 0.18;
+const SUBAGENT_TINT_FLOOR = 0.35;
+const CRON_TINT_FLOOR = 0.35;
+
+function computeEdgeTints(
+  graph: TheiaGraph,
+): (edge: GraphEdge) => number {
+  // Cron-chain rank-by-time within each sequence.
+  // Older runs sit at the low end (rank 0); newer runs are higher.
+  const cronRank = new Map<string, number>();
+  const cronMaxRank = new Map<number, number>();
+  const cronGroups = new Map<number, Array<TheiaGraph["nodes"][number]>>();
+  for (const node of graph.nodes) {
+    const seq = node.metadata?.cron_sequence_id;
+    if (seq === null || seq === undefined) continue;
+    let group = cronGroups.get(seq);
+    if (!group) {
+      group = [];
+      cronGroups.set(seq, group);
+    }
+    group.push(node);
+  }
+  for (const [seq, group] of cronGroups) {
+    group.sort((a, b) => (a.started_at < b.started_at ? -1 : 1));
+    for (let i = 0; i < group.length; i++) {
+      cronRank.set(group[i]!.id, i);
+    }
+    cronMaxRank.set(seq, Math.max(1, group.length - 1));
+  }
+
+  // Precompute lookups: hierarchy_depth and cron_sequence_id by node id.
+  const depthById = new Map<string, number>();
+  const seqById = new Map<string, number>();
+  for (const node of graph.nodes) {
+    const d = node.metadata?.hierarchy_depth;
+    if (typeof d === "number") depthById.set(node.id, d);
+    const s = node.metadata?.cron_sequence_id;
+    if (typeof s === "number") seqById.set(node.id, s);
+  }
+
+  return (edge: GraphEdge) => {
+    if (edge.kind === "subagent") {
+      // Use the parent's depth (= shallower endpoint) so the root's outgoing
+      // edges are the brightest, and edges deeper in the tree dim out.
+      const ds = depthById.get(edge.source);
+      const dt = depthById.get(edge.target);
+      if (ds === undefined && dt === undefined) return 1.0;
+      const parentDepth = Math.min(ds ?? Infinity, dt ?? Infinity);
+      return Math.max(
+        SUBAGENT_TINT_FLOOR,
+        1.0 - parentDepth * SUBAGENT_DEPTH_FALLOFF,
+      );
+    }
+    if (edge.kind === "cron-chain") {
+      // The "newer" endpoint of a cron-chain edge drives the tint: edges
+      // between recent runs glow, edges between old runs fade.
+      const seq = seqById.get(edge.target) ?? seqById.get(edge.source);
+      if (seq === undefined) return 1.0;
+      const rs = cronRank.get(edge.source) ?? 0;
+      const rt = cronRank.get(edge.target) ?? 0;
+      const newerRank = Math.max(rs, rt);
+      const maxRank = cronMaxRank.get(seq) ?? 1;
+      const t = newerRank / maxRank;
+      return CRON_TINT_FLOOR + (1.0 - CRON_TINT_FLOOR) * t;
+    }
+    return 1.0;
+  };
+}
 
 const PALETTE_MAP: Record<GraphEdge["kind"], number> = {
   "memory-share": PALETTE.edgeMemory,
@@ -98,6 +174,8 @@ export function createEdges(): EdgeLayer {
     }
     lineSegmentsByKind.clear();
 
+    const tintFor = computeEdgeTints(graph);
+
     for (const kind of enabledKinds) {
       const edgesRaw = graph.edges.filter((e) => e.kind === kind);
       if (edgesRaw.length === 0) continue;
@@ -118,6 +196,7 @@ export function createEdges(): EdgeLayer {
       const opacities = new Float32Array(edges.length * 2);
       const phases = new Float32Array(edges.length * 2);
       const reveals = new Float32Array(edges.length * 2);
+      const tints = new Float32Array(edges.length * 2);
       const validIndices: number[] = [];
       for (let i = 0; i < edges.length; i++) {
         const e = edges[i]!;
@@ -164,6 +243,9 @@ export function createEdges(): EdgeLayer {
         const reveal = getConnectionProgress?.(e) ?? 1;
         reveals[i * 2 + 0] = reveal;
         reveals[i * 2 + 1] = reveal;
+        const tint = tintFor(e);
+        tints[i * 2 + 0] = tint;
+        tints[i * 2 + 1] = tint;
         validIndices.push(i);
       }
       const geometry = new THREE.BufferGeometry();
@@ -177,6 +259,7 @@ export function createEdges(): EdgeLayer {
       );
       geometry.setAttribute("aPhase", new THREE.BufferAttribute(phases, 1));
       geometry.setAttribute("aReveal", new THREE.BufferAttribute(reveals, 1));
+      geometry.setAttribute("aTint", new THREE.BufferAttribute(tints, 1));
       let mat = materials.get(kind);
       if (!mat) {
         const c = new THREE.Color(PALETTE_MAP[kind]);

--- a/theia-panel/src/scene/Edges.ts
+++ b/theia-panel/src/scene/Edges.ts
@@ -126,13 +126,29 @@ export function createEdges(): EdgeLayer {
         if (si === undefined || ti === undefined) continue;
         const s = graph.nodes[si]!;
         const t = graph.nodes[ti]!;
-        positions[i * 6 + 0] = s.position.x;
-        positions[i * 6 + 1] = s.position.y;
+        // Read live positions from `nodePositions` for x/y too — not just z.
+        // `node.position` is the raw dataset anchor; the simulation places
+        // nodes at `position * spread` (Simulation.ts) plus whatever physics
+        // shifts them, so anchors don't match the rendered layout. The
+        // original code only got away with reading anchors here because
+        // tick() ran every frame and `updatePositions` immediately
+        // overwrote these values; the idle-tick gate exposed the latent
+        // mismatch as edges snapping to ~origin after a rebuild.
+        positions[i * 6 + 0] = nodePositions
+          ? (nodePositions[si * 3 + 0] ?? s.position.x)
+          : s.position.x;
+        positions[i * 6 + 1] = nodePositions
+          ? (nodePositions[si * 3 + 1] ?? s.position.y)
+          : s.position.y;
         positions[i * 6 + 2] = nodePositions
           ? (nodePositions[si * 3 + 2] ?? 0)
           : 0;
-        positions[i * 6 + 3] = t.position.x;
-        positions[i * 6 + 4] = t.position.y;
+        positions[i * 6 + 3] = nodePositions
+          ? (nodePositions[ti * 3 + 0] ?? t.position.x)
+          : t.position.x;
+        positions[i * 6 + 4] = nodePositions
+          ? (nodePositions[ti * 3 + 1] ?? t.position.y)
+          : t.position.y;
         positions[i * 6 + 5] = nodePositions
           ? (nodePositions[ti * 3 + 2] ?? 0)
           : 0;

--- a/theia-panel/src/scene/Edges.ts
+++ b/theia-panel/src/scene/Edges.ts
@@ -55,6 +55,13 @@ export interface EdgeLayer {
     getProgress: ((edge: GraphEdge) => number) | null,
   ): void;
   setTime(t: number): void;
+  pickAt(
+    camera: THREE.Camera,
+    container: HTMLElement,
+    clientX: number,
+    clientY: number,
+    tolerancePx?: number,
+  ): GraphEdge | null;
   dispose(): void;
 }
 
@@ -258,6 +265,72 @@ export function createEdges(): EdgeLayer {
     }
   }
 
+  const _pickA = new THREE.Vector3();
+  const _pickB = new THREE.Vector3();
+  function pickAt(
+    camera: THREE.Camera,
+    container: HTMLElement,
+    clientX: number,
+    clientY: number,
+    tolerancePx = 6,
+  ): GraphEdge | null {
+    const rect = container.getBoundingClientRect();
+    const mx = clientX - rect.left;
+    const my = clientY - rect.top;
+    let best: GraphEdge | null = null;
+    let bestDist2 = tolerancePx * tolerancePx;
+
+    for (const {
+      line,
+      edgeList,
+      validIndices,
+    } of lineSegmentsByKind.values()) {
+      const posAttr = line.geometry.getAttribute("position") as
+        | THREE.BufferAttribute
+        | undefined;
+      if (!posAttr) continue;
+      for (const i of validIndices) {
+        _pickA.set(
+          posAttr.getX(i * 2 + 0),
+          posAttr.getY(i * 2 + 0),
+          posAttr.getZ(i * 2 + 0),
+        );
+        _pickB.set(
+          posAttr.getX(i * 2 + 1),
+          posAttr.getY(i * 2 + 1),
+          posAttr.getZ(i * 2 + 1),
+        );
+        _pickA.project(camera);
+        _pickB.project(camera);
+        // Reject if both endpoints behind the near plane
+        if (_pickA.z > 1 && _pickB.z > 1) continue;
+        const ax = (_pickA.x * 0.5 + 0.5) * rect.width;
+        const ay = (1 - (_pickA.y * 0.5 + 0.5)) * rect.height;
+        const bx = (_pickB.x * 0.5 + 0.5) * rect.width;
+        const by = (1 - (_pickB.y * 0.5 + 0.5)) * rect.height;
+        const dx = bx - ax;
+        const dy = by - ay;
+        const len2 = dx * dx + dy * dy;
+        let t = 0;
+        if (len2 > 0) {
+          t = ((mx - ax) * dx + (my - ay) * dy) / len2;
+          if (t < 0) t = 0;
+          else if (t > 1) t = 1;
+        }
+        const px = ax + t * dx;
+        const py = ay + t * dy;
+        const ex = mx - px;
+        const ey = my - py;
+        const dist2 = ex * ex + ey * ey;
+        if (dist2 < bestDist2) {
+          bestDist2 = dist2;
+          best = edgeList[i] ?? null;
+        }
+      }
+    }
+    return best;
+  }
+
   function dispose() {
     for (const { line } of lineSegmentsByKind.values()) {
       line.geometry.dispose();
@@ -272,6 +345,7 @@ export function createEdges(): EdgeLayer {
     setHoverNode,
     setConnectionProgress,
     setTime,
+    pickAt,
     dispose,
   };
 }

--- a/theia-panel/src/scene/Edges.ts
+++ b/theia-panel/src/scene/Edges.ts
@@ -44,9 +44,7 @@ const SUBAGENT_DEPTH_FALLOFF = 0.18;
 const SUBAGENT_TINT_FLOOR = 0.35;
 const CRON_TINT_FLOOR = 0.35;
 
-function computeEdgeTints(
-  graph: TheiaGraph,
-): (edge: GraphEdge) => number {
+function computeEdgeTints(graph: TheiaGraph): (edge: GraphEdge) => number {
   // Cron-chain rank-by-time within each sequence.
   // Older runs sit at the low end (rank 0); newer runs are higher.
   const cronRank = new Map<string, number>();

--- a/theia-panel/src/scene/Edges.ts
+++ b/theia-panel/src/scene/Edges.ts
@@ -51,6 +51,7 @@ export interface EdgeLayer {
   ): void;
   updatePositions(nodePositions: Float32Array): void;
   setHoverNode(nodeId: string | null): void;
+  setHoverEdge(edge: GraphEdge | null): void;
   setConnectionProgress(
     getProgress: ((edge: GraphEdge) => number) | null,
   ): void;
@@ -62,6 +63,11 @@ export interface EdgeLayer {
     clientY: number,
     tolerancePx?: number,
   ): GraphEdge | null;
+  visibleEdges(): Array<{
+    edge: GraphEdge;
+    sourceIdx: number;
+    targetIdx: number;
+  }>;
   dispose(): void;
 }
 
@@ -74,6 +80,9 @@ export function createEdges(): EdgeLayer {
   >();
   let currentNodeIndex: Map<string, number> | null = null;
   let getConnectionProgress: ((edge: GraphEdge) => number) | null = null;
+  let hoverNodeId: string | null = null;
+  let hoverEdge: GraphEdge | null = null;
+  const HOVER_EDGE_OPACITY = 1.0;
 
   function rebuild(
     graph: TheiaGraph,
@@ -209,7 +218,7 @@ export function createEdges(): EdgeLayer {
     }
   }
 
-  function setHoverNode(nodeId: string | null) {
+  function refreshOpacities() {
     for (const [
       kind,
       { line, edgeList, validIndices },
@@ -224,14 +233,50 @@ export function createEdges(): EdgeLayer {
         SIZES.edgeOpacity;
       for (const i of validIndices) {
         const e = edgeList[i]!;
-        const dim =
-          nodeId !== null && e.source !== nodeId && e.target !== nodeId;
-        const opacity = dim ? 0.08 : baseOpacity;
+        let opacity: number;
+        if (hoverEdge !== null && e === hoverEdge) {
+          opacity = HOVER_EDGE_OPACITY;
+        } else {
+          const dim =
+            hoverNodeId !== null &&
+            e.source !== hoverNodeId &&
+            e.target !== hoverNodeId;
+          opacity = dim ? 0.08 : baseOpacity;
+        }
         attr.setX(i * 2 + 0, opacity);
         attr.setX(i * 2 + 1, opacity);
       }
       attr.needsUpdate = true;
     }
+  }
+
+  function setHoverNode(nodeId: string | null) {
+    hoverNodeId = nodeId;
+    refreshOpacities();
+  }
+
+  function setHoverEdge(edge: GraphEdge | null) {
+    hoverEdge = edge;
+    refreshOpacities();
+  }
+
+  function visibleEdges() {
+    if (!currentNodeIndex) return [];
+    const out: Array<{
+      edge: GraphEdge;
+      sourceIdx: number;
+      targetIdx: number;
+    }> = [];
+    for (const { edgeList, validIndices } of lineSegmentsByKind.values()) {
+      for (const i of validIndices) {
+        const e = edgeList[i]!;
+        const sourceIdx = currentNodeIndex.get(e.source);
+        const targetIdx = currentNodeIndex.get(e.target);
+        if (sourceIdx === undefined || targetIdx === undefined) continue;
+        out.push({ edge: e, sourceIdx, targetIdx });
+      }
+    }
+    return out;
   }
 
   function setConnectionProgress(
@@ -343,6 +388,8 @@ export function createEdges(): EdgeLayer {
     rebuild,
     updatePositions,
     setHoverNode,
+    setHoverEdge,
+    visibleEdges,
     setConnectionProgress,
     setTime,
     pickAt,

--- a/theia-panel/src/scene/KeyboardNav.ts
+++ b/theia-panel/src/scene/KeyboardNav.ts
@@ -95,14 +95,16 @@ export function createKeyboardNav(ctx: SceneContext): KeyboardNav {
         ? SHIFT_MULTIPLIER
         : 1;
 
-    // Pan — WASD maps to screen-relative dx/dy in pixel units.
-    // Scene.pan treats +dy as "drag down", so W (up) sends -dy.
+    // Pan — WASD maps to screen-relative camera motion. Scene.pan
+    // moves target along +up when dyPixel > 0, which slides the camera
+    // up alongside it; so W (camera up) needs +dyPixel and S needs
+    // -dyPixel. The previous mapping had these inverted.
     let panDx = 0;
     let panDy = 0;
     if (pressed.has("KeyA")) panDx -= 1;
     if (pressed.has("KeyD")) panDx += 1;
-    if (pressed.has("KeyW")) panDy -= 1;
-    if (pressed.has("KeyS")) panDy += 1;
+    if (pressed.has("KeyW")) panDy += 1;
+    if (pressed.has("KeyS")) panDy -= 1;
     if (panDx !== 0 || panDy !== 0) {
       const m = PAN_PIXELS_PER_SEC * dt * speed;
       // Scene.pan internally negates dxPixel (mouse-drag convention),

--- a/theia-panel/src/scene/KeyboardNav.ts
+++ b/theia-panel/src/scene/KeyboardNav.ts
@@ -1,0 +1,148 @@
+import type { SceneContext } from "./Scene";
+
+export interface KeyboardNav {
+  tick(now: number): void;
+  dispose(): void;
+}
+
+/**
+ * Hold-to-move keyboard navigation for the orbital camera.
+ *
+ * - WASD                : screen-relative pan (W up, S down, A left, D right)
+ * - Arrow keys          : orbit (←→ yaw, ↑↓ pitch)
+ * - Space               : zoom in
+ * - Ctrl                : zoom out (Ctrl+Space also zooms out for users who
+ *                         prefer a chord)
+ * - Shift (held)        : 3× speed modifier on any of the above
+ *
+ * Movement integrates per-frame against `now` so hold-to-move is smooth and
+ * frame-rate independent. Events are ignored while a text input or
+ * contenteditable element has focus, so the search bar still works normally.
+ */
+export function createKeyboardNav(ctx: SceneContext): KeyboardNav {
+  const pressed = new Set<string>();
+  let lastTick: number | null = null;
+
+  // Tuned so a 1-second hold gives a "useful" amount of motion at default
+  // zoom — pan covers ~30% of viewport, orbit ~60°, zoom doubles/halves.
+  const PAN_PIXELS_PER_SEC = 520;
+  const ROTATE_PIXELS_PER_SEC = 420;
+  const ZOOM_PER_SEC = 1.6; // multiplicative: zoom *= ZOOM_PER_SEC ** dt
+  const SHIFT_MULTIPLIER = 3;
+
+  function isTypingTarget(el: EventTarget | null): boolean {
+    if (!(el instanceof HTMLElement)) return false;
+    if (el.isContentEditable) return true;
+    const tag = el.tagName;
+    return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+  }
+
+  // Keys we explicitly own — preventDefault on these so arrow keys / space
+  // don't scroll the host page when the panel is focused.
+  const OWNED_KEYS = new Set([
+    "KeyW",
+    "KeyA",
+    "KeyS",
+    "KeyD",
+    "ArrowUp",
+    "ArrowDown",
+    "ArrowLeft",
+    "ArrowRight",
+    "Space",
+  ]);
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (isTypingTarget(e.target)) return;
+    if (e.altKey || e.metaKey) return;
+    pressed.add(e.code);
+    if (OWNED_KEYS.has(e.code)) {
+      e.preventDefault();
+    }
+  }
+
+  function onKeyUp(e: KeyboardEvent) {
+    pressed.delete(e.code);
+  }
+
+  function onBlur() {
+    // Drop all pressed state — we won't see the keyup if focus left while
+    // a key was held, and a stuck key would scroll the camera forever.
+    pressed.clear();
+    lastTick = null;
+  }
+
+  // Listen on window so the panel works regardless of whether the
+  // container itself has focus — but skip when the user is typing.
+  window.addEventListener("keydown", onKeyDown);
+  window.addEventListener("keyup", onKeyUp);
+  window.addEventListener("blur", onBlur);
+
+  function tick(now: number) {
+    if (pressed.size === 0) {
+      lastTick = now;
+      return;
+    }
+    if (lastTick === null) {
+      lastTick = now;
+      return;
+    }
+    const dt = Math.min(0.1, (now - lastTick) / 1000);
+    lastTick = now;
+    if (dt <= 0) return;
+
+    const speed =
+      pressed.has("ShiftLeft") || pressed.has("ShiftRight")
+        ? SHIFT_MULTIPLIER
+        : 1;
+
+    // Pan — WASD maps to screen-relative dx/dy in pixel units.
+    // Scene.pan treats +dy as "drag down", so W (up) sends -dy.
+    let panDx = 0;
+    let panDy = 0;
+    if (pressed.has("KeyA")) panDx -= 1;
+    if (pressed.has("KeyD")) panDx += 1;
+    if (pressed.has("KeyW")) panDy -= 1;
+    if (pressed.has("KeyS")) panDy += 1;
+    if (panDx !== 0 || panDy !== 0) {
+      const m = PAN_PIXELS_PER_SEC * dt * speed;
+      // Scene.pan internally negates dxPixel (mouse-drag convention),
+      // so passing +panDx moves the world left when you press D — which
+      // is wrong for a "fly with WASD" feel. Negate to match expectations.
+      ctx.pan(-panDx * m, panDy * m);
+    }
+
+    // Orbit — arrow keys map to rotate dx/dy.
+    let rotDx = 0;
+    let rotDy = 0;
+    if (pressed.has("ArrowLeft")) rotDx -= 1;
+    if (pressed.has("ArrowRight")) rotDx += 1;
+    if (pressed.has("ArrowUp")) rotDy -= 1;
+    if (pressed.has("ArrowDown")) rotDy += 1;
+    if (rotDx !== 0 || rotDy !== 0) {
+      const m = ROTATE_PIXELS_PER_SEC * dt * speed;
+      ctx.rotate(rotDx * m, rotDy * m);
+    }
+
+    // Zoom — Space in (closer), Ctrl out (farther). Ctrl+Space behaves
+    // the same as Ctrl alone, since "zoom out" is the dominant intent.
+    const zoomIn =
+      pressed.has("Space") &&
+      !pressed.has("ControlLeft") &&
+      !pressed.has("ControlRight");
+    const zoomOut = pressed.has("ControlLeft") || pressed.has("ControlRight");
+    if (zoomIn || zoomOut) {
+      const factor = Math.pow(ZOOM_PER_SEC, dt * speed);
+      const next = zoomIn ? ctx.getZoom() * factor : ctx.getZoom() / factor;
+      ctx.setZoom(next);
+    }
+  }
+
+  function dispose() {
+    window.removeEventListener("keydown", onKeyDown);
+    window.removeEventListener("keyup", onKeyUp);
+    window.removeEventListener("blur", onBlur);
+    pressed.clear();
+  }
+
+  return { tick, dispose };
+}

--- a/theia-panel/src/scene/Nodes.ts
+++ b/theia-panel/src/scene/Nodes.ts
@@ -84,24 +84,39 @@ function stellarAgeColor(
 }
 
 const VERT = `
+attribute vec3 aBaseColor;
+attribute float aWaveOffset;
+attribute float aBrightness;
+attribute float aDim;
+attribute float aState;
+
 varying vec2 vUv;
-varying vec3 vColor;
+varying vec3 vBaseColor;
 varying vec3 vCenterPos;
+varying float vWaveOffset;
+varying float vBrightness;
+varying float vDim;
+varying float vState;
+
 void main() {
   vUv = uv;
-  vColor = instanceColor;
+  vBaseColor = aBaseColor;
+  vWaveOffset = aWaveOffset;
+  vBrightness = aBrightness;
+  vDim = aDim;
+  vState = aState;
 
   vec3 instancePos = instanceMatrix[3].xyz;
-  vec3 scale = vec3(
-    length(instanceMatrix[0].xyz),
-    length(instanceMatrix[1].xyz),
-    length(instanceMatrix[2].xyz)
-  );
+  // writeMatrix() always sets identity quaternion + uniform scale, so the
+  // instance matrix is diagonal-scale + translation. Pull scale straight
+  // from the matrix diagonal — equivalent to length(matrix[0].xyz)
+  // without three sqrts per vertex.
+  float instScale = instanceMatrix[0][0];
 
   vCenterPos = instancePos;
 
   vec4 viewPos = viewMatrix * vec4(instancePos, 1.0);
-  viewPos.xy += position.xy * scale.xy;
+  viewPos.xy += position.xy * instScale;
 
   gl_Position = projectionMatrix * viewPos;
 }
@@ -110,19 +125,50 @@ void main() {
 const FRAG = `
 precision highp float;
 uniform sampler2D map;
-uniform vec3 uCameraPos;
+uniform float uTime;
+uniform vec3 uHighlightColor;
+uniform vec3 uSelectedColor;
+uniform float uDimFactor;
+
 varying vec2 vUv;
-varying vec3 vColor;
+varying vec3 vBaseColor;
 varying vec3 vCenterPos;
+varying float vWaveOffset;
+varying float vBrightness;
+varying float vDim;
+varying float vState;
+
 void main() {
   vec4 texColor = texture2D(map, vUv);
-  vec3 finalColor = texColor.rgb * vColor;
+
+  // Selected (state=2) and highlighted (state=1) override twinkle/brightness,
+  // matching the original CPU-side branching in setTime(). vState is
+  // per-instance, so all fragments of a given quad take the same branch
+  // — coherent control flow, fine on modern GPUs.
+  vec3 tint;
+  float effect;
+  if (vState > 1.5) {
+    tint = uSelectedColor;
+    effect = 1.0;
+  } else if (vState > 0.5) {
+    tint = uHighlightColor;
+    effect = 1.0;
+  } else {
+    tint = vBaseColor;
+    float twinkle = 1.0 + 0.12 * sin(uTime * 1.5 + vWaveOffset);
+    float dim = mix(1.0, uDimFactor, vDim);
+    effect = twinkle * vBrightness * dim;
+  }
+
+  vec3 rgb = min(texColor.rgb * tint * effect, vec3(1.0));
   float alpha = texColor.a;
-  float dist = distance(vCenterPos, uCameraPos);
+  // cameraPosition is auto-injected by ShaderMaterial — no explicit
+  // uniform needed.
+  float dist = distance(vCenterPos, cameraPosition);
   float fade = smoothstep(0.15, 0.8, dist);
   alpha *= fade;
   if (alpha < 0.01) discard;
-  gl_FragColor = vec4(finalColor, alpha);
+  gl_FragColor = vec4(rgb, alpha);
 }
 `;
 
@@ -137,7 +183,6 @@ export interface NodeLayer {
   setRevealScale(i: number, scale: number): void;
   setVisible(i: number, visible: boolean): void;
   setTime(t: number): void;
-  setCameraPosition(pos: THREE.Vector3): void;
   flush(): void;
   dispose(): void;
 }
@@ -150,10 +195,27 @@ export function createNodes(
 ): NodeLayer {
   const n = graph.nodes.length;
   const geometry = new THREE.PlaneGeometry(1, 1);
+  const highlightColor = new THREE.Color(PALETTE.nodeHighlight);
+  const selectedColor = new THREE.Color(PALETTE.nodeSelected);
   const material = new THREE.ShaderMaterial({
     uniforms: {
       map: { value: NODE_GLOW_TEXTURE },
-      uCameraPos: { value: new THREE.Vector3() },
+      uTime: { value: 0 },
+      uHighlightColor: {
+        value: new THREE.Vector3(
+          highlightColor.r,
+          highlightColor.g,
+          highlightColor.b,
+        ),
+      },
+      uSelectedColor: {
+        value: new THREE.Vector3(
+          selectedColor.r,
+          selectedColor.g,
+          selectedColor.b,
+        ),
+      },
+      uDimFactor: { value: DIM_FACTOR },
     },
     vertexShader: VERT,
     fragmentShader: FRAG,
@@ -163,8 +225,6 @@ export function createNodes(
   });
   const mesh = new THREE.InstancedMesh(geometry, material, n);
   const dummy = new THREE.Object3D();
-  const highlightColor = new THREE.Color(PALETTE.nodeHighlight);
-  const selectedColor = new THREE.Color(PALETTE.nodeSelected);
 
   // Compute time range for stellar age coloring
   let minTime = Infinity;
@@ -181,25 +241,47 @@ export function createNodes(
     maxTime = 1;
   }
 
-  // Precompute per-node size, color, and wave offset for spatial twinkling
   const nodeSizes = new Float32Array(n);
-  const nodeColors: THREE.Color[] = new Array(n);
-  const nodeWaveOffsets = new Float32Array(n);
+
+  // Per-instance shader inputs. These are uploaded only when their values
+  // actually change — not every frame. Twinkle/highlight/dim/select math
+  // moved into the fragment shader; setTime() collapses to a single
+  // uniform update.
+  const baseColorArr = new Float32Array(n * 3);
+  const waveOffsetArr = new Float32Array(n);
+  const brightnessArr = new Float32Array(n);
+  const dimArr = new Float32Array(n);
+  const stateArr = new Float32Array(n);
 
   for (let i = 0; i < n; i++) {
     const node = graph.nodes[i]!;
     const turns = node.message_count ?? node.tool_count;
     nodeSizes[i] = Math.min(0.18, 0.05 + Math.log1p(turns) * 0.014);
-    nodeColors[i] = stellarAgeColor(
-      node.started_at,
-      minTime,
-      maxTime,
-      node.model,
-    );
+    const c = stellarAgeColor(node.started_at, minTime, maxTime, node.model);
+    baseColorArr[i * 3 + 0] = c.r;
+    baseColorArr[i * 3 + 1] = c.g;
+    baseColorArr[i * 3 + 2] = c.b;
     // Spatial wave: coherent ripple across the constellation
-    nodeWaveOffsets[i] =
+    waveOffsetArr[i] =
       node.position.x * 2.0 + node.position.y * 1.5 + hash01(node.id) * 3.0;
+    brightnessArr[i] = 1;
+    dimArr[i] = 0;
+    stateArr[i] = 0;
   }
+
+  const baseColorAttr = new THREE.InstancedBufferAttribute(baseColorArr, 3);
+  const waveOffsetAttr = new THREE.InstancedBufferAttribute(waveOffsetArr, 1);
+  const brightnessAttr = new THREE.InstancedBufferAttribute(brightnessArr, 1);
+  const dimAttr = new THREE.InstancedBufferAttribute(dimArr, 1);
+  const stateAttr = new THREE.InstancedBufferAttribute(stateArr, 1);
+  brightnessAttr.setUsage(THREE.DynamicDrawUsage);
+  dimAttr.setUsage(THREE.DynamicDrawUsage);
+  stateAttr.setUsage(THREE.DynamicDrawUsage);
+  geometry.setAttribute("aBaseColor", baseColorAttr);
+  geometry.setAttribute("aWaveOffset", waveOffsetAttr);
+  geometry.setAttribute("aBrightness", brightnessAttr);
+  geometry.setAttribute("aDim", dimAttr);
+  geometry.setAttribute("aState", stateAttr);
 
   for (let i = 0; i < n; i++) {
     const node = graph.nodes[i]!;
@@ -212,17 +294,13 @@ export function createNodes(
     dummy.scale.set(sz, sz, sz);
     dummy.updateMatrix();
     mesh.setMatrixAt(i, dummy.matrix);
-    mesh.setColorAt(i, nodeColors[i]!);
   }
   mesh.instanceMatrix.needsUpdate = true;
-  if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
 
   const highlighted = new Set<number>();
   const selected = new Set<number>();
-  const dimmed = new Set<number>();
   const visibleFlags = new Array(n).fill(true);
   const revealScales = new Float32Array(n).fill(1);
-  const brightnessMultipliers = new Float32Array(n).fill(1);
 
   function writeMatrix(i: number) {
     const sz = visibleFlags[i] ? nodeSizes[i]! * revealScales[i]! : 0;
@@ -237,6 +315,15 @@ export function createNodes(
     mesh.setMatrixAt(i, dummy.matrix);
   }
 
+  // Selected wins over highlighted, matching original branching.
+  function writeState(i: number) {
+    const s = selected.has(i) ? 2 : highlighted.has(i) ? 1 : 0;
+    if (stateArr[i] !== s) {
+      stateArr[i] = s;
+      stateAttr.needsUpdate = true;
+    }
+  }
+
   return {
     mesh,
     count: n,
@@ -249,17 +336,26 @@ export function createNodes(
     setHighlight(i, on) {
       if (on) highlighted.add(i);
       else highlighted.delete(i);
+      writeState(i);
     },
     setSelected(i, on) {
       if (on) selected.add(i);
       else selected.delete(i);
+      writeState(i);
     },
     setBrightness(i, multiplier) {
-      brightnessMultipliers[i] = Math.max(0, multiplier);
+      const v = Math.max(0, multiplier);
+      if (brightnessArr[i] !== v) {
+        brightnessArr[i] = v;
+        brightnessAttr.needsUpdate = true;
+      }
     },
     setDim(i, on) {
-      if (on) dimmed.add(i);
-      else dimmed.delete(i);
+      const v = on ? 1 : 0;
+      if (dimArr[i] !== v) {
+        dimArr[i] = v;
+        dimAttr.needsUpdate = true;
+      }
     },
     setRevealScale(i, scale) {
       revealScales[i] = Math.max(0, scale);
@@ -270,46 +366,10 @@ export function createNodes(
       writeMatrix(i);
     },
     setTime(t: number) {
-      const colorAttr = mesh.instanceColor!;
-      for (let i = 0; i < n; i++) {
-        if (selected.has(i)) {
-          colorAttr.setXYZ(
-            i,
-            selectedColor.r,
-            selectedColor.g,
-            selectedColor.b,
-          );
-          continue;
-        }
-        if (highlighted.has(i)) {
-          colorAttr.setXYZ(
-            i,
-            highlightColor.r,
-            highlightColor.g,
-            highlightColor.b,
-          );
-          continue;
-        }
-        const tint = nodeColors[i]!;
-        // Gentle wavy blink: slow traveling wave across the constellation
-        const twinkle = 1.0 + 0.12 * Math.sin(t * 1.5 + nodeWaveOffsets[i]!);
-        const brightness = brightnessMultipliers[i]!;
-        const dim = dimmed.has(i) ? DIM_FACTOR : 1.0;
-        colorAttr.setXYZ(
-          i,
-          Math.min(1, tint.r * twinkle * brightness * dim),
-          Math.min(1, tint.g * twinkle * brightness * dim),
-          Math.min(1, tint.b * twinkle * brightness * dim),
-        );
-      }
-      colorAttr.needsUpdate = true;
-    },
-    setCameraPosition(pos) {
-      material.uniforms.uCameraPos!.value.copy(pos);
+      material.uniforms.uTime!.value = t;
     },
     flush() {
       mesh.instanceMatrix.needsUpdate = true;
-      if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
     },
     dispose() {
       geometry.dispose();

--- a/theia-panel/src/scene/Nodes.ts
+++ b/theia-panel/src/scene/Nodes.ts
@@ -28,21 +28,59 @@ function makeGlowTexture(): THREE.Texture {
   return tex;
 }
 
-/** Derive a slight tint from the model name, keeping the base amber feel. */
-function modelTintColor(model: string | undefined): THREE.Color {
-  const base = new THREE.Color(PALETTE.nodeBase);
-  if (!model) return base;
-  const hash = hash01(model);
-  const hsl = { h: 0, s: 0, l: 0 };
-  base.getHSL(hsl);
-  // Shift hue +/- 25 degrees for visible but tasteful model distinction
-  hsl.h = (hsl.h + (hash - 0.5) * 0.14 + 1) % 1;
-  // Vary saturation and lightness subtly
-  hsl.s = Math.min(1, Math.max(0.3, hsl.s + (hash - 0.5) * 0.2));
-  hsl.l = Math.min(0.85, Math.max(0.25, hsl.l + (hash - 0.5) * 0.15));
-  const c = new THREE.Color();
-  c.setHSL(hsl.h, hsl.s, hsl.l);
-  return c;
+/** Stellar evolution color based on session age (started_at).
+ *  Youngest (hottest) → blue-white, oldest (coolest) → dark red.
+ */
+function stellarAgeColor(
+  startedAt: string,
+  minTime: number,
+  maxTime: number,
+  model?: string,
+): THREE.Color {
+  const rawT =
+    maxTime === minTime
+      ? 0.5
+      : (Date.parse(startedAt) - minTime) / (maxTime - minTime);
+  const t = Math.max(0, Math.min(1, rawT));
+
+  // Stellar-class gradient stops: hot/young → cool/old
+  const stops: { t: number; r: number; g: number; b: number }[] = [
+    { t: 0.0, r: 0.608, g: 0.710, b: 1.0 },   // blue-white (B-class)
+    { t: 0.2, r: 1.0, g: 1.0, b: 1.0 },        // white (A-class)
+    { t: 0.4, r: 1.0, g: 0.961, b: 0.882 },    // yellow-white (F-class)
+    { t: 0.55, r: 1.0, g: 0.82, b: 0.4 },      // yellow (G-class)
+    { t: 0.7, r: 1.0, g: 0.624, b: 0.263 },    // orange (K-class)
+    { t: 0.85, r: 0.906, g: 0.298, b: 0.235 }, // red (M-class)
+    { t: 1.0, r: 0.36, g: 0.039, b: 0.039 },   // dark red (old M)
+  ];
+
+  for (let i = 0; i < stops.length - 1; i++) {
+    const a = stops[i]!;
+    const b = stops[i + 1]!;
+    if (t >= a.t && t <= b.t) {
+      const localT = (t - a.t) / (b.t - a.t);
+      const c = new THREE.Color();
+      c.r = a.r + (b.r - a.r) * localT;
+      c.g = a.g + (b.g - a.g) * localT;
+      c.b = a.b + (b.b - a.b) * localT;
+
+      // Subtle model tint so same-age stars from different models
+      // remain faintly distinguishable without breaking the gradient.
+      if (model) {
+        const hash = hash01(model);
+        const hsl = { h: 0, s: 0, l: 0 };
+        c.getHSL(hsl);
+        hsl.h = (hsl.h + (hash - 0.5) * 0.05 + 1) % 1;
+        hsl.s = Math.min(1, Math.max(0.2, hsl.s + (hash - 0.5) * 0.06));
+        hsl.l = Math.min(0.9, Math.max(0.2, hsl.l + (hash - 0.5) * 0.05));
+        c.setHSL(hsl.h, hsl.s, hsl.l);
+      }
+      return c;
+    }
+  }
+
+  const last = stops[stops.length - 1]!;
+  return new THREE.Color(last.r, last.g, last.b);
 }
 
 const VERT = `
@@ -125,6 +163,21 @@ export function createNodes(
   const highlightColor = new THREE.Color(PALETTE.nodeHighlight);
   const selectedColor = new THREE.Color(PALETTE.nodeSelected);
 
+  // Compute time range for stellar age coloring
+  let minTime = Infinity;
+  let maxTime = -Infinity;
+  for (const node of graph.nodes) {
+    const ts = Date.parse(node.started_at);
+    if (Number.isFinite(ts)) {
+      minTime = Math.min(minTime, ts);
+      maxTime = Math.max(maxTime, ts);
+    }
+  }
+  if (!Number.isFinite(minTime)) {
+    minTime = 0;
+    maxTime = 1;
+  }
+
   // Precompute per-node size, color, and wave offset for spatial twinkling
   const nodeSizes = new Float32Array(n);
   const nodeColors: THREE.Color[] = new Array(n);
@@ -134,7 +187,12 @@ export function createNodes(
     const node = graph.nodes[i]!;
     const turns = node.message_count ?? node.tool_count;
     nodeSizes[i] = Math.min(0.18, 0.05 + Math.log1p(turns) * 0.014);
-    nodeColors[i] = modelTintColor(node.model);
+    nodeColors[i] = stellarAgeColor(
+      node.started_at,
+      minTime,
+      maxTime,
+      node.model,
+    );
     // Spatial wave: coherent ripple across the constellation
     nodeWaveOffsets[i] =
       node.position.x * 2.0 + node.position.y * 1.5 + hash01(node.id) * 3.0;

--- a/theia-panel/src/scene/Nodes.ts
+++ b/theia-panel/src/scene/Nodes.ts
@@ -358,10 +358,13 @@ export function createNodes(
       }
     },
     setRevealScale(i, scale) {
-      revealScales[i] = Math.max(0, scale);
+      const v = Math.max(0, scale);
+      if (revealScales[i] === v) return;
+      revealScales[i] = v;
       writeMatrix(i);
     },
     setVisible(i, visible) {
+      if (visibleFlags[i] === visible) return;
       visibleFlags[i] = visible;
       writeMatrix(i);
     },

--- a/theia-panel/src/scene/Nodes.ts
+++ b/theia-panel/src/scene/Nodes.ts
@@ -29,7 +29,9 @@ function makeGlowTexture(): THREE.Texture {
 }
 
 /** Stellar evolution color based on session age (started_at).
- *  Youngest (hottest) → blue-white, oldest (coolest) → dark red.
+ *  Youngest (hottest) → blue O-class, oldest (coolest) → dark red origin.
+ *  Stops follow the OFGKM spectral classification; nodes between two
+ *  classes get a linearly interpolated tint based on their creation date.
  */
 function stellarAgeColor(
   startedAt: string,
@@ -43,15 +45,16 @@ function stellarAgeColor(
       : (Date.parse(startedAt) - minTime) / (maxTime - minTime);
   const t = Math.max(0, Math.min(1, rawT));
 
-  // Stellar-class gradient stops: hot/young → cool/old
+  // Spectral-class gradient stops: hot/young → cool/old.
+  // O/F/G/K/M are evenly spaced; the final stop pulls the very oldest
+  // (origin) nodes into the darkest red.
   const stops: { t: number; r: number; g: number; b: number }[] = [
-    { t: 0.0, r: 0.608, g: 0.71, b: 1.0 }, // blue-white (B-class)
-    { t: 0.2, r: 1.0, g: 1.0, b: 1.0 }, // white (A-class)
-    { t: 0.4, r: 1.0, g: 0.961, b: 0.882 }, // yellow-white (F-class)
-    { t: 0.55, r: 1.0, g: 0.82, b: 0.4 }, // yellow (G-class)
-    { t: 0.7, r: 1.0, g: 0.624, b: 0.263 }, // orange (K-class)
-    { t: 0.85, r: 0.906, g: 0.298, b: 0.235 }, // red (M-class)
-    { t: 1.0, r: 0.36, g: 0.039, b: 0.039 }, // dark red (old M)
+    { t: 0.0, r: 0.36, g: 0.55, b: 1.0 }, // O — blue (Rigel, Spica, Bellatrix) ~25,000 K
+    { t: 0.25, r: 1.0, g: 1.0, b: 1.0 }, // F — white (Sirius, Vega) ~10,000 K
+    { t: 0.5, r: 1.0, g: 0.85, b: 0.4 }, // G — yellow (Proxima, the Sun) ~6,000 K
+    { t: 0.75, r: 1.0, g: 0.58, b: 0.22 }, // K — orange (Aldebaran, Arcturus) ~4,000 K
+    { t: 0.92, r: 0.92, g: 0.28, b: 0.2 }, // M — red (Antares, Betelgeuse) ~3,000 K
+    { t: 1.0, r: 0.36, g: 0.04, b: 0.04 }, // origin — darkest red (oldest)
   ];
 
   for (let i = 0; i < stops.length - 1; i++) {

--- a/theia-panel/src/scene/Nodes.ts
+++ b/theia-panel/src/scene/Nodes.ts
@@ -133,6 +133,7 @@ export interface NodeLayer {
   setHighlight(i: number, on: boolean): void;
   setSelected(i: number, on: boolean): void;
   setBrightness(i: number, multiplier: number): void;
+  setDim(i: number, on: boolean): void;
   setRevealScale(i: number, scale: number): void;
   setVisible(i: number, visible: boolean): void;
   setTime(t: number): void;
@@ -140,6 +141,8 @@ export interface NodeLayer {
   flush(): void;
   dispose(): void;
 }
+
+const DIM_FACTOR = 0.25;
 
 export function createNodes(
   graph: TheiaGraph,
@@ -216,6 +219,7 @@ export function createNodes(
 
   const highlighted = new Set<number>();
   const selected = new Set<number>();
+  const dimmed = new Set<number>();
   const visibleFlags = new Array(n).fill(true);
   const revealScales = new Float32Array(n).fill(1);
   const brightnessMultipliers = new Float32Array(n).fill(1);
@@ -253,6 +257,10 @@ export function createNodes(
     setBrightness(i, multiplier) {
       brightnessMultipliers[i] = Math.max(0, multiplier);
     },
+    setDim(i, on) {
+      if (on) dimmed.add(i);
+      else dimmed.delete(i);
+    },
     setRevealScale(i, scale) {
       revealScales[i] = Math.max(0, scale);
       writeMatrix(i);
@@ -286,11 +294,12 @@ export function createNodes(
         // Gentle wavy blink: slow traveling wave across the constellation
         const twinkle = 1.0 + 0.12 * Math.sin(t * 1.5 + nodeWaveOffsets[i]!);
         const brightness = brightnessMultipliers[i]!;
+        const dim = dimmed.has(i) ? DIM_FACTOR : 1.0;
         colorAttr.setXYZ(
           i,
-          Math.min(1, tint.r * twinkle * brightness),
-          Math.min(1, tint.g * twinkle * brightness),
-          Math.min(1, tint.b * twinkle * brightness),
+          Math.min(1, tint.r * twinkle * brightness * dim),
+          Math.min(1, tint.g * twinkle * brightness * dim),
+          Math.min(1, tint.b * twinkle * brightness * dim),
         );
       }
       colorAttr.needsUpdate = true;

--- a/theia-panel/src/scene/Nodes.ts
+++ b/theia-panel/src/scene/Nodes.ts
@@ -45,13 +45,13 @@ function stellarAgeColor(
 
   // Stellar-class gradient stops: hot/young → cool/old
   const stops: { t: number; r: number; g: number; b: number }[] = [
-    { t: 0.0, r: 0.608, g: 0.710, b: 1.0 },   // blue-white (B-class)
-    { t: 0.2, r: 1.0, g: 1.0, b: 1.0 },        // white (A-class)
-    { t: 0.4, r: 1.0, g: 0.961, b: 0.882 },    // yellow-white (F-class)
-    { t: 0.55, r: 1.0, g: 0.82, b: 0.4 },      // yellow (G-class)
-    { t: 0.7, r: 1.0, g: 0.624, b: 0.263 },    // orange (K-class)
+    { t: 0.0, r: 0.608, g: 0.71, b: 1.0 }, // blue-white (B-class)
+    { t: 0.2, r: 1.0, g: 1.0, b: 1.0 }, // white (A-class)
+    { t: 0.4, r: 1.0, g: 0.961, b: 0.882 }, // yellow-white (F-class)
+    { t: 0.55, r: 1.0, g: 0.82, b: 0.4 }, // yellow (G-class)
+    { t: 0.7, r: 1.0, g: 0.624, b: 0.263 }, // orange (K-class)
     { t: 0.85, r: 0.906, g: 0.298, b: 0.235 }, // red (M-class)
-    { t: 1.0, r: 0.36, g: 0.039, b: 0.039 },   // dark red (old M)
+    { t: 1.0, r: 0.36, g: 0.039, b: 0.039 }, // dark red (old M)
   ];
 
   for (let i = 0; i < stops.length - 1; i++) {

--- a/theia-panel/src/scene/Picker.ts
+++ b/theia-panel/src/scene/Picker.ts
@@ -1,11 +1,21 @@
 import * as THREE from "three";
 import type { NodeLayer } from "./Nodes";
+import type { TheiaGraph } from "../data/types";
+
+type GraphEdge = TheiaGraph["edges"][number];
 
 export interface PickerOptions {
   maxDistance?: number; // world units — nodes farther than this are ignored
   sizeScale?: number; // multiplier for projected node radius
   shouldBlock?: () => boolean;
   isVisible?: (i: number) => boolean;
+  // Edge picking — pickable when no node is under the cursor
+  getEdges?: () => Array<{
+    edge: GraphEdge;
+    sourceIdx: number;
+    targetIdx: number;
+  }>;
+  edgeNdcThreshold?: number; // NDC distance within which an edge counts as hit
 }
 
 export function createPicker(
@@ -18,9 +28,20 @@ export function createPicker(
   const ndc = new THREE.Vector2();
   const pos = new THREE.Vector3();
   const cameraPos = new THREE.Vector3();
+  const sProj = new THREE.Vector3();
+  const tProj = new THREE.Vector3();
   let hovered: number | null = null;
+  let hoveredEdge: GraphEdge | null = null;
   const listeners: Array<(i: number | null) => void> = [];
-  const { maxDistance = 30, sizeScale = 1.1, shouldBlock, isVisible } = options;
+  const edgeListeners: Array<(edge: GraphEdge | null) => void> = [];
+  const {
+    maxDistance = 30,
+    sizeScale = 1.1,
+    shouldBlock,
+    isVisible,
+    getEdges,
+    edgeNdcThreshold = 0.012,
+  } = options;
 
   function pickNDC(
     ndcX: number,
@@ -63,6 +84,53 @@ export function createPicker(
     return bestIdx;
   }
 
+  function pickEdgeNDC(ndcX: number, ndcY: number): GraphEdge | null {
+    if (!getEdges) return null;
+    const edges = getEdges();
+    if (edges.length === 0) return null;
+    let bestEdge: GraphEdge | null = null;
+    let bestDist = edgeNdcThreshold;
+    for (const { edge, sourceIdx, targetIdx } of edges) {
+      const sx = nodePositions[sourceIdx * 3 + 0];
+      const sy = nodePositions[sourceIdx * 3 + 1];
+      const sz = nodePositions[sourceIdx * 3 + 2];
+      const tx = nodePositions[targetIdx * 3 + 0];
+      const ty = nodePositions[targetIdx * 3 + 1];
+      const tz = nodePositions[targetIdx * 3 + 2];
+      if (
+        sx === undefined ||
+        sy === undefined ||
+        sz === undefined ||
+        tx === undefined ||
+        ty === undefined ||
+        tz === undefined
+      ) {
+        continue;
+      }
+      sProj.set(sx, sy, sz).project(camera);
+      tProj.set(tx, ty, tz).project(camera);
+      // Only consider edges in front of the camera plane
+      if (sProj.z > 1 || tProj.z > 1 || sProj.z < -1 || tProj.z < -1) continue;
+      const dx = tProj.x - sProj.x;
+      const dy = tProj.y - sProj.y;
+      const len2 = dx * dx + dy * dy;
+      if (len2 < 1e-10) continue;
+      const px = ndcX - sProj.x;
+      const py = ndcY - sProj.y;
+      const tParam = Math.max(0, Math.min(1, (px * dx + py * dy) / len2));
+      const cx = sProj.x + tParam * dx;
+      const cy = sProj.y + tParam * dy;
+      const ddx = ndcX - cx;
+      const ddy = ndcY - cy;
+      const dist = Math.sqrt(ddx * ddx + ddy * ddy);
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestEdge = edge;
+      }
+    }
+    return bestEdge;
+  }
+
   function onMove(evt: MouseEvent) {
     if (shouldBlock?.()) return;
     if ((evt.target as HTMLElement).closest("[data-ui-overlay]")) return;
@@ -73,7 +141,7 @@ export function createPicker(
 
     const bestIdx = pickNDC(ndc.x, ndc.y, 1.0);
 
-    // Sticky hover: only transition from hovered→null, never hoveredA→hoveredB
+    // Sticky hover for nodes: only transition node-hover → null, never A→B
     if (hovered !== null && bestIdx !== null && bestIdx !== hovered) {
       return;
     }
@@ -81,6 +149,13 @@ export function createPicker(
     if (bestIdx !== hovered) {
       hovered = bestIdx;
       listeners.forEach((fn) => fn(bestIdx));
+    }
+
+    // Edge hover only fires when no node is under the cursor — nodes win.
+    const nextEdge = bestIdx === null ? pickEdgeNDC(ndc.x, ndc.y) : null;
+    if (nextEdge !== hoveredEdge) {
+      hoveredEdge = nextEdge;
+      edgeListeners.forEach((fn) => fn(nextEdge));
     }
   }
 
@@ -90,8 +165,14 @@ export function createPicker(
     onHover(fn: (i: number | null) => void) {
       listeners.push(fn);
     },
+    onHoverEdge(fn: (edge: GraphEdge | null) => void) {
+      edgeListeners.push(fn);
+    },
     currentHovered() {
       return hovered;
+    },
+    currentHoveredEdge() {
+      return hoveredEdge;
     },
     /**
      * Perform a one-off pick at screen coordinates.

--- a/theia-panel/src/scene/Picker.ts
+++ b/theia-panel/src/scene/Picker.ts
@@ -131,9 +131,19 @@ export function createPicker(
     return bestEdge;
   }
 
+  // Cap raycast at ~20fps. With a few thousand nodes the per-move scan
+  // adds up; every 50ms is below the perceptual hover-feedback threshold
+  // and matches the throttle convention in the threejs-interaction skill.
+  const HOVER_THROTTLE_MS = 50;
+  let lastHoverAt = 0;
+
   function onMove(evt: MouseEvent) {
     if (shouldBlock?.()) return;
     if ((evt.target as HTMLElement).closest("[data-ui-overlay]")) return;
+
+    const now = performance.now();
+    if (now - lastHoverAt < HOVER_THROTTLE_MS) return;
+    lastHoverAt = now;
 
     const rect = container.getBoundingClientRect();
     ndc.x = ((evt.clientX - rect.left) / rect.width) * 2 - 1;

--- a/theia-panel/src/scene/Scene.ts
+++ b/theia-panel/src/scene/Scene.ts
@@ -72,6 +72,9 @@ export function createScene(container: HTMLElement): SceneContext {
     0.01,
     100,
   );
+  // Generous extent for graph spread past the orbit target. d3 layouts
+  // settle within ~30 units; 100 leaves room for panning + outliers.
+  const SCENE_EXTENT = 100;
 
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
   renderer.setPixelRatio(effectivePixelRatio());
@@ -96,6 +99,18 @@ export function createScene(container: HTMLElement): SceneContext {
     camera.position.y = target.y + radius * Math.cos(phi);
     camera.position.z = target.z + radius * Math.sin(phi) * Math.cos(theta);
     camera.lookAt(target);
+    // Adapt the depth slab to the current orbit radius so nodes/edges on
+    // the far side of the target don't clip when zoomed out, and close
+    // ones don't clip when zoomed in. Fixed near=0.01/far=100 used to
+    // line up with max-zoom-out radius (100) — anything past target
+    // disappeared into the clear color.
+    const nextNear = Math.max(0.01, radius * 0.01);
+    const nextFar = radius + SCENE_EXTENT;
+    if (camera.near !== nextNear || camera.far !== nextFar) {
+      camera.near = nextNear;
+      camera.far = nextFar;
+      camera.updateProjectionMatrix();
+    }
   }
   updateCamera();
 

--- a/theia-panel/src/scene/Scene.ts
+++ b/theia-panel/src/scene/Scene.ts
@@ -14,6 +14,11 @@ export interface SceneContext {
   container: HTMLElement;
   pan(dxPixel: number, dyPixel: number): void;
   focusOn(x: number, y: number, targetZoom?: number): void;
+  /**
+   * Animate the camera back to the initial framing: origin target,
+   * front-on rotation, default zoom (the "fitted" view).
+   */
+  resetView(): void;
   setZoom(z: number): void;
   getZoom(): number;
   rotate(dxPixel: number, dyPixel: number): void;
@@ -159,6 +164,38 @@ export function createScene(container: HTMLElement): SceneContext {
         if (t < 1) {
           rafId = requestAnimationFrame(step);
         } else {
+          rafId = null;
+        }
+      }
+      rafId = requestAnimationFrame(step);
+    },
+    resetView() {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      const startTarget = target.clone();
+      const startRadius = radius;
+      const startTheta = theta;
+      const startPhi = phi;
+      const endZoom = 0.5; // matches initial setZoom(0.5) in mount()
+      const endRadius = baseRadius / endZoom;
+      const endTheta = 0;
+      const endPhi = Math.PI / 2;
+      const startTime = performance.now();
+      const duration = 700;
+
+      function step(now: number) {
+        const t = Math.min(1, (now - startTime) / duration);
+        const ease = 1 - Math.pow(1 - t, 3);
+        target.x = startTarget.x + (0 - startTarget.x) * ease;
+        target.y = startTarget.y + (0 - startTarget.y) * ease;
+        target.z = startTarget.z + (0 - startTarget.z) * ease;
+        theta = startTheta + (endTheta - startTheta) * ease;
+        phi = startPhi + (endPhi - startPhi) * ease;
+        radius = startRadius + (endRadius - startRadius) * ease;
+        updateCamera();
+        if (t < 1) {
+          rafId = requestAnimationFrame(step);
+        } else {
+          zoom = endZoom;
           rafId = null;
         }
       }

--- a/theia-panel/src/scene/Scene.ts
+++ b/theia-panel/src/scene/Scene.ts
@@ -72,9 +72,13 @@ export function createScene(container: HTMLElement): SceneContext {
     0.01,
     100,
   );
-  // Generous extent for graph spread past the orbit target. d3 layouts
-  // settle within ~30 units; 100 leaves room for panning + outliers.
-  const SCENE_EXTENT = 100;
+  // Generous bound on the graph radius from the world origin. Used to
+  // size the far plane: camera-to-node distance is bounded by
+  // |target| + radius + SCENE_RADIUS (triangle inequality), so we can
+  // pick a constant here without plumbing live node bounds in. Bumped
+  // generously — z-buffer precision impact is small and clipping is
+  // far more user-visible than depth fighting.
+  const SCENE_RADIUS = 500;
 
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
   renderer.setPixelRatio(effectivePixelRatio());
@@ -99,13 +103,14 @@ export function createScene(container: HTMLElement): SceneContext {
     camera.position.y = target.y + radius * Math.cos(phi);
     camera.position.z = target.z + radius * Math.sin(phi) * Math.cos(theta);
     camera.lookAt(target);
-    // Adapt the depth slab to the current orbit radius so nodes/edges on
-    // the far side of the target don't clip when zoomed out, and close
-    // ones don't clip when zoomed in. Fixed near=0.01/far=100 used to
-    // line up with max-zoom-out radius (100) — anything past target
-    // disappeared into the clear color.
+    // Adapt the depth slab so nothing clips. Far bound by triangle
+    // inequality: d(W, camera) ≤ |W| + |target| + radius, and |W| is
+    // capped by SCENE_RADIUS. Without |target| in this sum, panning or
+    // search-focusing to an edge node clipped opposite-side nodes
+    // because target moved out of origin.
+    const targetDist = Math.hypot(target.x, target.y, target.z);
     const nextNear = Math.max(0.01, radius * 0.01);
-    const nextFar = radius + SCENE_EXTENT;
+    const nextFar = radius + targetDist + SCENE_RADIUS;
     if (camera.near !== nextNear || camera.far !== nextFar) {
       camera.near = nextNear;
       camera.far = nextFar;
@@ -140,7 +145,13 @@ export function createScene(container: HTMLElement): SceneContext {
     renderer,
     container,
     pan(dxPixel, dyPixel) {
-      const panSpeed = radius * 0.0015;
+      // 1:1 cursor-to-world pan: world units per CSS pixel at the
+      // target's depth = (2 * tan(fov/2) * radius) / canvasHeight. The
+      // old fixed `radius * 0.0015` multiplier was tuned for ~770px
+      // canvases and felt sluggish on taller viewports / larger graphs.
+      const canvasHeight = renderer.domElement.clientHeight || 1;
+      const fovRad = (camera.fov * Math.PI) / 180;
+      const panSpeed = (2 * Math.tan(fovRad / 2) * radius) / canvasHeight;
       right.setFromMatrixColumn(camera.matrixWorld, 0);
       up.setFromMatrixColumn(camera.matrixWorld, 1);
       target.x += (-right.x * dxPixel + up.x * dyPixel) * panSpeed;

--- a/theia-panel/src/scene/Scene.ts
+++ b/theia-panel/src/scene/Scene.ts
@@ -52,6 +52,15 @@ function fovForAspect(a: number): number {
   return BASE_FOV_DEG;
 }
 
+// Cap pixel ratio to bound fragment work on high-DPR displays. The post
+// pipeline allocates four full-resolution HalfFloat render targets plus
+// runs a multi-pass composer + UnrealBloom — fragment cost scales with
+// dpr², so a 3× display would do 9× the shading of a 1× reference.
+// 2× is enough to look crisp without paying the full retina tax.
+const MAX_PIXEL_RATIO = 2;
+const effectivePixelRatio = (): number =>
+  Math.min(window.devicePixelRatio, MAX_PIXEL_RATIO);
+
 export function createScene(container: HTMLElement): SceneContext {
   const scene = new THREE.Scene();
 
@@ -65,7 +74,7 @@ export function createScene(container: HTMLElement): SceneContext {
   );
 
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
-  renderer.setPixelRatio(window.devicePixelRatio);
+  renderer.setPixelRatio(effectivePixelRatio());
   renderer.setSize(w, h, true);
   renderer.domElement.style.display = "block";
   container.appendChild(renderer.domElement);
@@ -102,7 +111,7 @@ export function createScene(container: HTMLElement): SceneContext {
     // Re-sync DPR — fullscreen transitions and monitor changes can
     // change devicePixelRatio, and the renderer caches it from the
     // first setPixelRatio call.
-    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setPixelRatio(effectivePixelRatio());
     renderer.setSize(w2, h2, true);
     for (const fn of resizeListeners) fn();
   };

--- a/theia-panel/src/scene/chain.test.ts
+++ b/theia-panel/src/scene/chain.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { computeEdgeChain } from "./chain";
+import type { TheiaGraph } from "../data/types";
+
+type EdgeKind = TheiaGraph["edges"][number]["kind"];
+type GraphEdge = TheiaGraph["edges"][number];
+type GraphNode = TheiaGraph["nodes"][number];
+
+const ALL_KINDS: Set<EdgeKind> = new Set([
+  "memory-share",
+  "cross-search",
+  "tool-overlap",
+  "subagent",
+  "cron-chain",
+]);
+
+function node(id: string): GraphNode {
+  return {
+    id,
+    title: id,
+    started_at: "2026-04-20T00:00:00Z",
+    duration_sec: 0,
+    tool_count: 0,
+    position: { x: 0, y: 0 },
+  };
+}
+
+function edge(
+  source: string,
+  target: string,
+  kind: EdgeKind = "memory-share",
+): GraphEdge {
+  return { source, target, kind, weight: 1 };
+}
+
+function graph(nodes: string[], edges: GraphEdge[]): TheiaGraph {
+  return {
+    meta: {
+      generated_at: "2026-04-20T00:00:00Z",
+      source_count: nodes.length,
+      projection: "pca",
+    },
+    nodes: nodes.map(node),
+    edges,
+  };
+}
+
+function visible(g: TheiaGraph): Set<string> {
+  return new Set(g.nodes.map((n) => n.id));
+}
+
+describe("computeEdgeChain", () => {
+  it("returns just the two endpoints for an isolated edge", () => {
+    const g = graph(["a", "b"], [edge("a", "b")]);
+    const chain = computeEdgeChain(g, ["a", "b"], ALL_KINDS, visible(g));
+    expect([...chain.nodes].sort()).toEqual(["a", "b"]);
+    expect(chain.edgeCount).toBe(1);
+  });
+
+  it("walks a linear chain past depth 1 from a single seed", () => {
+    // a — b — c — d  (BFS from b should reach a, c, d)
+    const g = graph(
+      ["a", "b", "c", "d"],
+      [edge("a", "b"), edge("b", "c"), edge("c", "d")],
+    );
+    const chain = computeEdgeChain(g, ["b", "c"], ALL_KINDS, visible(g));
+    expect([...chain.nodes].sort()).toEqual(["a", "b", "c", "d"]);
+    expect(chain.edgeCount).toBe(3);
+  });
+
+  it("isolates the seed component when multiple components exist", () => {
+    // component 1: a—b—c    component 2: x—y
+    const g = graph(
+      ["a", "b", "c", "x", "y"],
+      [edge("a", "b"), edge("b", "c"), edge("x", "y")],
+    );
+    const chain = computeEdgeChain(g, ["a", "b"], ALL_KINDS, visible(g));
+    expect([...chain.nodes].sort()).toEqual(["a", "b", "c"]);
+    expect(chain.edgeCount).toBe(2);
+  });
+
+  it("does not traverse through edges of disabled kinds", () => {
+    // a —[memory]— b —[subagent]— c —[memory]— d
+    // With subagent disabled, BFS from a—b should NOT reach c or d.
+    const g = graph(
+      ["a", "b", "c", "d"],
+      [
+        edge("a", "b", "memory-share"),
+        edge("b", "c", "subagent"),
+        edge("c", "d", "memory-share"),
+      ],
+    );
+    const enabled: Set<EdgeKind> = new Set(["memory-share"]);
+    const chain = computeEdgeChain(g, ["a", "b"], enabled, visible(g));
+    expect([...chain.nodes].sort()).toEqual(["a", "b"]);
+    expect(chain.edgeCount).toBe(1);
+  });
+
+  it("does not traverse through hidden nodes", () => {
+    // a — b — c — d, but b is filtered out of visibleNodeIds.
+    // Seed at c should reach c and d, but not a (b blocks the path).
+    const g = graph(
+      ["a", "b", "c", "d"],
+      [edge("a", "b"), edge("b", "c"), edge("c", "d")],
+    );
+    const visibleSet = new Set(["a", "c", "d"]);
+    const chain = computeEdgeChain(g, ["c", "d"], ALL_KINDS, visibleSet);
+    expect([...chain.nodes].sort()).toEqual(["c", "d"]);
+    expect(chain.edgeCount).toBe(1);
+  });
+
+  it("handles cycles without infinite-looping", () => {
+    // Triangle a—b—c—a, plus a tail c—d.
+    const g = graph(
+      ["a", "b", "c", "d"],
+      [edge("a", "b"), edge("b", "c"), edge("c", "a"), edge("c", "d")],
+    );
+    const chain = computeEdgeChain(g, ["a", "b"], ALL_KINDS, visible(g));
+    expect([...chain.nodes].sort()).toEqual(["a", "b", "c", "d"]);
+    expect(chain.edgeCount).toBe(4);
+  });
+
+  it("returns an empty chain when no seed is visible", () => {
+    const g = graph(["a", "b"], [edge("a", "b")]);
+    const chain = computeEdgeChain(g, ["a", "b"], ALL_KINDS, new Set());
+    expect(chain.nodes.size).toBe(0);
+    expect(chain.edgeCount).toBe(0);
+  });
+
+  it("counts deduplicated parallel edges between the same pair", () => {
+    // Two edges of different kinds between a—b should both count
+    // (the chain BFS doesn't dedupe; it reflects the underlying edge list).
+    const g = graph(
+      ["a", "b"],
+      [edge("a", "b", "memory-share"), edge("a", "b", "cross-search")],
+    );
+    const chain = computeEdgeChain(g, ["a"], ALL_KINDS, visible(g));
+    expect([...chain.nodes].sort()).toEqual(["a", "b"]);
+    expect(chain.edgeCount).toBe(2);
+  });
+});

--- a/theia-panel/src/scene/chain.ts
+++ b/theia-panel/src/scene/chain.ts
@@ -1,0 +1,69 @@
+import type { TheiaGraph } from "../data/types";
+
+type GraphEdge = TheiaGraph["edges"][number];
+
+export interface EdgeChain {
+  nodes: Set<string>;
+  edgeCount: number;
+}
+
+/**
+ * Undirected BFS over edges of `enabledKinds`, restricted to `visibleNodeIds`.
+ * Returns the connected component containing `seedIds`, plus the edge count
+ * fully contained within that component (used for the chain overlay label).
+ *
+ * Pure: no DOM, no THREE, no closure over module state.
+ */
+export function computeEdgeChain(
+  graph: TheiaGraph,
+  seedIds: Iterable<string>,
+  enabledKinds: Set<GraphEdge["kind"]>,
+  visibleNodeIds: ReadonlySet<string>,
+): EdgeChain {
+  const adjacency = new Map<string, string[]>();
+  for (const edge of graph.edges) {
+    if (!enabledKinds.has(edge.kind)) continue;
+    if (!visibleNodeIds.has(edge.source) || !visibleNodeIds.has(edge.target)) {
+      continue;
+    }
+    let aList = adjacency.get(edge.source);
+    if (!aList) {
+      aList = [];
+      adjacency.set(edge.source, aList);
+    }
+    aList.push(edge.target);
+    let bList = adjacency.get(edge.target);
+    if (!bList) {
+      bList = [];
+      adjacency.set(edge.target, bList);
+    }
+    bList.push(edge.source);
+  }
+
+  const visited = new Set<string>();
+  const queue: string[] = [];
+  for (const id of seedIds) {
+    if (visibleNodeIds.has(id) && !visited.has(id)) {
+      visited.add(id);
+      queue.push(id);
+    }
+  }
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    const neighbors = adjacency.get(id);
+    if (!neighbors) continue;
+    for (const n of neighbors) {
+      if (!visited.has(n)) {
+        visited.add(n);
+        queue.push(n);
+      }
+    }
+  }
+
+  let edgeCount = 0;
+  for (const edge of graph.edges) {
+    if (!enabledKinds.has(edge.kind)) continue;
+    if (visited.has(edge.source) && visited.has(edge.target)) edgeCount++;
+  }
+  return { nodes: visited, edgeCount };
+}

--- a/theia-panel/src/state/filterState.ts
+++ b/theia-panel/src/state/filterState.ts
@@ -1,0 +1,119 @@
+import type { TheiaGraph } from "../data/types";
+
+export const VALID_KINDS: TheiaGraph["edges"][number]["kind"][] = [
+  "memory-share",
+  "cross-search",
+  "tool-overlap",
+  "subagent",
+  "cron-chain",
+];
+
+export const DEFAULT_KINDS: TheiaGraph["edges"][number]["kind"][] = VALID_KINDS;
+
+export const STORAGE_KEY = "theia-constellation-filter";
+
+export function loadFilterState(): {
+  kinds: Set<TheiaGraph["edges"][number]["kind"]>;
+  model: string | null;
+  searchFocus: boolean;
+  hideOrphans: boolean;
+  componentFocus: boolean;
+} | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    const parsedKinds = Array.isArray(parsed?.kinds)
+      ? parsed.kinds.filter(
+          (k: unknown): k is TheiaGraph["edges"][number]["kind"] =>
+            (VALID_KINDS as readonly unknown[]).includes(k),
+        )
+      : DEFAULT_KINDS;
+    return {
+      kinds: new Set(parsedKinds.length > 0 ? parsedKinds : DEFAULT_KINDS),
+      model: typeof parsed?.model === "string" ? parsed.model : null,
+      searchFocus: parsed?.searchFocus === true,
+      hideOrphans: parsed?.hideOrphans === true,
+      componentFocus: parsed?.componentFocus === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function saveFilterState(
+  kinds: Set<string>,
+  model: string | null,
+  searchFocus: boolean,
+  hideOrphans: boolean,
+  componentFocus: boolean,
+): void {
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        kinds: Array.from(kinds),
+        model,
+        searchFocus,
+        hideOrphans,
+        componentFocus,
+      }),
+    );
+  } catch {
+    /* quota exceeded, ignore */
+  }
+}
+
+export function computeVisibleNodeIds(
+  graph: TheiaGraph,
+  enabledKinds: Set<string>,
+  modelFilter?: string | null,
+  hideOrphans = false,
+): Set<string> {
+  const kindVisible = new Set<string>();
+  if (enabledKinds.has("subagent")) {
+    for (const node of graph.nodes) {
+      kindVisible.add(node.id);
+    }
+  } else {
+    const subagentIds = new Set<string>();
+    const hasNonSubagentConnection = new Map<string, boolean>();
+    for (const node of graph.nodes) {
+      if (node.parent_id) {
+        subagentIds.add(node.id);
+      } else {
+        hasNonSubagentConnection.set(node.id, true);
+      }
+    }
+    for (const edge of graph.edges) {
+      if (edge.kind === "subagent") continue;
+      if (!enabledKinds.has(edge.kind)) continue;
+      if (!subagentIds.has(edge.source)) {
+        hasNonSubagentConnection.set(edge.source, true);
+      }
+      if (!subagentIds.has(edge.target)) {
+        hasNonSubagentConnection.set(edge.target, true);
+      }
+    }
+    for (const node of graph.nodes) {
+      if (hasNonSubagentConnection.get(node.id)) {
+        kindVisible.add(node.id);
+      }
+    }
+  }
+  if (hideOrphans) {
+    for (const node of graph.nodes) {
+      if (node.metadata?.is_orphan) kindVisible.delete(node.id);
+    }
+  }
+  if (modelFilter) {
+    const modelMatch = new Set<string>();
+    for (const node of graph.nodes) {
+      if (node.model === modelFilter && kindVisible.has(node.id)) {
+        modelMatch.add(node.id);
+      }
+    }
+    return modelMatch;
+  }
+  return kindVisible;
+}

--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -293,15 +293,22 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
       deps.ctx.setCameraState({ ...cam, theta: cam.theta + rotationDelta });
     }
 
-    // Throttle the heavy rebuild path; always force one final rebuild
-    // when the last node has been revealed so the simulation gets the
-    // full active set before settling.
     const sawNewReveals = revealCount !== state.lastRevealedCount;
     state.lastRevealedCount = revealCount;
     const finalReveal = revealCount === state.order.length;
     const newSinceRebuild = revealCount - state.lastRebuiltRevealCount;
     const enoughNewToRebuild =
       newSinceRebuild >= minRebuildDelta(state.order.length);
+
+    // Make newly revealed nodes visible immediately so they don't wait
+    // for the heavy rebuild throttle — that caused "plops" where 20-30
+    // nodes appeared at once after a black-screen delay.
+    if (sawNewReveals) {
+      deps.setNodeVisibilityFromState();
+    }
+
+    // Throttle the heavy rebuild path (edges + worker simulation);
+    // always force one final rebuild when the last node is revealed.
     if (
       sawNewReveals &&
       (finalReveal ||
@@ -310,7 +317,6 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
     ) {
       state.lastHeavyRebuildAt = now;
       state.lastRebuiltRevealCount = revealCount;
-      deps.setNodeVisibilityFromState();
       deps.rebuildVisibleEdges();
       deps.simState().replaceActive({
         activeIds: deps.activeVisibleNodeIds(),

--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -12,7 +12,7 @@ const ONBOARDING_LINK_UP_MS = 700;
 // Camera zoom progressively retreats across the reveal so the user can
 // watch the constellation expand into view. Driven by raw time progress
 // (not reveal fraction) so the zoom-out feels steady regardless of how
-// the supernova-then-easeOutQuad reveal lands nodes.
+// the supernova-burst-then-easeInOutCubic reveal lands nodes.
 const ONBOARDING_START_ZOOM = 0.72;
 const ONBOARDING_END_ZOOM = 0.32;
 
@@ -31,24 +31,23 @@ function onboardingDurationMs(nodeCount: number): number {
   );
 }
 
-// Reveal progression: a "supernova" front-loads the first quarter of
-// the constellation in the opening burst, then easeOutQuad eases the
-// rest in across the remaining duration.
-const SUPERNOVA_DURATION_FRAC = 0.18;
-const SUPERNOVA_NODE_FRAC = 1 / 4;
+// Reveal progression: a "supernova" pops the first 10% of the
+// constellation in a single burst at t=0, then easeInOutCubic eases
+// the remaining 90% in across the full duration. Front-loading the
+// burst as a simultaneous pop (instead of a fast linear ramp) keeps
+// the visual punchy — the previous ramp still spawned nodes one by
+// one, just faster.
+const SUPERNOVA_NODE_FRAC = 0.1;
+function easeInOutCubic(t: number): number {
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}
 function onboardingRevealFraction(rawProgress: number): number {
   if (rawProgress <= 0) return 0;
   if (rawProgress >= 1) return 1;
-  if (rawProgress < SUPERNOVA_DURATION_FRAC) {
-    // Linear ramp through the supernova window — the per-node popScale
-    // animation supplies the explosive visual on top of this.
-    return (rawProgress / SUPERNOVA_DURATION_FRAC) * SUPERNOVA_NODE_FRAC;
-  }
-  const t =
-    (rawProgress - SUPERNOVA_DURATION_FRAC) / (1 - SUPERNOVA_DURATION_FRAC);
-  // easeOutQuad: 1 - (1-t)²
-  const easedRemaining = 1 - (1 - t) * (1 - t);
-  return SUPERNOVA_NODE_FRAC + easedRemaining * (1 - SUPERNOVA_NODE_FRAC);
+  return (
+    SUPERNOVA_NODE_FRAC +
+    easeInOutCubic(rawProgress) * (1 - SUPERNOVA_NODE_FRAC)
+  );
 }
 
 function easeQuadInOut(t: number): number {
@@ -223,9 +222,9 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
     const graph = deps.graph();
     const nodes = deps.nodes();
     const raw = Math.min(1, (now - state.startedAt) / state.durationMs);
-    // Camera rotation rides the smooth in-out curve; reveal rides the
-    // supernova-then-easeOutQuad curve. Decoupled so the camera doesn't
-    // lurch at the supernova→quad seam.
+    // Camera rotation rides easeQuadInOut; reveal rides the
+    // supernova-burst-then-easeInOutCubic curve. Decoupled so the
+    // camera motion stays smooth even as nodes pop in.
     const eased = easeQuadInOut(raw);
     const revealFloat = onboardingRevealFraction(raw) * state.order.length;
     const revealCount = Math.min(state.order.length, Math.ceil(revealFloat));

--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -31,27 +31,34 @@ function onboardingDurationMs(nodeCount: number): number {
   );
 }
 
-// Reveal progression: a "supernova" pops the first 10% of the
-// constellation in a single burst at t=0, then easeInOutCubic eases
-// the remaining 90% in across the full duration. Front-loading the
-// burst as a simultaneous pop (instead of a fast linear ramp) keeps
-// the visual punchy — the previous ramp still spawned nodes one by
-// one, just faster.
-const SUPERNOVA_NODE_FRAC = 0.1;
+function easeQuadInOut(t: number): number {
+  return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+}
+
 function easeInOutCubic(t: number): number {
   return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
 }
+
+// Reveal progression: an easeQuadInOut warmup eases the first
+// WARMUP_NODE_FRAC of nodes in across WARMUP_DURATION_FRAC of duration,
+// then easeInOutCubic takes over for the rest. The previous version
+// popped 10% of nodes in a single frame at t=0, which slammed the
+// worker with one big replaceActive (full sim rebuild) plus dozens of
+// concurrent popScale animations — a visible FPS dip right at the
+// moment the user starts watching. The warmup spreads that startup
+// cost over ~1-2s. Both easings have zero derivative at the seam, so
+// the rate transition is smooth.
+const WARMUP_DURATION_FRAC = 0.1;
+const WARMUP_NODE_FRAC = 0.1;
 function onboardingRevealFraction(rawProgress: number): number {
   if (rawProgress <= 0) return 0;
   if (rawProgress >= 1) return 1;
-  return (
-    SUPERNOVA_NODE_FRAC +
-    easeInOutCubic(rawProgress) * (1 - SUPERNOVA_NODE_FRAC)
-  );
-}
-
-function easeQuadInOut(t: number): number {
-  return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+  if (rawProgress < WARMUP_DURATION_FRAC) {
+    const t = rawProgress / WARMUP_DURATION_FRAC;
+    return easeQuadInOut(t) * WARMUP_NODE_FRAC;
+  }
+  const t = (rawProgress - WARMUP_DURATION_FRAC) / (1 - WARMUP_DURATION_FRAC);
+  return WARMUP_NODE_FRAC + easeInOutCubic(t) * (1 - WARMUP_NODE_FRAC);
 }
 
 function popScale(t: number): number {

--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -86,11 +86,20 @@ function markOnboardingComplete(): void {
 
 // Heavy rebuild throttle. Each rebuild iterates all nodes
 // (setNodeVisibilityFromState), regenerates the entire edges geometry
-// (rebuildVisibleEdges), and asks the worker to recreate the
-// d3-force-3d simulation for the new active set. With reveals crossing
-// integer boundaries multiple times per frame at 60Hz, an un-throttled
-// version would fire this on essentially every frame.
-const HEAVY_REBUILD_INTERVAL_MS = 150;
+// (rebuildVisibleEdges), and — most expensive — asks the worker to
+// recreate the d3-force-3d simulation for the new active set. The
+// worker rebuild blocks its own thread for tens of ms at 1.6k nodes,
+// pausing position updates and causing visible stutter. 400ms (was
+// 150ms) is still well below human reveal-cadence perception while
+// cutting rebuild frequency to 2.5/sec.
+const HEAVY_REBUILD_INTERVAL_MS = 400;
+// Don't rebuild for tiny reveal increments — wait until enough new
+// nodes have appeared to be worth a worker resync. Without this, the
+// long tail of one-node-per-frame reveals would still trigger a
+// rebuild every 400ms with only 1-2 new nodes each time.
+function minRebuildDelta(total: number): number {
+  return Math.max(20, Math.floor(total * 0.02));
+}
 
 export interface OnboardingDeps {
   element: HTMLElement;
@@ -133,12 +142,17 @@ interface OnboardingStateInternal {
   startedAt: number;
   durationMs: number;
   order: number[];
-  rankByIndex: Map<number, number>;
   revealedNodeIds: Set<string>;
   revealStartedAtByIndex: Map<number, number>;
   linkStartedAtByKey: Map<string, number>;
   lastRevealedCount: number;
   lastHeavyRebuildAt: number;
+  lastRebuiltRevealCount: number;
+  // Smallest rank whose reveal+blink animation is still in progress.
+  // Ranks below this are settled at scale=1, brightness=1; ranks above
+  // revealCount aren't yet revealed. Per-frame work only touches the
+  // active range, not all N nodes.
+  blinkMinRank: number;
   lastEase: number;
   cameraZoom: number;
   cameraAutoZoomEnabled: boolean;
@@ -165,12 +179,13 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
       startedAt: performance.now(),
       durationMs: onboardingDurationMs(g.nodes.length),
       order,
-      rankByIndex: new Map(order.map((index, rank) => [index, rank])),
       revealedNodeIds: new Set(),
       revealStartedAtByIndex: new Map(),
       linkStartedAtByKey: new Map(),
       lastRevealedCount: 0,
       lastHeavyRebuildAt: 0,
+      lastRebuiltRevealCount: 0,
+      blinkMinRank: 0,
       lastEase: 0,
       cameraZoom: ONBOARDING_START_ZOOM,
       cameraAutoZoomEnabled: true,
@@ -235,15 +250,28 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
       state.revealStartedAtByIndex.set(idx, now);
     }
 
-    for (const idx of state.order) {
-      const rank = state.rankByIndex.get(idx)!;
+    // Advance blinkMinRank past any rank that has fully settled.
+    // Settling them once (scale=1, brightness=1) and skipping in
+    // future frames is the big per-frame win — at 1.6k nodes the old
+    // loop touched every node every frame.
+    while (state.blinkMinRank < revealCount) {
+      const idx = state.order[state.blinkMinRank]!;
+      const revealedAt = state.revealStartedAtByIndex.get(idx)!;
+      if (now - revealedAt < ONBOARDING_BLINK_MS) break;
+      nodes.setRevealScale(idx, 1);
+      nodes.setBrightness(idx, 1);
+      state.blinkMinRank++;
+    }
+    // Active animation range — only nodes still popping or blinking.
+    for (let rank = state.blinkMinRank; rank < revealCount; rank++) {
+      const idx = state.order[rank]!;
       const localProgress = Math.max(0, Math.min(1, revealFloat - rank));
       nodes.setRevealScale(idx, popScale(localProgress));
-      const revealedAt = state.revealStartedAtByIndex.get(idx);
-      const blinkProgress =
-        revealedAt === undefined
-          ? 0
-          : Math.min(1, (now - revealedAt) / ONBOARDING_BLINK_MS);
+      const revealedAt = state.revealStartedAtByIndex.get(idx)!;
+      const blinkProgress = Math.min(
+        1,
+        (now - revealedAt) / ONBOARDING_BLINK_MS,
+      );
       nodes.setBrightness(idx, revealBrightness(blinkProgress));
     }
     updateOnboardingLinks(now);
@@ -261,12 +289,17 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
     const sawNewReveals = revealCount !== state.lastRevealedCount;
     state.lastRevealedCount = revealCount;
     const finalReveal = revealCount === state.order.length;
+    const newSinceRebuild = revealCount - state.lastRebuiltRevealCount;
+    const enoughNewToRebuild =
+      newSinceRebuild >= minRebuildDelta(state.order.length);
     if (
       sawNewReveals &&
       (finalReveal ||
-        now - state.lastHeavyRebuildAt > HEAVY_REBUILD_INTERVAL_MS)
+        (enoughNewToRebuild &&
+          now - state.lastHeavyRebuildAt > HEAVY_REBUILD_INTERVAL_MS))
     ) {
       state.lastHeavyRebuildAt = now;
+      state.lastRebuiltRevealCount = revealCount;
       deps.setNodeVisibilityFromState();
       deps.rebuildVisibleEdges();
       deps.simState().replaceActive({
@@ -295,20 +328,25 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
     }
 
     if (state.complete) {
-      let allBlinkDone = true;
-      for (const idx of state.order) {
+      // Same active-range trick: settle finished ranks once, only
+      // animate the still-blinking tail.
+      while (state.blinkMinRank < state.order.length) {
+        const idx = state.order[state.blinkMinRank]!;
+        const revealedAt = state.revealStartedAtByIndex.get(idx) ?? now;
+        if (now - revealedAt < ONBOARDING_BLINK_MS) break;
+        nodes.setBrightness(idx, 1);
+        state.blinkMinRank++;
+      }
+      for (let rank = state.blinkMinRank; rank < state.order.length; rank++) {
+        const idx = state.order[rank]!;
         const revealedAt = state.revealStartedAtByIndex.get(idx) ?? now;
         const blinkProgress = Math.min(
           1,
           (now - revealedAt) / ONBOARDING_BLINK_MS,
         );
         nodes.setBrightness(idx, revealBrightness(blinkProgress));
-        allBlinkDone &&= blinkProgress >= 1;
       }
-      if (allBlinkDone) {
-        for (const idx of state.order) {
-          nodes.setBrightness(idx, 1);
-        }
+      if (state.blinkMinRank >= state.order.length) {
         state = null;
         deps.edges.setConnectionProgress(null);
       }

--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -35,16 +35,39 @@ function easeQuadInOut(t: number): number {
   return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
 }
 
-// Group reveal rate: quadratic easeIn (`t²`). Linear was too dense
-// at frame 1 ("much at once"); easeInOutCubic was the opposite —
-// `cubic(0.1) ≈ 0.004` left the first ~2s essentially empty before
-// flooding the worker mid-reveal. Quadratic gives the gradual ramp
-// the user wants (1, then 2, then 4…) while still completing on
-// schedule.
-function onboardingRevealFraction(rawProgress: number): number {
+// Group reveal: piecewise.
+//   Phase 1 — slow individual reveals at SLOW_PHASE_INTERVAL_MS each,
+//     until either SLOW_PHASE_NODES_TARGET or SLOW_PHASE_MAX_FRACTION
+//     of total duration is reached. Restores the visible "1, then 2,
+//     then 4" pacing of the original onboarding for the *first ~16
+//     nodes* before the bulk reveal kicks in.
+//   Phase 2 — t² catches up the remaining nodes in the remaining time.
+//
+// Cap on phase 1 duration prevents the slow phase from monopolizing
+// short onboarding (e.g., 50 nodes / 5s would otherwise spend 4.8s on
+// the first 16 and blast 34 in 200ms).
+const SLOW_PHASE_NODES_TARGET = 16;
+const SLOW_PHASE_INTERVAL_MS = 300;
+const SLOW_PHASE_MAX_FRACTION = 0.3;
+function onboardingRevealFloat(
+  rawProgress: number,
+  durationMs: number,
+  totalNodes: number,
+): number {
   if (rawProgress <= 0) return 0;
-  if (rawProgress >= 1) return 1;
-  return rawProgress * rawProgress;
+  if (rawProgress >= 1) return totalNodes;
+  const elapsedMs = rawProgress * durationMs;
+  const idealSlowDur =
+    Math.min(SLOW_PHASE_NODES_TARGET, totalNodes) * SLOW_PHASE_INTERVAL_MS;
+  const slowDur = Math.min(idealSlowDur, durationMs * SLOW_PHASE_MAX_FRACTION);
+  const slowNodes = slowDur / SLOW_PHASE_INTERVAL_MS;
+  if (elapsedMs < slowDur) {
+    return elapsedMs / SLOW_PHASE_INTERVAL_MS;
+  }
+  const remainingNodes = totalNodes - slowNodes;
+  const remainingMs = durationMs - slowDur;
+  const phase2T = (elapsedMs - slowDur) / remainingMs;
+  return slowNodes + phase2T * phase2T * remainingNodes;
 }
 
 // Per-node entry animation. Driven by wall-clock since each node was
@@ -277,7 +300,11 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
     // and per-node pop is adaptive (matches spawn interval). Decoupled
     // so camera motion stays smooth as nodes appear.
     const eased = easeQuadInOut(raw);
-    const revealFloat = onboardingRevealFraction(raw) * state.order.length;
+    const revealFloat = onboardingRevealFloat(
+      raw,
+      state.durationMs,
+      state.order.length,
+    );
     const revealCount = Math.min(state.order.length, Math.ceil(revealFloat));
 
     const newRevealsThisFrame = revealCount - state.lastRevealedCount;

--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -1,0 +1,366 @@
+import type { TheiaGraph } from "../data/types";
+import type { NodeLayer } from "../scene/Nodes";
+import type { EdgeLayer } from "../scene/Edges";
+import type { SceneContext } from "../scene/Scene";
+import type { SimulationState } from "./simulation";
+import { createOnboardingOverlay } from "../ui/Overlays";
+
+const ONBOARDING_STORAGE_KEY = "theia-first-load-onboarding-complete";
+const ONBOARDING_ROTATION_RADIANS = Math.PI * 1.15;
+const ONBOARDING_BLINK_MS = 3200;
+const ONBOARDING_LINK_UP_MS = 700;
+const ONBOARDING_BASE_ZOOM = 0.72;
+const ONBOARDING_MIN_ZOOM = 0.42;
+const ONBOARDING_NEAR_DISTANCE = 3.2;
+const ONBOARDING_SAFE_DISTANCE = 5.6;
+
+// Onboarding duration scales gently with node count, but capped so the
+// first-load reveal stays in the 5-18s range. Previously this was
+// `ceil(N/3) * 1000`, which produced ~9 minutes for a 1.6k-node graph.
+// Keep deterministic so the overlay can confidently advertise progress.
+const ONBOARDING_MIN_DURATION_MS = 5000;
+const ONBOARDING_MAX_DURATION_MS = 18000;
+const ONBOARDING_MS_PER_NODE = 6;
+function onboardingDurationMs(nodeCount: number): number {
+  const raw = ONBOARDING_MIN_DURATION_MS + nodeCount * ONBOARDING_MS_PER_NODE;
+  return Math.min(
+    ONBOARDING_MAX_DURATION_MS,
+    Math.max(ONBOARDING_MIN_DURATION_MS, raw),
+  );
+}
+
+// Reveal progression: a "supernova" front-loads the first third of the
+// constellation in the opening burst, then easeOutQuad eases the rest
+// in across the remaining duration.
+const SUPERNOVA_DURATION_FRAC = 0.18;
+const SUPERNOVA_NODE_FRAC = 1 / 3;
+function onboardingRevealFraction(rawProgress: number): number {
+  if (rawProgress <= 0) return 0;
+  if (rawProgress >= 1) return 1;
+  if (rawProgress < SUPERNOVA_DURATION_FRAC) {
+    // Linear ramp through the supernova window — the per-node popScale
+    // animation supplies the explosive visual on top of this.
+    return (rawProgress / SUPERNOVA_DURATION_FRAC) * SUPERNOVA_NODE_FRAC;
+  }
+  const t =
+    (rawProgress - SUPERNOVA_DURATION_FRAC) / (1 - SUPERNOVA_DURATION_FRAC);
+  // easeOutQuad: 1 - (1-t)²
+  const easedRemaining = 1 - (1 - t) * (1 - t);
+  return SUPERNOVA_NODE_FRAC + easedRemaining * (1 - SUPERNOVA_NODE_FRAC);
+}
+
+function easeQuadInOut(t: number): number {
+  return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+}
+
+function popScale(t: number): number {
+  if (t <= 0) return 0;
+  if (t >= 1) return 1;
+  const eased = easeQuadInOut(t);
+  return 1 + 0.28 * Math.sin(Math.PI * eased);
+}
+
+function revealBrightness(t: number): number {
+  if (t <= 0) return 0;
+  if (t >= 1) return 1;
+  const eased = easeQuadInOut(t);
+  return 1 + 0.5 * Math.sin(Math.PI * eased);
+}
+
+export function hasCompletedOnboarding(): boolean {
+  try {
+    return localStorage.getItem(ONBOARDING_STORAGE_KEY) === "1";
+  } catch {
+    return true;
+  }
+}
+
+function markOnboardingComplete(): void {
+  try {
+    localStorage.setItem(ONBOARDING_STORAGE_KEY, "1");
+  } catch {
+    /* quota exceeded, ignore */
+  }
+}
+
+// Heavy rebuild throttle. Each rebuild iterates all nodes
+// (setNodeVisibilityFromState), regenerates the entire edges geometry
+// (rebuildVisibleEdges), and asks the worker to recreate the
+// d3-force-3d simulation for the new active set. With reveals crossing
+// integer boundaries multiple times per frame at 60Hz, an un-throttled
+// version would fire this on essentially every frame.
+const HEAVY_REBUILD_INTERVAL_MS = 150;
+
+export interface OnboardingDeps {
+  element: HTMLElement;
+  /** Lazy accessor — graph reference changes on setupGraph. */
+  graph: () => TheiaGraph;
+  /** Lazy accessor — NodeLayer is recreated on setupGraph. */
+  nodes: () => NodeLayer;
+  edges: EdgeLayer;
+  ctx: SceneContext;
+  simState: () => SimulationState;
+  /** Lazy accessor — nodePositions buffer is recreated on setupGraph. */
+  nodePositions: () => Float32Array;
+  setNodeVisibilityFromState(): void;
+  rebuildVisibleEdges(): void;
+  activeVisibleNodeIds(): Set<string>;
+  edgeKey(edge: TheiaGraph["edges"][number]): string;
+  savePhysicsSnapshot(): void;
+}
+
+export interface OnboardingController {
+  /** Start onboarding for the current graph. */
+  begin(): void;
+  /** True if onboarding state exists (running OR still blinking). */
+  isActive(): boolean;
+  /** True after the final reveal — blink phase may still be running. */
+  isComplete(): boolean;
+  /** Set of node ids that have been revealed so far. Empty when inactive. */
+  revealedNodeIds(): Set<string>;
+  /** Per-frame update: reveal nodes, drive camera rotation, throttle rebuilds. */
+  update(now: number): void;
+  /** Per-frame camera-zoom adjustment based on crowding around revealed nodes. */
+  updateCamera(): void;
+  /** Disable auto-zoom and capture user's chosen zoom (called from input handlers). */
+  onUserZoomChanged(zoom: number): void;
+  /** Forcibly tear down — used on graph reload. */
+  cancel(): void;
+}
+
+interface OnboardingStateInternal {
+  startedAt: number;
+  durationMs: number;
+  order: number[];
+  rankByIndex: Map<number, number>;
+  revealedNodeIds: Set<string>;
+  revealStartedAtByIndex: Map<number, number>;
+  linkStartedAtByKey: Map<string, number>;
+  lastRevealedCount: number;
+  lastHeavyRebuildAt: number;
+  lastEase: number;
+  cameraZoom: number;
+  cameraAutoZoomEnabled: boolean;
+  complete: boolean;
+  overlay: { update(progress: number): void; remove(): void };
+}
+
+const EMPTY_REVEALED = new Set<string>();
+
+export function createOnboarding(deps: OnboardingDeps): OnboardingController {
+  let state: OnboardingStateInternal | null = null;
+
+  function begin() {
+    const g = deps.graph();
+    const order = g.nodes
+      .map((node, index) => ({ index, time: Date.parse(node.started_at) }))
+      .sort((a, b) => {
+        const at = Number.isFinite(a.time) ? a.time : Number.POSITIVE_INFINITY;
+        const bt = Number.isFinite(b.time) ? b.time : Number.POSITIVE_INFINITY;
+        return at - bt || a.index - b.index;
+      })
+      .map(({ index }) => index);
+    state = {
+      startedAt: performance.now(),
+      durationMs: onboardingDurationMs(g.nodes.length),
+      order,
+      rankByIndex: new Map(order.map((index, rank) => [index, rank])),
+      revealedNodeIds: new Set(),
+      revealStartedAtByIndex: new Map(),
+      linkStartedAtByKey: new Map(),
+      lastRevealedCount: 0,
+      lastHeavyRebuildAt: 0,
+      lastEase: 0,
+      cameraZoom: ONBOARDING_BASE_ZOOM,
+      cameraAutoZoomEnabled: true,
+      complete: false,
+      overlay: createOnboardingOverlay(deps.element),
+    };
+    deps.ctx.setZoom(ONBOARDING_BASE_ZOOM);
+    const nodes = deps.nodes();
+    for (let i = 0; i < g.nodes.length; i++) {
+      nodes.setRevealScale(i, 0);
+      nodes.setBrightness(i, 0);
+    }
+    deps.setNodeVisibilityFromState();
+    deps.rebuildVisibleEdges();
+    deps.simState().replaceActive({
+      activeIds: deps.activeVisibleNodeIds(),
+      animateNew: true,
+    });
+  }
+
+  function updateOnboardingLinks(now: number) {
+    const graph = deps.graph();
+    if (!state) {
+      deps.edges.setConnectionProgress(null);
+      return;
+    }
+    for (const edge of graph.edges) {
+      if (
+        state.revealedNodeIds.has(edge.source) &&
+        state.revealedNodeIds.has(edge.target)
+      ) {
+        const key = deps.edgeKey(edge);
+        if (!state.linkStartedAtByKey.has(key)) {
+          state.linkStartedAtByKey.set(key, now);
+        }
+      }
+    }
+    deps.edges.setConnectionProgress((edge) => {
+      const startedAt = state?.linkStartedAtByKey.get(deps.edgeKey(edge));
+      if (startedAt === undefined) return 0;
+      return easeQuadInOut(
+        Math.min(1, (now - startedAt) / ONBOARDING_LINK_UP_MS),
+      );
+    });
+  }
+
+  function update(now: number) {
+    if (!state) return;
+    const graph = deps.graph();
+    const nodes = deps.nodes();
+    const raw = Math.min(1, (now - state.startedAt) / state.durationMs);
+    // Camera rotation rides the smooth in-out curve; reveal rides the
+    // supernova-then-easeOutQuad curve. Decoupled so the camera doesn't
+    // lurch at the supernova→quad seam.
+    const eased = easeQuadInOut(raw);
+    const revealFloat = onboardingRevealFraction(raw) * state.order.length;
+    const revealCount = Math.min(state.order.length, Math.ceil(revealFloat));
+
+    for (let rank = state.lastRevealedCount; rank < revealCount; rank++) {
+      const idx = state.order[rank]!;
+      state.revealedNodeIds.add(graph.nodes[idx]!.id);
+      state.revealStartedAtByIndex.set(idx, now);
+    }
+
+    for (const idx of state.order) {
+      const rank = state.rankByIndex.get(idx)!;
+      const localProgress = Math.max(0, Math.min(1, revealFloat - rank));
+      nodes.setRevealScale(idx, popScale(localProgress));
+      const revealedAt = state.revealStartedAtByIndex.get(idx);
+      const blinkProgress =
+        revealedAt === undefined
+          ? 0
+          : Math.min(1, (now - revealedAt) / ONBOARDING_BLINK_MS);
+      nodes.setBrightness(idx, revealBrightness(blinkProgress));
+    }
+    updateOnboardingLinks(now);
+
+    const rotationDelta =
+      (eased - state.lastEase) * ONBOARDING_ROTATION_RADIANS;
+    if (rotationDelta !== 0) {
+      const cam = deps.ctx.getCameraState();
+      deps.ctx.setCameraState({ ...cam, theta: cam.theta + rotationDelta });
+    }
+
+    // Throttle the heavy rebuild path; always force one final rebuild
+    // when the last node has been revealed so the simulation gets the
+    // full active set before settling.
+    const sawNewReveals = revealCount !== state.lastRevealedCount;
+    state.lastRevealedCount = revealCount;
+    const finalReveal = revealCount === state.order.length;
+    if (
+      sawNewReveals &&
+      (finalReveal ||
+        now - state.lastHeavyRebuildAt > HEAVY_REBUILD_INTERVAL_MS)
+    ) {
+      state.lastHeavyRebuildAt = now;
+      deps.setNodeVisibilityFromState();
+      deps.rebuildVisibleEdges();
+      deps.simState().replaceActive({
+        activeIds: deps.activeVisibleNodeIds(),
+        animateNew: true,
+      });
+    }
+    state.lastEase = eased;
+    state.overlay.update(eased);
+
+    if (raw >= 1 && !state.complete) {
+      for (const idx of state.order) {
+        state.revealedNodeIds.add(graph.nodes[idx]!.id);
+        nodes.setRevealScale(idx, 1);
+        if (!state.revealStartedAtByIndex.has(idx)) {
+          state.revealStartedAtByIndex.set(idx, now);
+        }
+      }
+      state.complete = true;
+      markOnboardingComplete();
+      state.overlay.remove();
+      deps.setNodeVisibilityFromState();
+      deps.rebuildVisibleEdges();
+      updateOnboardingLinks(now);
+      deps.savePhysicsSnapshot();
+    }
+
+    if (state.complete) {
+      let allBlinkDone = true;
+      for (const idx of state.order) {
+        const revealedAt = state.revealStartedAtByIndex.get(idx) ?? now;
+        const blinkProgress = Math.min(
+          1,
+          (now - revealedAt) / ONBOARDING_BLINK_MS,
+        );
+        nodes.setBrightness(idx, revealBrightness(blinkProgress));
+        allBlinkDone &&= blinkProgress >= 1;
+      }
+      if (allBlinkDone) {
+        for (const idx of state.order) {
+          nodes.setBrightness(idx, 1);
+        }
+        state = null;
+        deps.edges.setConnectionProgress(null);
+      }
+    }
+  }
+
+  function updateCamera() {
+    if (!state || state.complete || !state.cameraAutoZoomEnabled) return;
+    const graph = deps.graph();
+    const nodePositions = deps.nodePositions();
+    const camPos = deps.ctx.camera.position;
+    let nearest = Number.POSITIVE_INFINITY;
+    for (const idx of state.order) {
+      if (!state.revealedNodeIds.has(graph.nodes[idx]!.id)) continue;
+      // nodePositions tracks the same per-frame smoothed values that the
+      // simulation tick writes; reading from there avoids reaching into
+      // the simulation module's private renderedPositions buffer.
+      const dx = nodePositions[idx * 3]! - camPos.x;
+      const dy = nodePositions[idx * 3 + 1]! - camPos.y;
+      const dz = nodePositions[idx * 3 + 2]! - camPos.z;
+      nearest = Math.min(nearest, Math.sqrt(dx * dx + dy * dy + dz * dz));
+    }
+    if (!Number.isFinite(nearest)) return;
+    const crowding = Math.max(
+      0,
+      Math.min(
+        1,
+        (ONBOARDING_SAFE_DISTANCE - nearest) /
+          (ONBOARDING_SAFE_DISTANCE - ONBOARDING_NEAR_DISTANCE),
+      ),
+    );
+    const targetZoom =
+      ONBOARDING_BASE_ZOOM -
+      (ONBOARDING_BASE_ZOOM - ONBOARDING_MIN_ZOOM) * easeQuadInOut(crowding);
+    state.cameraZoom += (targetZoom - state.cameraZoom) * 0.08;
+    deps.ctx.setZoom(state.cameraZoom);
+  }
+
+  return {
+    begin,
+    isActive: () => state !== null,
+    isComplete: () => state?.complete === true,
+    revealedNodeIds: () => state?.revealedNodeIds ?? EMPTY_REVEALED,
+    update,
+    updateCamera,
+    onUserZoomChanged(zoom: number) {
+      if (!state) return;
+      state.cameraAutoZoomEnabled = false;
+      state.cameraZoom = zoom;
+    },
+    cancel() {
+      state?.overlay.remove();
+      state = null;
+    },
+  };
+}

--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -9,18 +9,20 @@ const ONBOARDING_STORAGE_KEY = "theia-first-load-onboarding-complete";
 const ONBOARDING_ROTATION_RADIANS = Math.PI * 1.15;
 const ONBOARDING_BLINK_MS = 3200;
 const ONBOARDING_LINK_UP_MS = 700;
-const ONBOARDING_BASE_ZOOM = 0.72;
-const ONBOARDING_MIN_ZOOM = 0.42;
-const ONBOARDING_NEAR_DISTANCE = 3.2;
-const ONBOARDING_SAFE_DISTANCE = 5.6;
+// Camera zoom progressively retreats across the reveal so the user can
+// watch the constellation expand into view. Driven by raw time progress
+// (not reveal fraction) so the zoom-out feels steady regardless of how
+// the supernova-then-easeOutQuad reveal lands nodes.
+const ONBOARDING_START_ZOOM = 0.72;
+const ONBOARDING_END_ZOOM = 0.32;
 
-// Onboarding duration scales gently with node count, but capped so the
-// first-load reveal stays in the 5-18s range. Previously this was
-// `ceil(N/3) * 1000`, which produced ~9 minutes for a 1.6k-node graph.
-// Keep deterministic so the overlay can confidently advertise progress.
+// Onboarding duration scales gently with node count, capped so the
+// first-load reveal stays in roughly the 5-22s range. Previously this
+// was `ceil(N/3) * 1000`, which produced ~9 minutes for a 1.6k-node
+// graph. Keep deterministic so the overlay percentage stays meaningful.
 const ONBOARDING_MIN_DURATION_MS = 5000;
-const ONBOARDING_MAX_DURATION_MS = 18000;
-const ONBOARDING_MS_PER_NODE = 6;
+const ONBOARDING_MAX_DURATION_MS = 22000;
+const ONBOARDING_MS_PER_NODE = 9;
 function onboardingDurationMs(nodeCount: number): number {
   const raw = ONBOARDING_MIN_DURATION_MS + nodeCount * ONBOARDING_MS_PER_NODE;
   return Math.min(
@@ -29,11 +31,11 @@ function onboardingDurationMs(nodeCount: number): number {
   );
 }
 
-// Reveal progression: a "supernova" front-loads the first third of the
-// constellation in the opening burst, then easeOutQuad eases the rest
-// in across the remaining duration.
+// Reveal progression: a "supernova" front-loads the first quarter of
+// the constellation in the opening burst, then easeOutQuad eases the
+// rest in across the remaining duration.
 const SUPERNOVA_DURATION_FRAC = 0.18;
-const SUPERNOVA_NODE_FRAC = 1 / 3;
+const SUPERNOVA_NODE_FRAC = 1 / 4;
 function onboardingRevealFraction(rawProgress: number): number {
   if (rawProgress <= 0) return 0;
   if (rawProgress >= 1) return 1;
@@ -120,8 +122,8 @@ export interface OnboardingController {
   revealedNodeIds(): Set<string>;
   /** Per-frame update: reveal nodes, drive camera rotation, throttle rebuilds. */
   update(now: number): void;
-  /** Per-frame camera-zoom adjustment based on crowding around revealed nodes. */
-  updateCamera(): void;
+  /** Per-frame camera-zoom adjustment — pulls back as the reveal progresses. */
+  updateCamera(now: number): void;
   /** Disable auto-zoom and capture user's chosen zoom (called from input handlers). */
   onUserZoomChanged(zoom: number): void;
   /** Forcibly tear down — used on graph reload. */
@@ -171,12 +173,12 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
       lastRevealedCount: 0,
       lastHeavyRebuildAt: 0,
       lastEase: 0,
-      cameraZoom: ONBOARDING_BASE_ZOOM,
+      cameraZoom: ONBOARDING_START_ZOOM,
       cameraAutoZoomEnabled: true,
       complete: false,
       overlay: createOnboardingOverlay(deps.element),
     };
-    deps.ctx.setZoom(ONBOARDING_BASE_ZOOM);
+    deps.ctx.setZoom(ONBOARDING_START_ZOOM);
     const nodes = deps.nodes();
     for (let i = 0; i < g.nodes.length; i++) {
       nodes.setRevealScale(i, 0);
@@ -314,34 +316,19 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
     }
   }
 
-  function updateCamera() {
+  function updateCamera(now: number) {
     if (!state || state.complete || !state.cameraAutoZoomEnabled) return;
-    const graph = deps.graph();
-    const nodePositions = deps.nodePositions();
-    const camPos = deps.ctx.camera.position;
-    let nearest = Number.POSITIVE_INFINITY;
-    for (const idx of state.order) {
-      if (!state.revealedNodeIds.has(graph.nodes[idx]!.id)) continue;
-      // nodePositions tracks the same per-frame smoothed values that the
-      // simulation tick writes; reading from there avoids reaching into
-      // the simulation module's private renderedPositions buffer.
-      const dx = nodePositions[idx * 3]! - camPos.x;
-      const dy = nodePositions[idx * 3 + 1]! - camPos.y;
-      const dz = nodePositions[idx * 3 + 2]! - camPos.z;
-      nearest = Math.min(nearest, Math.sqrt(dx * dx + dy * dy + dz * dz));
-    }
-    if (!Number.isFinite(nearest)) return;
-    const crowding = Math.max(
-      0,
-      Math.min(
-        1,
-        (ONBOARDING_SAFE_DISTANCE - nearest) /
-          (ONBOARDING_SAFE_DISTANCE - ONBOARDING_NEAR_DISTANCE),
-      ),
-    );
+    // Time-progressive zoom-out: as the reveal proceeds, the camera
+    // pulls back so each newly-revealed node lands inside an
+    // ever-widening field of view. easeOutQuad means most of the
+    // pull-back happens in the first half — by the time the easeOutQuad
+    // reveal phase is filling in the long tail of nodes, the camera is
+    // already most of the way out and changes slowly, so the user
+    // perceives the constellation expanding into a stable wide shot.
+    const raw = Math.min(1, (now - state.startedAt) / state.durationMs);
+    const t = 1 - (1 - raw) * (1 - raw); // easeOutQuad
     const targetZoom =
-      ONBOARDING_BASE_ZOOM -
-      (ONBOARDING_BASE_ZOOM - ONBOARDING_MIN_ZOOM) * easeQuadInOut(crowding);
+      ONBOARDING_START_ZOOM + (ONBOARDING_END_ZOOM - ONBOARDING_START_ZOOM) * t;
     state.cameraZoom += (targetZoom - state.cameraZoom) * 0.08;
     deps.ctx.setZoom(state.cameraZoom);
   }

--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -11,17 +11,17 @@ const ONBOARDING_BLINK_MS = 3200;
 const ONBOARDING_LINK_UP_MS = 700;
 // Camera zoom progressively retreats across the reveal so the user can
 // watch the constellation expand into view. Driven by raw time progress
-// (not reveal fraction) so the zoom-out feels steady regardless of how
-// the supernova-burst-then-easeInOutCubic reveal lands nodes.
+// (not reveal fraction) so the zoom-out feels steady regardless of the
+// reveal cadence.
 const ONBOARDING_START_ZOOM = 0.72;
 const ONBOARDING_END_ZOOM = 0.32;
 
 // Onboarding duration scales gently with node count, capped so the
-// first-load reveal stays in roughly the 5-22s range. Previously this
+// first-load reveal stays in roughly the 5-24s range. Previously this
 // was `ceil(N/3) * 1000`, which produced ~9 minutes for a 1.6k-node
 // graph. Keep deterministic so the overlay percentage stays meaningful.
 const ONBOARDING_MIN_DURATION_MS = 5000;
-const ONBOARDING_MAX_DURATION_MS = 22000;
+const ONBOARDING_MAX_DURATION_MS = 24000;
 const ONBOARDING_MS_PER_NODE = 9;
 function onboardingDurationMs(nodeCount: number): number {
   const raw = ONBOARDING_MIN_DURATION_MS + nodeCount * ONBOARDING_MS_PER_NODE;
@@ -35,35 +35,38 @@ function easeQuadInOut(t: number): number {
   return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
 }
 
-function easeInOutCubic(t: number): number {
-  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
 }
 
-// Group reveal rate: easeInOutCubic across the full duration. The
-// supernova-burst at t=0 was retired in favor of a smooth start —
-// dropping it removes the FPS hit from popping ~10% of nodes in a
-// single frame. With the per-node ease-in below, individual nodes
-// already get a slow visual entry as they're revealed.
+// Group reveal rate: quadratic easeIn (`t²`). Linear was too dense
+// at frame 1 ("much at once"); easeInOutCubic was the opposite —
+// `cubic(0.1) ≈ 0.004` left the first ~2s essentially empty before
+// flooding the worker mid-reveal. Quadratic gives the gradual ramp
+// the user wants (1, then 2, then 4…) while still completing on
+// schedule.
 function onboardingRevealFraction(rawProgress: number): number {
   if (rawProgress <= 0) return 0;
   if (rawProgress >= 1) return 1;
-  return easeInOutCubic(rawProgress);
+  return rawProgress * rawProgress;
 }
 
 // Per-node entry animation. Driven by wall-clock time since the node
-// was first revealed, NOT by the group reveal rate. This means each
-// individual node eases in over POP_DURATION_MS regardless of how many
-// other nodes are revealing at the same moment — the slow ease-in is
-// "to singular nodes, not groups". The previous version derived
-// localProgress from `revealFloat - rank`, so any time multiple ranks
-// were crossed in one frame, those nodes jumped to scale=1 instantly.
+// was first revealed, NOT by the group reveal rate, so each individual
+// node eases in over POP_DURATION_MS regardless of how many siblings
+// are revealing alongside it.
+//
+// Curve is easeOutCubic — fast initial appearance (visible within a
+// frame or two of reveal) then settles smoothly to scale=1. The
+// previous easeQuadInOut had near-zero scale for the first ~150ms,
+// which made the very first node look invisible at t=0+.
 const POP_DURATION_MS = 600;
 function popScale(now: number, revealedAt: number | undefined): number {
   if (revealedAt === undefined) return 0;
   const t = Math.min(1, (now - revealedAt) / POP_DURATION_MS);
   if (t <= 0) return 0;
   if (t >= 1) return 1;
-  return easeQuadInOut(t);
+  return easeOutCubic(t);
 }
 
 function revealBrightness(t: number): number {
@@ -242,9 +245,9 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
     const graph = deps.graph();
     const nodes = deps.nodes();
     const raw = Math.min(1, (now - state.startedAt) / state.durationMs);
-    // Camera rotation rides easeQuadInOut; reveal rides the
-    // supernova-burst-then-easeInOutCubic curve. Decoupled so the
-    // camera motion stays smooth even as nodes pop in.
+    // Camera rotation rides easeQuadInOut; group reveal rate is
+    // quadratic (per-node easeOutCubic handles individual entry).
+    // Decoupled so camera motion stays smooth as nodes appear.
     const eased = easeQuadInOut(raw);
     const revealFloat = onboardingRevealFraction(raw) * state.order.length;
     const revealCount = Math.min(state.order.length, Math.ceil(revealFloat));

--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -39,33 +39,31 @@ function easeInOutCubic(t: number): number {
   return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
 }
 
-// Reveal progression: an easeQuadInOut warmup eases the first
-// WARMUP_NODE_FRAC of nodes in across WARMUP_DURATION_FRAC of duration,
-// then easeInOutCubic takes over for the rest. The previous version
-// popped 10% of nodes in a single frame at t=0, which slammed the
-// worker with one big replaceActive (full sim rebuild) plus dozens of
-// concurrent popScale animations — a visible FPS dip right at the
-// moment the user starts watching. The warmup spreads that startup
-// cost over ~1-2s. Both easings have zero derivative at the seam, so
-// the rate transition is smooth.
-const WARMUP_DURATION_FRAC = 0.1;
-const WARMUP_NODE_FRAC = 0.1;
+// Group reveal rate: easeInOutCubic across the full duration. The
+// supernova-burst at t=0 was retired in favor of a smooth start —
+// dropping it removes the FPS hit from popping ~10% of nodes in a
+// single frame. With the per-node ease-in below, individual nodes
+// already get a slow visual entry as they're revealed.
 function onboardingRevealFraction(rawProgress: number): number {
   if (rawProgress <= 0) return 0;
   if (rawProgress >= 1) return 1;
-  if (rawProgress < WARMUP_DURATION_FRAC) {
-    const t = rawProgress / WARMUP_DURATION_FRAC;
-    return easeQuadInOut(t) * WARMUP_NODE_FRAC;
-  }
-  const t = (rawProgress - WARMUP_DURATION_FRAC) / (1 - WARMUP_DURATION_FRAC);
-  return WARMUP_NODE_FRAC + easeInOutCubic(t) * (1 - WARMUP_NODE_FRAC);
+  return easeInOutCubic(rawProgress);
 }
 
-function popScale(t: number): number {
+// Per-node entry animation. Driven by wall-clock time since the node
+// was first revealed, NOT by the group reveal rate. This means each
+// individual node eases in over POP_DURATION_MS regardless of how many
+// other nodes are revealing at the same moment — the slow ease-in is
+// "to singular nodes, not groups". The previous version derived
+// localProgress from `revealFloat - rank`, so any time multiple ranks
+// were crossed in one frame, those nodes jumped to scale=1 instantly.
+const POP_DURATION_MS = 600;
+function popScale(now: number, revealedAt: number | undefined): number {
+  if (revealedAt === undefined) return 0;
+  const t = Math.min(1, (now - revealedAt) / POP_DURATION_MS);
   if (t <= 0) return 0;
   if (t >= 1) return 1;
-  const eased = easeQuadInOut(t);
-  return 1 + 0.28 * Math.sin(Math.PI * eased);
+  return easeQuadInOut(t);
 }
 
 function revealBrightness(t: number): number {
@@ -270,11 +268,13 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
       state.blinkMinRank++;
     }
     // Active animation range — only nodes still popping or blinking.
+    // Both popScale and brightness are driven by wall-clock since each
+    // node was revealed, so per-node animations are independent of the
+    // group reveal rate.
     for (let rank = state.blinkMinRank; rank < revealCount; rank++) {
       const idx = state.order[rank]!;
-      const localProgress = Math.max(0, Math.min(1, revealFloat - rank));
-      nodes.setRevealScale(idx, popScale(localProgress));
       const revealedAt = state.revealStartedAtByIndex.get(idx)!;
+      nodes.setRevealScale(idx, popScale(now, revealedAt));
       const blinkProgress = Math.min(
         1,
         (now - revealedAt) / ONBOARDING_BLINK_MS,

--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -48,23 +48,43 @@ function onboardingRevealFraction(rawProgress: number): number {
 }
 
 // Per-node entry animation. Driven by wall-clock since each node was
-// revealed (not by the group rate), so individual nodes animate
-// independently regardless of how many siblings reveal alongside.
+// revealed (not by group rate), so individuals animate independently
+// regardless of how many siblings reveal alongside.
 //
-// Curve mirrors the original (pre-extraction) implementation: snap
-// to scale=1 instantly on the reveal frame, then a sin overshoot up
-// to ~1.28 and back to 1. This is the key fix for "the first node
-// doesn't appear" — earlier ease-from-zero curves spent ~150ms at
-// near-zero scale before becoming visible, so the user couldn't see
-// the lone node that t² spawns at frame 2. Snap-to-1 makes it
-// visible *on its reveal frame*, the bounce keeps it satisfying.
-const POP_DURATION_MS = 600;
-function popScale(now: number, revealedAt: number | undefined): number {
+// Duration is **adaptive** — derived from the actual spawn interval
+// so each pop lasts ~POP_INTERVAL_K × the time between consecutive
+// reveals. Slow phases (early in t², small graphs) get long satisfying
+// pops; fast phases collapse toward the floor so concurrent pops
+// don't pile up indefinitely. Bounded by [MIN, MAX] so tiny graphs
+// (long interval) don't get multi-second pops, and high-rate phases
+// (~zero interval) still get a visible pop.
+//
+// Curve mirrors the original: snap to scale=1 instantly on the reveal
+// frame, then sin overshoot to ~1.28 and back to 1. At raw=0,
+// easeQuadInOut(0)=0 → sin(0)=0 → returns 1, so the node is visible
+// on its reveal frame; the bounce starts immediately after.
+const MIN_POP_DURATION_MS = 300;
+const MAX_POP_DURATION_MS = 1500;
+const POP_INTERVAL_K = 4;
+function clamp(min: number, max: number, v: number): number {
+  return v < min ? min : v > max ? max : v;
+}
+function popDurationFromInterval(intervalMs: number): number {
+  return clamp(
+    MIN_POP_DURATION_MS,
+    MAX_POP_DURATION_MS,
+    POP_INTERVAL_K * intervalMs,
+  );
+}
+function popScale(
+  now: number,
+  revealedAt: number | undefined,
+  popDurationMs: number,
+): number {
   if (revealedAt === undefined) return 0;
-  const raw = (now - revealedAt) / POP_DURATION_MS;
+  const raw = (now - revealedAt) / popDurationMs;
   if (raw < 0) return 0;
   if (raw >= 1) return 1;
-  // At raw=0: easeQuadInOut(0)=0 → sin(0)=0 → returns 1. Instant pop.
   const eased = easeQuadInOut(raw);
   return 1 + 0.28 * Math.sin(Math.PI * eased);
 }
@@ -156,6 +176,12 @@ interface OnboardingStateInternal {
   lastRevealedCount: number;
   lastHeavyRebuildAt: number;
   lastRebuiltRevealCount: number;
+  // Tracks the wall-clock time of the most recent reveal-batch and the
+  // last observed spawn interval (ms per node). popDurationFromInterval
+  // turns this into the per-node animation length so slow phases get
+  // long pops and fast phases get short ones — bounded by [MIN, MAX].
+  lastSpawnAt: number;
+  lastSpawnIntervalMs: number;
   // Smallest rank whose reveal+blink animation is still in progress.
   // Ranks below this are settled at scale=1, brightness=1; ranks above
   // revealCount aren't yet revealed. Per-frame work only touches the
@@ -193,6 +219,8 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
       lastRevealedCount: 0,
       lastHeavyRebuildAt: 0,
       lastRebuiltRevealCount: 0,
+      lastSpawnAt: performance.now(),
+      lastSpawnIntervalMs: MAX_POP_DURATION_MS / POP_INTERVAL_K,
       blinkMinRank: 0,
       lastEase: 0,
       cameraZoom: ONBOARDING_START_ZOOM,
@@ -245,12 +273,23 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
     const graph = deps.graph();
     const nodes = deps.nodes();
     const raw = Math.min(1, (now - state.startedAt) / state.durationMs);
-    // Camera rotation rides easeQuadInOut; group reveal rate is
-    // quadratic (per-node easeOutCubic handles individual entry).
-    // Decoupled so camera motion stays smooth as nodes appear.
+    // Camera rotation rides easeQuadInOut; group rate is quadratic
+    // and per-node pop is adaptive (matches spawn interval). Decoupled
+    // so camera motion stays smooth as nodes appear.
     const eased = easeQuadInOut(raw);
     const revealFloat = onboardingRevealFraction(raw) * state.order.length;
     const revealCount = Math.min(state.order.length, Math.ceil(revealFloat));
+
+    const newRevealsThisFrame = revealCount - state.lastRevealedCount;
+    if (newRevealsThisFrame > 0) {
+      // Spawn interval = wall-clock since the last batch divided by
+      // the number of new reveals in this batch. Drives popDurationMs
+      // adaptively so per-node animations match the actual cadence.
+      state.lastSpawnIntervalMs =
+        (now - state.lastSpawnAt) / newRevealsThisFrame;
+      state.lastSpawnAt = now;
+    }
+    const popDurationMs = popDurationFromInterval(state.lastSpawnIntervalMs);
 
     for (let rank = state.lastRevealedCount; rank < revealCount; rank++) {
       const idx = state.order[rank]!;
@@ -277,7 +316,7 @@ export function createOnboarding(deps: OnboardingDeps): OnboardingController {
     for (let rank = state.blinkMinRank; rank < revealCount; rank++) {
       const idx = state.order[rank]!;
       const revealedAt = state.revealStartedAtByIndex.get(idx)!;
-      nodes.setRevealScale(idx, popScale(now, revealedAt));
+      nodes.setRevealScale(idx, popScale(now, revealedAt, popDurationMs));
       const blinkProgress = Math.min(
         1,
         (now - revealedAt) / ONBOARDING_BLINK_MS,

--- a/theia-panel/src/state/onboarding.ts
+++ b/theia-panel/src/state/onboarding.ts
@@ -35,10 +35,6 @@ function easeQuadInOut(t: number): number {
   return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
 }
 
-function easeOutCubic(t: number): number {
-  return 1 - Math.pow(1 - t, 3);
-}
-
 // Group reveal rate: quadratic easeIn (`t²`). Linear was too dense
 // at frame 1 ("much at once"); easeInOutCubic was the opposite —
 // `cubic(0.1) ≈ 0.004` left the first ~2s essentially empty before
@@ -51,22 +47,26 @@ function onboardingRevealFraction(rawProgress: number): number {
   return rawProgress * rawProgress;
 }
 
-// Per-node entry animation. Driven by wall-clock time since the node
-// was first revealed, NOT by the group reveal rate, so each individual
-// node eases in over POP_DURATION_MS regardless of how many siblings
-// are revealing alongside it.
+// Per-node entry animation. Driven by wall-clock since each node was
+// revealed (not by the group rate), so individual nodes animate
+// independently regardless of how many siblings reveal alongside.
 //
-// Curve is easeOutCubic — fast initial appearance (visible within a
-// frame or two of reveal) then settles smoothly to scale=1. The
-// previous easeQuadInOut had near-zero scale for the first ~150ms,
-// which made the very first node look invisible at t=0+.
+// Curve mirrors the original (pre-extraction) implementation: snap
+// to scale=1 instantly on the reveal frame, then a sin overshoot up
+// to ~1.28 and back to 1. This is the key fix for "the first node
+// doesn't appear" — earlier ease-from-zero curves spent ~150ms at
+// near-zero scale before becoming visible, so the user couldn't see
+// the lone node that t² spawns at frame 2. Snap-to-1 makes it
+// visible *on its reveal frame*, the bounce keeps it satisfying.
 const POP_DURATION_MS = 600;
 function popScale(now: number, revealedAt: number | undefined): number {
   if (revealedAt === undefined) return 0;
-  const t = Math.min(1, (now - revealedAt) / POP_DURATION_MS);
-  if (t <= 0) return 0;
-  if (t >= 1) return 1;
-  return easeOutCubic(t);
+  const raw = (now - revealedAt) / POP_DURATION_MS;
+  if (raw < 0) return 0;
+  if (raw >= 1) return 1;
+  // At raw=0: easeQuadInOut(0)=0 → sin(0)=0 → returns 1. Instant pop.
+  const eased = easeQuadInOut(raw);
+  return 1 + 0.28 * Math.sin(Math.PI * eased);
 }
 
 function revealBrightness(t: number): number {

--- a/theia-panel/src/state/physicsSnapshot.ts
+++ b/theia-panel/src/state/physicsSnapshot.ts
@@ -1,0 +1,144 @@
+import type { CameraState } from "../scene/Scene";
+import type { createSimulation } from "../physics/Simulation";
+
+const PHYSICS_SNAPSHOT_KEY_PREFIX = "theia-physics-snapshot:";
+const PHYSICS_SNAPSHOT_INTERVAL_MS = 5000;
+
+export type PhysicsSnapshotNode = {
+  x: number;
+  y: number;
+  z: number;
+  vx: number;
+  vy: number;
+  vz: number;
+};
+
+export type PhysicsSnapshot = {
+  nodes: Map<string, PhysicsSnapshotNode>;
+  camera: CameraState | null;
+};
+
+type SimNodes = ReturnType<typeof createSimulation>["nodes"];
+
+function physicsSnapshotKey(graphUrl: string): string {
+  return `${PHYSICS_SNAPSHOT_KEY_PREFIX}${graphUrl}`;
+}
+
+function loadPhysicsSnapshot(graphUrl: string): PhysicsSnapshot {
+  try {
+    const raw = localStorage.getItem(physicsSnapshotKey(graphUrl));
+    if (!raw) return { nodes: new Map(), camera: null };
+    const parsed = JSON.parse(raw);
+    const nodesById = parsed?.nodes;
+    if (!nodesById || typeof nodesById !== "object") {
+      return { nodes: new Map(), camera: null };
+    }
+    const snapshot = new Map<string, PhysicsSnapshotNode>();
+    for (const [id, value] of Object.entries(nodesById)) {
+      if (!value || typeof value !== "object") continue;
+      const node = value as Record<string, unknown>;
+      const x = Number(node.x);
+      const y = Number(node.y);
+      const z = Number(node.z);
+      const vx = Number(node.vx ?? 0);
+      const vy = Number(node.vy ?? 0);
+      const vz = Number(node.vz ?? 0);
+      if ([x, y, z, vx, vy, vz].every(Number.isFinite)) {
+        snapshot.set(id, { x, y, z, vx, vy, vz });
+      }
+    }
+    const cameraRaw = parsed?.camera;
+    const targetRaw = cameraRaw?.target;
+    const camera =
+      cameraRaw &&
+      targetRaw &&
+      [
+        targetRaw.x,
+        targetRaw.y,
+        targetRaw.z,
+        cameraRaw.theta,
+        cameraRaw.phi,
+        cameraRaw.zoom,
+      ]
+        .map(Number)
+        .every(Number.isFinite)
+        ? {
+            target: {
+              x: Number(targetRaw.x),
+              y: Number(targetRaw.y),
+              z: Number(targetRaw.z),
+            },
+            theta: Number(cameraRaw.theta),
+            phi: Number(cameraRaw.phi),
+            zoom: Number(cameraRaw.zoom),
+          }
+        : null;
+    return { nodes: snapshot, camera };
+  } catch {
+    return { nodes: new Map(), camera: null };
+  }
+}
+
+function savePhysicsSnapshot(
+  graphUrl: string,
+  simNodes: SimNodes,
+  cameraState: CameraState,
+): void {
+  const nodesById: Record<string, PhysicsSnapshotNode> = {};
+  for (const sn of simNodes) {
+    if (!sn) continue;
+    nodesById[sn.id] = {
+      x: sn.x,
+      y: sn.y,
+      z: sn.z,
+      vx: sn.vx ?? 0,
+      vy: sn.vy ?? 0,
+      vz: sn.vz ?? 0,
+    };
+  }
+  try {
+    localStorage.setItem(
+      physicsSnapshotKey(graphUrl),
+      JSON.stringify({
+        version: 1,
+        saved_at: Date.now(),
+        nodes: nodesById,
+        camera: cameraState,
+      }),
+    );
+  } catch {
+    /* quota exceeded, ignore */
+  }
+}
+
+export interface PhysicsSnapshotIO {
+  load(graphUrl: string): PhysicsSnapshot;
+  save(graphUrl: string, simNodes: SimNodes, cameraState: CameraState): void;
+  maybeSave(
+    now: number,
+    graphUrl: string,
+    simNodes: SimNodes,
+    getCameraState: () => CameraState,
+    canSave: boolean,
+  ): void;
+}
+
+export function createPhysicsSnapshotIO(
+  intervalMs: number = PHYSICS_SNAPSHOT_INTERVAL_MS,
+): PhysicsSnapshotIO {
+  let lastSavedAt = 0;
+  return {
+    load(graphUrl) {
+      return loadPhysicsSnapshot(graphUrl);
+    },
+    save(graphUrl, simNodes, cameraState) {
+      savePhysicsSnapshot(graphUrl, simNodes, cameraState);
+    },
+    maybeSave(now, graphUrl, simNodes, getCameraState, canSave) {
+      if (!canSave) return;
+      if (now - lastSavedAt < intervalMs) return;
+      lastSavedAt = now;
+      savePhysicsSnapshot(graphUrl, simNodes, getCameraState());
+    },
+  };
+}

--- a/theia-panel/src/state/simulation.ts
+++ b/theia-panel/src/state/simulation.ts
@@ -1,9 +1,15 @@
-import { createSimulation } from "../physics/Simulation";
 import type { TheiaGraph } from "../data/types";
 import type { NodeLayer } from "../scene/Nodes";
 import type { EdgeLayer } from "../scene/Edges";
-import { hashN11 } from "../util/hash";
 import type { PhysicsSnapshotNode } from "./physicsSnapshot";
+import type { createSimulation } from "../physics/Simulation";
+import SimulationWorker from "../physics/SimulationWorker?worker";
+import type {
+  SeedNode,
+  SnapshotPayloadNode,
+  WorkerInMsg,
+  WorkerOutMsg,
+} from "../physics/SimulationWorker";
 
 type SimNodes = ReturnType<typeof createSimulation>["nodes"];
 
@@ -17,9 +23,7 @@ export interface ReplaceActiveOpts {
 export interface SimulationStateDeps {
   graph: TheiaGraph;
   kinds: Set<string>;
-  /** True while onboarding is running (affects sim profile + lerp smoothing). */
   isOnboarding: () => boolean;
-  /** Called once each tick after positions advance — caller flushes meshes. */
   nodes: NodeLayer;
   edges: EdgeLayer;
   /** Shared with NodeLayer — sim writes node-space positions here each tick. */
@@ -27,36 +31,28 @@ export interface SimulationStateDeps {
 }
 
 export interface SimulationState {
-  /** Advance the sim, lerp toward sim positions, flush meshes. No-op once settled. */
   tick(): void;
-  /** Reset settle gate + bump alpha so filter/visibility changes re-equilibrate. */
   wakePhysics(): void;
-  /** Rebuild simulation for a new active set (filters, focus, snapshot restore). */
   replaceActive(opts: ReplaceActiveOpts): void;
-  /** Force renderedPositions/meshes to sim positions immediately (post-restore). */
   syncRenderedPositionsFromSimulation(): void;
-  /** Run a single internal sim tick — used to settle initial layout before display. */
   primeOnce(): void;
-  /** Read the current sim position of node by index (for camera focus, etc). */
   getNodePosition(idx: number): { x: number; y: number; z: number } | null;
-  /** Snapshot input for physicsSnapshotIO.save. */
+  /**
+   * Synchronous view of the simulation's last-known node states, in
+   * graph-node order. Built from cached worker positions/velocities;
+   * may lag by up to one tick relative to the worker. Used by snapshot
+   * save (`physicsSnapshotIO.save(...)`).
+   */
   getSimNodes(): SimNodes;
   dispose(): void;
 }
 
-// Settled-physics gate: skip the per-frame sim/lerp/edge-rewrite when the
-// layout has stabilised. The lerp drives matrix uploads and a full
-// edge-position attribute rewrite every frame; with 1.6k nodes that's
-// most of the per-frame cost once the simulation has converged.
+// Settled-physics gate (main side): the worker also has its own gate
+// that suppresses position posts when the layout has converged. The
+// main-side gate stops re-flushing meshes when both `lastSimPositions`
+// has stopped changing AND the local lerp has caught up.
 const SETTLED_THRESHOLD = 30;
-// Threshold ≈ 0.001² in world units — well below visible motion at any
-// reasonable zoom, since node sizes top out at 0.18 (see Nodes.ts).
 const SETTLE_EPSILON_SQ = 1e-6;
-// Energy injected on wake so filter/visibility changes actually produce
-// a visible re-equilibration. Without this, alpha sits at alphaTarget
-// (0.012, see Simulation.ts) which makes wake invisible — sub-pixel
-// motion that re-settles within a few ticks.
-const WAKE_ALPHA = 0.18;
 
 const ONBOARDING_SMOOTHING = 0.14;
 const NORMAL_SMOOTHING = 0.34;
@@ -65,135 +61,178 @@ export function createSimulationState(
   deps: SimulationStateDeps,
 ): SimulationState {
   const { graph, kinds, isOnboarding, nodes, edges, nodePositions } = deps;
-  const renderedPositions = new Float32Array(graph.nodes.length * 3);
-  const nodeIndex = new Map<string, number>(
-    graph.nodes.map((n, i) => [n.id, i]),
+  const n = graph.nodes.length;
+
+  // Two parallel buffers per node:
+  //   targetPositions  — last positions received from the worker (the
+  //                      simulation's current truth)
+  //   renderedPositions — the per-frame lerped values written into
+  //                       nodePositions (= NodeLayer's instanceMatrix)
+  // The lerp on the main thread provides visual smoothing between
+  // worker tick boundaries (worker ticks at 60Hz; main thread renders
+  // at display refresh, often higher).
+  const targetPositions = new Float32Array(n * 3);
+  const renderedPositions = new Float32Array(n * 3);
+
+  // Velocity cache, written from worker snapshot responses; used only
+  // for snapshot save. Out-of-date between snapshot requests, but the
+  // snapshot save path is the only sync consumer and a slightly stale
+  // velocity is fine (worker is the source of truth on the next save).
+  const cachedVelocities = new Float32Array(n * 3);
+
+  // Optimistic mirror of simNodes (id + last-known x/y/z/vx/vy/vz).
+  // `getSimNodes()` returns this for the snapshot save path.
+  const simNodesMirror: SimNodes = graph.nodes.map((node) => ({
+    id: node.id,
+    x: node.position.x,
+    y: node.position.y,
+    z: 0,
+    vx: 0,
+    vy: 0,
+    vz: 0,
+    // anchorX/anchorY/anchorZ/radius are required by the type; the
+    // worker is the authoritative owner of these and main-side never
+    // reads them. Fill with the same expressions the worker will use
+    // (see physics/Simulation.ts) so the mirror is structurally
+    // identical even before the first message round-trip.
+    anchorX: node.position.x,
+    anchorY: node.position.y,
+    anchorZ: 0,
+    radius: 0.08,
+  }));
+
+  // Seed renderedPositions/targetPositions/nodePositions from the
+  // graph's static anchor positions so the very first frames have
+  // something to draw before the worker reports back.
+  for (let i = 0; i < n; i++) {
+    const node = graph.nodes[i]!;
+    targetPositions[i * 3 + 0] = node.position.x;
+    targetPositions[i * 3 + 1] = node.position.y;
+    targetPositions[i * 3 + 2] = 0;
+    renderedPositions[i * 3 + 0] = node.position.x;
+    renderedPositions[i * 3 + 1] = node.position.y;
+    renderedPositions[i * 3 + 2] = 0;
+  }
+
+  let settledFrames = 0;
+  let workerReady = false;
+  let pendingSnapshotRequest: {
+    id: number;
+    resolve: (nodes: SnapshotPayloadNode[]) => void;
+  } | null = null;
+  let snapshotRequestSeq = 0;
+
+  const worker = new SimulationWorker();
+  function send(msg: WorkerInMsg, transfer?: Transferable[]) {
+    worker.postMessage(msg, transfer ?? []);
+  }
+
+  worker.addEventListener("message", (e: MessageEvent<WorkerOutMsg>) => {
+    const msg = e.data;
+    if (msg.type === "ready") {
+      workerReady = true;
+      return;
+    }
+    if (msg.type === "positions") {
+      const incoming = new Float32Array(msg.buffer);
+      // Length should match n*3; if it doesn't (graph swap mid-flight),
+      // ignore the stale message.
+      if (incoming.length === targetPositions.length) {
+        targetPositions.set(incoming);
+        // Mirror x/y/z onto simNodesMirror so getSimNodes is current.
+        for (let i = 0; i < n; i++) {
+          const sn = simNodesMirror[i]!;
+          sn.x = incoming[i * 3 + 0]!;
+          sn.y = incoming[i * 3 + 1]!;
+          sn.z = incoming[i * 3 + 2]!;
+        }
+        // Restart the main-side gate when worker reports motion.
+        if (!msg.settled) settledFrames = 0;
+      }
+      return;
+    }
+    if (msg.type === "snapshot") {
+      // Update velocity cache + mirror, then resolve any pending
+      // request. Snapshot save is sync via getSimNodes(), but the
+      // explicit request path lets the IO layer pull a fresh copy
+      // (e.g. just before navigating away).
+      for (const sn of msg.nodes) {
+        const idx = idxById.get(sn.id);
+        if (idx === undefined) continue;
+        cachedVelocities[idx * 3 + 0] = sn.vx;
+        cachedVelocities[idx * 3 + 1] = sn.vy;
+        cachedVelocities[idx * 3 + 2] = sn.vz;
+        const mirror = simNodesMirror[idx]!;
+        mirror.x = sn.x;
+        mirror.y = sn.y;
+        mirror.z = sn.z;
+        mirror.vx = sn.vx;
+        mirror.vy = sn.vy;
+        mirror.vz = sn.vz;
+      }
+      if (
+        pendingSnapshotRequest &&
+        pendingSnapshotRequest.id === msg.requestId
+      ) {
+        pendingSnapshotRequest.resolve(msg.nodes);
+        pendingSnapshotRequest = null;
+      }
+    }
+  });
+
+  const idxById = new Map<string, number>(
+    graph.nodes.map((node, i) => [node.id, i]),
   );
 
-  let simNodes: SimNodes = [];
-  let simulation: ReturnType<typeof createSimulation>["simulation"];
-  let settledFrames = 0;
-
-  function simulationGraphFor(activeIds: Set<string> | null): TheiaGraph {
-    if (!activeIds) return graph;
-    return {
-      ...graph,
-      nodes: graph.nodes.filter((node) => activeIds.has(node.id)),
-      edges: graph.edges.filter(
-        (edge) => activeIds.has(edge.source) && activeIds.has(edge.target),
-      ),
-    };
+  function seedNodesFromMap(
+    seedPositions?: Map<string, PhysicsSnapshotNode>,
+  ): SeedNode[] | undefined {
+    if (!seedPositions || seedPositions.size === 0) return undefined;
+    const seeds: SeedNode[] = [];
+    for (const [id, p] of seedPositions) {
+      seeds.push({
+        id,
+        x: p.x,
+        y: p.y,
+        z: p.z,
+        vx: p.vx,
+        vy: p.vy,
+        vz: p.vz,
+      });
+    }
+    return seeds;
   }
 
-  function replaceActive(opts: ReplaceActiveOpts) {
-    const {
-      activeIds,
-      animateNew = false,
-      preserveExisting = true,
-      seedPositions = new Map<string, PhysicsSnapshotNode>(),
-    } = opts;
-
-    const oldPositions = new Map<
-      string,
-      { x: number; y: number; z: number; vx?: number; vy?: number; vz?: number }
-    >();
-    for (const sn of simNodes) {
-      if (sn) {
-        oldPositions.set(sn.id, {
-          x: sn.x,
-          y: sn.y,
-          z: sn.z,
-          vx: sn.vx,
-          vy: sn.vy,
-          vz: sn.vz,
-        });
-      }
-    }
-
-    simulation?.stop();
-    const simResult = createSimulation(
-      simulationGraphFor(activeIds),
-      kinds,
-      isOnboarding() ? "onboarding" : "normal",
-    );
-    simulation = simResult.simulation;
-    simulation.stop();
-
-    const nextNodes = new Array(graph.nodes.length) as SimNodes;
-    for (const sn of simResult.nodes) {
-      const idx = nodeIndex.get(sn.id);
-      if (idx === undefined) continue;
-      const old = preserveExisting ? oldPositions.get(sn.id) : undefined;
-      const seed = seedPositions.get(sn.id);
-      if (old || seed) {
-        const source = old ?? seed!;
-        sn.x = source.x;
-        sn.y = source.y;
-        sn.z = source.z;
-        sn.vx = source.vx ?? 0;
-        sn.vy = source.vy ?? 0;
-        sn.vz = source.vz ?? 0;
-      } else if (animateNew) {
-        const jitter = 0.08;
-        sn.x = sn.anchorX * 0.55 + hashN11(`${sn.id}:x`) * jitter;
-        sn.y = sn.anchorY * 0.55 + hashN11(`${sn.id}:y`) * jitter;
-        sn.z = sn.anchorZ * 0.55 + hashN11(`${sn.id}:z`) * jitter;
-        sn.vx = (sn.anchorX - sn.x) * 0.006;
-        sn.vy = (sn.anchorY - sn.y) * 0.006;
-        sn.vz = (sn.anchorZ - sn.z) * 0.006;
-        renderedPositions[idx * 3] = sn.x;
-        renderedPositions[idx * 3 + 1] = sn.y;
-        renderedPositions[idx * 3 + 2] = sn.z;
-        nodes.setPosition(idx, sn.x, sn.y, sn.z);
-      }
-      nextNodes[idx] = sn;
-    }
-    simNodes = nextNodes;
-    simulation.alpha(animateNew ? 0.22 : simulation.alphaTarget());
-    wakePhysics();
-  }
-
-  function wakePhysics() {
-    settledFrames = 0;
-    if (simulation && simulation.alpha() < WAKE_ALPHA) {
-      simulation.alpha(WAKE_ALPHA);
-    }
-  }
-
-  function syncRenderedPositionsFromSimulation() {
-    wakePhysics();
-    for (let i = 0; i < simNodes.length; i++) {
-      const sn = simNodes[i];
-      if (!sn) continue;
-      renderedPositions[i * 3] = sn.x;
-      renderedPositions[i * 3 + 1] = sn.y;
-      renderedPositions[i * 3 + 2] = sn.z;
-      nodes.setPosition(i, sn.x, sn.y, sn.z);
-    }
-    nodes.flush();
-    edges.updatePositions(nodePositions);
-  }
+  // Init the worker with the graph + initial active set (null = full).
+  send({
+    type: "init",
+    graph,
+    kinds: Array.from(kinds),
+    isOnboarding: isOnboarding(),
+  });
 
   function tick() {
     if (settledFrames >= SETTLED_THRESHOLD) return;
-    simulation.tick(1);
+    // Lerp renderedPositions toward targetPositions; write into
+    // nodePositions (the buffer NodeLayer reads) and into the matrix.
     const smoothing = isOnboarding() ? ONBOARDING_SMOOTHING : NORMAL_SMOOTHING;
     let maxDeltaSq = 0;
-    for (let i = 0; i < simNodes.length; i++) {
-      const sn = simNodes[i];
-      if (!sn) continue;
-      const px = renderedPositions[i * 3]!;
+    for (let i = 0; i < n; i++) {
+      const px = renderedPositions[i * 3 + 0]!;
       const py = renderedPositions[i * 3 + 1]!;
       const pz = renderedPositions[i * 3 + 2]!;
-      const dx = (sn.x - px) * smoothing;
-      const dy = (sn.y - py) * smoothing;
-      const dz = (sn.z - pz) * smoothing;
+      const tx = targetPositions[i * 3 + 0]!;
+      const ty = targetPositions[i * 3 + 1]!;
+      const tz = targetPositions[i * 3 + 2]!;
+      const dx = (tx - px) * smoothing;
+      const dy = (ty - py) * smoothing;
+      const dz = (tz - pz) * smoothing;
       const x = px + dx;
       const y = py + dy;
       const z = pz + dz;
       const deltaSq = dx * dx + dy * dy + dz * dz;
       if (deltaSq > maxDeltaSq) maxDeltaSq = deltaSq;
-      renderedPositions[i * 3] = x;
+      renderedPositions[i * 3 + 0] = x;
       renderedPositions[i * 3 + 1] = y;
       renderedPositions[i * 3 + 2] = z;
       nodes.setPosition(i, x, y, z);
@@ -204,18 +243,79 @@ export function createSimulationState(
     else settledFrames = 0;
   }
 
+  function wakePhysics() {
+    settledFrames = 0;
+    send({ type: "wake" });
+  }
+
+  function replaceActive(opts: ReplaceActiveOpts) {
+    const seedNodes = seedNodesFromMap(opts.seedPositions);
+    send({
+      type: "replaceActive",
+      activeIds: opts.activeIds ? Array.from(opts.activeIds) : null,
+      animateNew: opts.animateNew ?? false,
+      preserveExisting: opts.preserveExisting ?? true,
+      seedNodes,
+      isOnboarding: isOnboarding(),
+    });
+    settledFrames = 0;
+  }
+
+  function syncRenderedPositionsFromSimulation() {
+    // Snap the local rendered buffer to whatever target positions we
+    // currently know about. Used after snapshot restore / setupGraph
+    // to avoid an interpolated transition on first display.
+    for (let i = 0; i < n; i++) {
+      const tx = targetPositions[i * 3 + 0]!;
+      const ty = targetPositions[i * 3 + 1]!;
+      const tz = targetPositions[i * 3 + 2]!;
+      renderedPositions[i * 3 + 0] = tx;
+      renderedPositions[i * 3 + 1] = ty;
+      renderedPositions[i * 3 + 2] = tz;
+      nodes.setPosition(i, tx, ty, tz);
+    }
+    nodes.flush();
+    edges.updatePositions(nodePositions);
+    settledFrames = 0;
+  }
+
   function primeOnce() {
-    simulation.tick(1);
+    // No-op on the main side; the worker will produce position updates
+    // on its own schedule. Kept for API parity with the previous
+    // in-process implementation, where setupGraph used it to bake one
+    // tick of layout before the first display.
+    void workerReady;
   }
 
   function getNodePosition(idx: number) {
-    const sn = simNodes[idx];
-    if (!sn) return null;
-    return { x: sn.x, y: sn.y, z: sn.z };
+    if (idx < 0 || idx >= n) return null;
+    return {
+      x: targetPositions[idx * 3 + 0]!,
+      y: targetPositions[idx * 3 + 1]!,
+      z: targetPositions[idx * 3 + 2]!,
+    };
+  }
+
+  function getSimNodes(): SimNodes {
+    // Request a fresh snapshot in the background so the next save call
+    // sees updated velocities. Returns the mirror synchronously — its
+    // x/y/z are always current (updated on every positions message);
+    // vx/vy/vz lag until the snapshot response arrives.
+    snapshotRequestSeq++;
+    const id = snapshotRequestSeq;
+    pendingSnapshotRequest = {
+      id,
+      resolve: () => {
+        /* mirror is updated in-place by the message handler */
+      },
+    };
+    send({ type: "snapshotRequest", requestId: id });
+    return simNodesMirror;
   }
 
   function dispose() {
-    simulation?.stop();
+    send({ type: "dispose" });
+    worker.terminate();
   }
 
   return {
@@ -225,8 +325,7 @@ export function createSimulationState(
     syncRenderedPositionsFromSimulation,
     primeOnce,
     getNodePosition,
-    getSimNodes: () => simNodes,
+    getSimNodes,
     dispose,
   };
 }
-

--- a/theia-panel/src/state/simulation.ts
+++ b/theia-panel/src/state/simulation.ts
@@ -33,6 +33,12 @@ export interface SimulationStateDeps {
 export interface SimulationState {
   tick(): void;
   wakePhysics(): void;
+  /**
+   * Re-seed positions to anchors (with jitter) and re-run the simulation
+   * from alpha=1.0. Lets the user escape the layout produced by the
+   * initial seed without rebuilding the worker or graph.
+   */
+  optimize(): void;
   replaceActive(opts: ReplaceActiveOpts): void;
   syncRenderedPositionsFromSimulation(): void;
   primeOnce(): void;
@@ -248,6 +254,11 @@ export function createSimulationState(
     send({ type: "wake" });
   }
 
+  function optimize() {
+    settledFrames = 0;
+    send({ type: "relayout" });
+  }
+
   function replaceActive(opts: ReplaceActiveOpts) {
     const seedNodes = seedNodesFromMap(opts.seedPositions);
     send({
@@ -321,6 +332,7 @@ export function createSimulationState(
   return {
     tick,
     wakePhysics,
+    optimize,
     replaceActive,
     syncRenderedPositionsFromSimulation,
     primeOnce,

--- a/theia-panel/src/state/simulation.ts
+++ b/theia-panel/src/state/simulation.ts
@@ -1,0 +1,232 @@
+import { createSimulation } from "../physics/Simulation";
+import type { TheiaGraph } from "../data/types";
+import type { NodeLayer } from "../scene/Nodes";
+import type { EdgeLayer } from "../scene/Edges";
+import { hashN11 } from "../util/hash";
+import type { PhysicsSnapshotNode } from "./physicsSnapshot";
+
+type SimNodes = ReturnType<typeof createSimulation>["nodes"];
+
+export interface ReplaceActiveOpts {
+  activeIds: Set<string> | null;
+  animateNew?: boolean;
+  preserveExisting?: boolean;
+  seedPositions?: Map<string, PhysicsSnapshotNode>;
+}
+
+export interface SimulationStateDeps {
+  graph: TheiaGraph;
+  kinds: Set<string>;
+  /** True while onboarding is running (affects sim profile + lerp smoothing). */
+  isOnboarding: () => boolean;
+  /** Called once each tick after positions advance — caller flushes meshes. */
+  nodes: NodeLayer;
+  edges: EdgeLayer;
+  /** Shared with NodeLayer — sim writes node-space positions here each tick. */
+  nodePositions: Float32Array;
+}
+
+export interface SimulationState {
+  /** Advance the sim, lerp toward sim positions, flush meshes. No-op once settled. */
+  tick(): void;
+  /** Reset settle gate + bump alpha so filter/visibility changes re-equilibrate. */
+  wakePhysics(): void;
+  /** Rebuild simulation for a new active set (filters, focus, snapshot restore). */
+  replaceActive(opts: ReplaceActiveOpts): void;
+  /** Force renderedPositions/meshes to sim positions immediately (post-restore). */
+  syncRenderedPositionsFromSimulation(): void;
+  /** Run a single internal sim tick — used to settle initial layout before display. */
+  primeOnce(): void;
+  /** Read the current sim position of node by index (for camera focus, etc). */
+  getNodePosition(idx: number): { x: number; y: number; z: number } | null;
+  /** Snapshot input for physicsSnapshotIO.save. */
+  getSimNodes(): SimNodes;
+  dispose(): void;
+}
+
+// Settled-physics gate: skip the per-frame sim/lerp/edge-rewrite when the
+// layout has stabilised. The lerp drives matrix uploads and a full
+// edge-position attribute rewrite every frame; with 1.6k nodes that's
+// most of the per-frame cost once the simulation has converged.
+const SETTLED_THRESHOLD = 30;
+// Threshold ≈ 0.001² in world units — well below visible motion at any
+// reasonable zoom, since node sizes top out at 0.18 (see Nodes.ts).
+const SETTLE_EPSILON_SQ = 1e-6;
+// Energy injected on wake so filter/visibility changes actually produce
+// a visible re-equilibration. Without this, alpha sits at alphaTarget
+// (0.012, see Simulation.ts) which makes wake invisible — sub-pixel
+// motion that re-settles within a few ticks.
+const WAKE_ALPHA = 0.18;
+
+const ONBOARDING_SMOOTHING = 0.14;
+const NORMAL_SMOOTHING = 0.34;
+
+export function createSimulationState(
+  deps: SimulationStateDeps,
+): SimulationState {
+  const { graph, kinds, isOnboarding, nodes, edges, nodePositions } = deps;
+  const renderedPositions = new Float32Array(graph.nodes.length * 3);
+  const nodeIndex = new Map<string, number>(
+    graph.nodes.map((n, i) => [n.id, i]),
+  );
+
+  let simNodes: SimNodes = [];
+  let simulation: ReturnType<typeof createSimulation>["simulation"];
+  let settledFrames = 0;
+
+  function simulationGraphFor(activeIds: Set<string> | null): TheiaGraph {
+    if (!activeIds) return graph;
+    return {
+      ...graph,
+      nodes: graph.nodes.filter((node) => activeIds.has(node.id)),
+      edges: graph.edges.filter(
+        (edge) => activeIds.has(edge.source) && activeIds.has(edge.target),
+      ),
+    };
+  }
+
+  function replaceActive(opts: ReplaceActiveOpts) {
+    const {
+      activeIds,
+      animateNew = false,
+      preserveExisting = true,
+      seedPositions = new Map<string, PhysicsSnapshotNode>(),
+    } = opts;
+
+    const oldPositions = new Map<
+      string,
+      { x: number; y: number; z: number; vx?: number; vy?: number; vz?: number }
+    >();
+    for (const sn of simNodes) {
+      if (sn) {
+        oldPositions.set(sn.id, {
+          x: sn.x,
+          y: sn.y,
+          z: sn.z,
+          vx: sn.vx,
+          vy: sn.vy,
+          vz: sn.vz,
+        });
+      }
+    }
+
+    simulation?.stop();
+    const simResult = createSimulation(
+      simulationGraphFor(activeIds),
+      kinds,
+      isOnboarding() ? "onboarding" : "normal",
+    );
+    simulation = simResult.simulation;
+    simulation.stop();
+
+    const nextNodes = new Array(graph.nodes.length) as SimNodes;
+    for (const sn of simResult.nodes) {
+      const idx = nodeIndex.get(sn.id);
+      if (idx === undefined) continue;
+      const old = preserveExisting ? oldPositions.get(sn.id) : undefined;
+      const seed = seedPositions.get(sn.id);
+      if (old || seed) {
+        const source = old ?? seed!;
+        sn.x = source.x;
+        sn.y = source.y;
+        sn.z = source.z;
+        sn.vx = source.vx ?? 0;
+        sn.vy = source.vy ?? 0;
+        sn.vz = source.vz ?? 0;
+      } else if (animateNew) {
+        const jitter = 0.08;
+        sn.x = sn.anchorX * 0.55 + hashN11(`${sn.id}:x`) * jitter;
+        sn.y = sn.anchorY * 0.55 + hashN11(`${sn.id}:y`) * jitter;
+        sn.z = sn.anchorZ * 0.55 + hashN11(`${sn.id}:z`) * jitter;
+        sn.vx = (sn.anchorX - sn.x) * 0.006;
+        sn.vy = (sn.anchorY - sn.y) * 0.006;
+        sn.vz = (sn.anchorZ - sn.z) * 0.006;
+        renderedPositions[idx * 3] = sn.x;
+        renderedPositions[idx * 3 + 1] = sn.y;
+        renderedPositions[idx * 3 + 2] = sn.z;
+        nodes.setPosition(idx, sn.x, sn.y, sn.z);
+      }
+      nextNodes[idx] = sn;
+    }
+    simNodes = nextNodes;
+    simulation.alpha(animateNew ? 0.22 : simulation.alphaTarget());
+    wakePhysics();
+  }
+
+  function wakePhysics() {
+    settledFrames = 0;
+    if (simulation && simulation.alpha() < WAKE_ALPHA) {
+      simulation.alpha(WAKE_ALPHA);
+    }
+  }
+
+  function syncRenderedPositionsFromSimulation() {
+    wakePhysics();
+    for (let i = 0; i < simNodes.length; i++) {
+      const sn = simNodes[i];
+      if (!sn) continue;
+      renderedPositions[i * 3] = sn.x;
+      renderedPositions[i * 3 + 1] = sn.y;
+      renderedPositions[i * 3 + 2] = sn.z;
+      nodes.setPosition(i, sn.x, sn.y, sn.z);
+    }
+    nodes.flush();
+    edges.updatePositions(nodePositions);
+  }
+
+  function tick() {
+    if (settledFrames >= SETTLED_THRESHOLD) return;
+    simulation.tick(1);
+    const smoothing = isOnboarding() ? ONBOARDING_SMOOTHING : NORMAL_SMOOTHING;
+    let maxDeltaSq = 0;
+    for (let i = 0; i < simNodes.length; i++) {
+      const sn = simNodes[i];
+      if (!sn) continue;
+      const px = renderedPositions[i * 3]!;
+      const py = renderedPositions[i * 3 + 1]!;
+      const pz = renderedPositions[i * 3 + 2]!;
+      const dx = (sn.x - px) * smoothing;
+      const dy = (sn.y - py) * smoothing;
+      const dz = (sn.z - pz) * smoothing;
+      const x = px + dx;
+      const y = py + dy;
+      const z = pz + dz;
+      const deltaSq = dx * dx + dy * dy + dz * dz;
+      if (deltaSq > maxDeltaSq) maxDeltaSq = deltaSq;
+      renderedPositions[i * 3] = x;
+      renderedPositions[i * 3 + 1] = y;
+      renderedPositions[i * 3 + 2] = z;
+      nodes.setPosition(i, x, y, z);
+    }
+    nodes.flush();
+    edges.updatePositions(nodePositions);
+    if (maxDeltaSq < SETTLE_EPSILON_SQ) settledFrames++;
+    else settledFrames = 0;
+  }
+
+  function primeOnce() {
+    simulation.tick(1);
+  }
+
+  function getNodePosition(idx: number) {
+    const sn = simNodes[idx];
+    if (!sn) return null;
+    return { x: sn.x, y: sn.y, z: sn.z };
+  }
+
+  function dispose() {
+    simulation?.stop();
+  }
+
+  return {
+    tick,
+    wakePhysics,
+    replaceActive,
+    syncRenderedPositionsFromSimulation,
+    primeOnce,
+    getNodePosition,
+    getSimNodes: () => simNodes,
+    dispose,
+  };
+}
+

--- a/theia-panel/src/ui/FilterBar.ts
+++ b/theia-panel/src/ui/FilterBar.ts
@@ -58,6 +58,10 @@ export interface FilterBarOptions {
   initialFocusEnabled?: boolean;
   onSearchFocusToggle?: (enabled: boolean) => void;
   initialSearchFocusEnabled?: boolean;
+  onHideOrphansToggle?: (enabled: boolean) => void;
+  initialHideOrphansEnabled?: boolean;
+  onComponentFocusToggle?: (enabled: boolean) => void;
+  initialComponentFocusEnabled?: boolean;
 }
 
 export function createFilterBar(
@@ -75,6 +79,10 @@ export function createFilterBar(
     initialFocusEnabled,
     onSearchFocusToggle,
     initialSearchFocusEnabled,
+    onHideOrphansToggle,
+    initialHideOrphansEnabled,
+    onComponentFocusToggle,
+    initialComponentFocusEnabled,
   } = options;
   let theme = initialTheme;
   const bar = document.createElement("div");
@@ -86,6 +94,8 @@ export function createFilterBar(
   let showSearchToggle = false;
   let focusEnabled = initialFocusEnabled ?? false;
   let searchFocusEnabled = initialSearchFocusEnabled ?? false;
+  let hideOrphansEnabled = initialHideOrphansEnabled ?? false;
+  let componentFocusEnabled = initialComponentFocusEnabled ?? false;
 
   const btn = document.createElement("button");
   btn.textContent = "Filters";
@@ -297,6 +307,10 @@ export function createFilterBar(
   let focusCb: HTMLInputElement | null = null;
   let searchFocusToggleEl: HTMLLabelElement | null = null;
   let searchFocusCb: HTMLInputElement | null = null;
+  let hideOrphansToggleEl: HTMLLabelElement | null = null;
+  let hideOrphansCb: HTMLInputElement | null = null;
+  let componentFocusToggleEl: HTMLLabelElement | null = null;
+  let componentFocusCb: HTMLInputElement | null = null;
 
   function applyFocusToggleStyle() {
     if (!focusToggleEl || !focusCb) return;
@@ -327,6 +341,34 @@ export function createFilterBar(
     searchFocusCb.style.background = searchFocusEnabled
       ? `#${theme.accent}`
       : `#${theme.bg}`;
+  }
+
+  function applyPlainCheckboxStyle(
+    label: HTMLLabelElement | null,
+    cb: HTMLInputElement | null,
+    enabled: boolean,
+  ) {
+    if (!label || !cb) return;
+    label.style.color = enabled ? `#${theme.fg}` : `#${theme.fg2}`;
+    cb.style.borderColor = `#${theme.border}`;
+    cb.style.borderRadius = theme.radius;
+    cb.style.background = enabled ? `#${theme.accent}` : `#${theme.bg}`;
+  }
+
+  function applyHideOrphansToggleStyle() {
+    applyPlainCheckboxStyle(
+      hideOrphansToggleEl,
+      hideOrphansCb,
+      hideOrphansEnabled,
+    );
+  }
+
+  function applyComponentFocusToggleStyle() {
+    applyPlainCheckboxStyle(
+      componentFocusToggleEl,
+      componentFocusCb,
+      componentFocusEnabled,
+    );
   }
 
   function initFocusToggle() {
@@ -375,12 +417,68 @@ export function createFilterBar(
     content.append(searchFocusToggleEl);
   }
 
+  function initHideOrphansToggle() {
+    hideOrphansToggleEl = document.createElement("label");
+    hideOrphansToggleEl.style.cssText = `
+      display: flex; gap: 10px; align-items: center; cursor: pointer;
+      letter-spacing: 0.05em;
+    `;
+    hideOrphansCb = document.createElement("input");
+    hideOrphansCb.type = "checkbox";
+    hideOrphansCb.checked = hideOrphansEnabled;
+    hideOrphansCb.style.cssText = `
+      appearance: none; width: 14px; height: 14px; margin: 0; flex-shrink: 0;
+      border: 1px solid;
+      cursor: pointer; transition: background .15s, border-color .15s;
+    `;
+    hideOrphansCb.onchange = () => {
+      hideOrphansEnabled = hideOrphansCb!.checked;
+      applyHideOrphansToggleStyle();
+      onHideOrphansToggle?.(hideOrphansEnabled);
+    };
+    hideOrphansToggleEl.append(
+      hideOrphansCb,
+      document.createTextNode("Hide orphans"),
+    );
+    applyHideOrphansToggleStyle();
+    content.append(hideOrphansToggleEl);
+  }
+
+  function initComponentFocusToggle() {
+    componentFocusToggleEl = document.createElement("label");
+    componentFocusToggleEl.style.cssText = `
+      display: flex; gap: 10px; align-items: center; cursor: pointer;
+      letter-spacing: 0.05em;
+    `;
+    componentFocusCb = document.createElement("input");
+    componentFocusCb.type = "checkbox";
+    componentFocusCb.checked = componentFocusEnabled;
+    componentFocusCb.style.cssText = `
+      appearance: none; width: 14px; height: 14px; margin: 0; flex-shrink: 0;
+      border: 1px solid;
+      cursor: pointer; transition: background .15s, border-color .15s;
+    `;
+    componentFocusCb.onchange = () => {
+      componentFocusEnabled = componentFocusCb!.checked;
+      applyComponentFocusToggleStyle();
+      onComponentFocusToggle?.(componentFocusEnabled);
+    };
+    componentFocusToggleEl.append(
+      componentFocusCb,
+      document.createTextNode("Focus on component"),
+    );
+    applyComponentFocusToggleStyle();
+    content.append(componentFocusToggleEl);
+  }
+
   applyBarStyle();
   dropdown.appendChild(content);
   bar.append(btn, searchToggle, dropdown);
   rebuildModelSelect();
   initFocusToggle();
   if (onSearchFocusToggle) initSearchFocusToggle();
+  if (onHideOrphansToggle) initHideOrphansToggle();
+  if (onComponentFocusToggle) initComponentFocusToggle();
   container.appendChild(bar);
 
   function setSearchToggleVisible(visible: boolean) {
@@ -409,6 +507,22 @@ export function createFilterBar(
     applySearchFocusToggleStyle();
   }
 
+  function setHideOrphansEnabled(enabled: boolean) {
+    hideOrphansEnabled = enabled;
+    if (hideOrphansCb) {
+      hideOrphansCb.checked = enabled;
+    }
+    applyHideOrphansToggleStyle();
+  }
+
+  function setComponentFocusEnabled(enabled: boolean) {
+    componentFocusEnabled = enabled;
+    if (componentFocusCb) {
+      componentFocusCb.checked = enabled;
+    }
+    applyComponentFocusToggleStyle();
+  }
+
   function updateTheme(newTheme: ThemeTokens) {
     theme = newTheme;
     applyBarStyle();
@@ -416,6 +530,8 @@ export function createFilterBar(
     applySelectStyle();
     applyFocusToggleStyle();
     applySearchFocusToggleStyle();
+    applyHideOrphansToggleStyle();
+    applyComponentFocusToggleStyle();
   }
 
   return {
@@ -424,6 +540,8 @@ export function createFilterBar(
     setSearchToggleVisible,
     setFocusEnabled,
     setSearchFocusEnabled,
+    setHideOrphansEnabled,
+    setComponentFocusEnabled,
     dispose: () => {
       document.removeEventListener("pointerdown", onDocumentClick);
       container.removeChild(bar);

--- a/theia-panel/src/ui/Overlays.ts
+++ b/theia-panel/src/ui/Overlays.ts
@@ -92,6 +92,50 @@ export function createChainOverlay(
   };
 }
 
+export function createOptimizeOverlay(
+  element: HTMLElement,
+  theme: ThemeTokens,
+  onClick: () => void,
+): { remove(): void } {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.setAttribute("data-ui-overlay", "true");
+  btn.setAttribute("aria-label", "Optimize layout");
+  btn.textContent = "Optimize layout";
+  btn.style.cssText = `
+    position: absolute; bottom: 12px; right: 12px;
+    appearance: none; box-sizing: border-box;
+    padding: 8px 12px;
+    border: 1px solid #${theme.border};
+    background: ${themeBgAlpha(theme, 0.85)}; color: #${theme.fg};
+    font: 13px/1.4 var(--theia-font, ${FONT_STACK});
+    cursor: pointer; z-index: 13; backdrop-filter: blur(4px);
+    transition: border-color 100ms, color 100ms;
+  `;
+  btn.onmouseenter = () => {
+    btn.style.borderColor = `#${theme.accent}`;
+    btn.style.color = `#${theme.accent}`;
+  };
+  btn.onmouseleave = () => {
+    btn.style.borderColor = `#${theme.border}`;
+    btn.style.color = `#${theme.fg}`;
+  };
+  btn.onclick = (e) => {
+    e.stopPropagation();
+    onClick();
+  };
+  element.appendChild(btn);
+  return {
+    remove() {
+      try {
+        element.removeChild(btn);
+      } catch {
+        /* container may have been destroyed */
+      }
+    },
+  };
+}
+
 export function createOnboardingOverlay(element: HTMLElement): {
   update(progress: number): void;
   remove(): void;

--- a/theia-panel/src/ui/Overlays.ts
+++ b/theia-panel/src/ui/Overlays.ts
@@ -92,46 +92,128 @@ export function createChainOverlay(
   };
 }
 
-export function createOptimizeOverlay(
+export interface ControlsOverlayHandlers {
+  onOptimize: () => void;
+  onHome: () => void;
+  onJumpToggle: (enabled: boolean) => void;
+  initialJumpEnabled: boolean;
+}
+
+export interface ControlsOverlay {
+  remove(): void;
+  setJumpEnabled(enabled: boolean): void;
+}
+
+export function createControlsOverlay(
   element: HTMLElement,
   theme: ThemeTokens,
-  onClick: () => void,
-): { remove(): void } {
-  const btn = document.createElement("button");
-  btn.type = "button";
-  btn.setAttribute("data-ui-overlay", "true");
-  btn.setAttribute("aria-label", "Optimize layout");
-  btn.textContent = "Optimize layout";
-  btn.style.cssText = `
+  handlers: ControlsOverlayHandlers,
+): ControlsOverlay {
+  const bar = document.createElement("div");
+  bar.setAttribute("data-ui-overlay", "true");
+  bar.style.cssText = `
     position: absolute; bottom: 12px; right: 12px;
+    display: flex; align-items: stretch; gap: 6px;
+    z-index: 13;
+  `;
+
+  const baseButtonCss = `
     appearance: none; box-sizing: border-box;
-    padding: 8px 12px;
     border: 1px solid #${theme.border};
     background: ${themeBgAlpha(theme, 0.85)}; color: #${theme.fg};
     font: 13px/1.4 var(--theia-font, ${FONT_STACK});
-    cursor: pointer; z-index: 13; backdrop-filter: blur(4px);
-    transition: border-color 100ms, color 100ms;
+    cursor: pointer; backdrop-filter: blur(4px);
+    transition: border-color 100ms, color 100ms, background 100ms;
   `;
-  btn.onmouseenter = () => {
-    btn.style.borderColor = `#${theme.accent}`;
-    btn.style.color = `#${theme.accent}`;
-  };
-  btn.onmouseleave = () => {
-    btn.style.borderColor = `#${theme.border}`;
-    btn.style.color = `#${theme.fg}`;
-  };
-  btn.onclick = (e) => {
+
+  function styleHover(btn: HTMLButtonElement) {
+    btn.onmouseenter = () => {
+      if (btn.dataset.active === "true") return;
+      btn.style.borderColor = `#${theme.accent}`;
+      btn.style.color = `#${theme.accent}`;
+    };
+    btn.onmouseleave = () => {
+      if (btn.dataset.active === "true") return;
+      btn.style.borderColor = `#${theme.border}`;
+      btn.style.color = `#${theme.fg}`;
+    };
+  }
+
+  const optimize = document.createElement("button");
+  optimize.type = "button";
+  optimize.setAttribute("aria-label", "Optimize layout");
+  optimize.textContent = "Optimize layout";
+  optimize.style.cssText = baseButtonCss + `padding: 8px 12px;`;
+  styleHover(optimize);
+  optimize.onclick = (e) => {
     e.stopPropagation();
-    onClick();
+    handlers.onOptimize();
   };
-  element.appendChild(btn);
+
+  const home = document.createElement("button");
+  home.type = "button";
+  home.setAttribute("aria-label", "Reset to fitted view");
+  home.title = "Reset view";
+  home.textContent = "⌂";
+  home.style.cssText =
+    baseButtonCss +
+    `width: 36px; padding: 0; display: inline-flex;
+     align-items: center; justify-content: center;
+     font-size: 16px;`;
+  styleHover(home);
+  home.onclick = (e) => {
+    e.stopPropagation();
+    handlers.onHome();
+  };
+
+  const jump = document.createElement("button");
+  jump.type = "button";
+  jump.setAttribute("role", "switch");
+  jump.setAttribute("aria-label", "Jump to node on selection");
+  jump.title = "Jump to node on selection";
+  jump.textContent = "◎";
+  jump.style.cssText =
+    baseButtonCss +
+    `width: 36px; padding: 0; display: inline-flex;
+     align-items: center; justify-content: center;
+     font-size: 16px;`;
+  styleHover(jump);
+
+  function applyJumpState(enabled: boolean) {
+    jump.setAttribute("aria-checked", String(enabled));
+    jump.dataset.active = enabled ? "true" : "false";
+    if (enabled) {
+      jump.style.borderColor = `#${theme.accent}`;
+      jump.style.color = `#${theme.accent}`;
+      jump.style.background = themeBgAlpha(theme, 0.95);
+    } else {
+      jump.style.borderColor = `#${theme.border}`;
+      jump.style.color = `#${theme.fg2}`;
+      jump.style.background = themeBgAlpha(theme, 0.85);
+    }
+  }
+  applyJumpState(handlers.initialJumpEnabled);
+
+  jump.onclick = (e) => {
+    e.stopPropagation();
+    const next = jump.dataset.active !== "true";
+    applyJumpState(next);
+    handlers.onJumpToggle(next);
+  };
+
+  bar.append(optimize, home, jump);
+  element.appendChild(bar);
+
   return {
     remove() {
       try {
-        element.removeChild(btn);
+        element.removeChild(bar);
       } catch {
         /* container may have been destroyed */
       }
+    },
+    setJumpEnabled(enabled: boolean) {
+      applyJumpState(enabled);
     },
   };
 }

--- a/theia-panel/src/ui/Overlays.ts
+++ b/theia-panel/src/ui/Overlays.ts
@@ -7,7 +7,7 @@
  * have to be defined inside the panel's `mount()` closure.
  */
 
-import { FONT_STACK } from "./Theme";
+import { FONT_STACK, themeBgAlpha } from "./Theme";
 import type { ThemeTokens } from "./Theme";
 
 export function createLoadingOverlay(
@@ -48,12 +48,12 @@ export function createChainOverlay(
   const el = document.createElement("div");
   el.setAttribute("data-ui-overlay", "true");
   el.style.cssText = `
-    position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
+    position: absolute; bottom: 12px; left: 50%; transform: translateX(-50%);
     display: flex; align-items: center; gap: 10px;
-    padding: 6px 10px 6px 12px; border: 1px solid #${theme.border};
-    background: rgba(7,8,13,0.78); color: #${theme.fg};
-    font: 11px/1.2 var(--theia-font, ${FONT_STACK}); letter-spacing: 0.08em;
-    text-transform: uppercase; border-radius: ${theme.radius};
+    box-sizing: border-box; padding: 8px 12px;
+    border: 1px solid #${theme.border};
+    background: ${themeBgAlpha(theme, 0.85)}; color: #${theme.fg};
+    font: 13px/1.4 var(--theia-font, ${FONT_STACK});
     z-index: 13; cursor: default; backdrop-filter: blur(4px);
   `;
   const label = document.createElement("span");

--- a/theia-panel/src/ui/Overlays.ts
+++ b/theia-panel/src/ui/Overlays.ts
@@ -1,0 +1,124 @@
+/**
+ * Overlays — small DOM overlays composited above the 3D canvas.
+ *
+ * Each factory creates an absolutely-positioned `<div>` inside the panel
+ * container, exposes update/remove handles, and is otherwise self-contained.
+ * The container element is passed in explicitly so these factories don't
+ * have to be defined inside the panel's `mount()` closure.
+ */
+
+import { FONT_STACK } from "./Theme";
+import type { ThemeTokens } from "./Theme";
+
+export function createLoadingOverlay(
+  element: HTMLElement,
+  text: string,
+): { remove(): void } {
+  const el = document.createElement("div");
+  el.style.cssText = `
+    position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+    background: rgba(7,8,13,0.8); color: rgba(255,255,255,0.6);
+    font: 13px/1.4 var(--theia-font, ${FONT_STACK});
+    letter-spacing: 0.05em; z-index: 20; transition: opacity 300ms;
+  `;
+  el.textContent = text;
+  element.appendChild(el);
+  return {
+    remove() {
+      el.style.opacity = "0";
+      setTimeout(() => {
+        try {
+          element.removeChild(el);
+        } catch {
+          /* container may have been destroyed during load */
+        }
+      }, 300);
+    },
+  };
+}
+
+export function createChainOverlay(
+  element: HTMLElement,
+  theme: ThemeTokens,
+  onClear: () => void,
+): {
+  update(nodeCount: number, edgeCount: number, label: string): void;
+  remove(): void;
+} {
+  const el = document.createElement("div");
+  el.setAttribute("data-ui-overlay", "true");
+  el.style.cssText = `
+    position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
+    display: flex; align-items: center; gap: 10px;
+    padding: 6px 10px 6px 12px; border: 1px solid #${theme.border};
+    background: rgba(7,8,13,0.78); color: #${theme.fg};
+    font: 11px/1.2 var(--theia-font, ${FONT_STACK}); letter-spacing: 0.08em;
+    text-transform: uppercase; border-radius: ${theme.radius};
+    z-index: 13; cursor: default; backdrop-filter: blur(4px);
+  `;
+  const label = document.createElement("span");
+  el.appendChild(label);
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.textContent = "✕";
+  btn.setAttribute("aria-label", "Clear chain selection");
+  btn.style.cssText = `
+    appearance: none; border: 0; background: transparent; cursor: pointer;
+    color: #${theme.fg2}; font: inherit; padding: 0 2px; line-height: 1;
+  `;
+  btn.onmouseenter = () => {
+    btn.style.color = `#${theme.accent}`;
+  };
+  btn.onmouseleave = () => {
+    btn.style.color = `#${theme.fg2}`;
+  };
+  btn.onclick = (e) => {
+    e.stopPropagation();
+    onClear();
+  };
+  el.appendChild(btn);
+  element.appendChild(el);
+  return {
+    update(nodeCount, edgeCount, kindLabel) {
+      label.textContent = `chain · ${kindLabel} · ${nodeCount} node${nodeCount === 1 ? "" : "s"}, ${edgeCount} edge${edgeCount === 1 ? "" : "s"}`;
+    },
+    remove() {
+      try {
+        element.removeChild(el);
+      } catch {
+        /* container may have been destroyed */
+      }
+    },
+  };
+}
+
+export function createOnboardingOverlay(element: HTMLElement): {
+  update(progress: number): void;
+  remove(): void;
+} {
+  const el = document.createElement("div");
+  el.setAttribute("data-ui-overlay", "true");
+  el.style.cssText = `
+    position: absolute; left: 50%; bottom: 28px; transform: translateX(-50%);
+    color: rgba(255,255,255,0.58); font: 11px/1.2 var(--theia-font, ${FONT_STACK});
+    letter-spacing: 0.18em; text-transform: uppercase; z-index: 12;
+    pointer-events: none; text-align: center; transition: opacity 450ms;
+  `;
+  element.appendChild(el);
+  return {
+    update(progress) {
+      const pct = Math.max(0, Math.min(100, Math.round(progress * 100)));
+      el.textContent = `CREATING THE UNIVERSE - ${pct}%`;
+    },
+    remove() {
+      el.style.opacity = "0";
+      setTimeout(() => {
+        try {
+          element.removeChild(el);
+        } catch {
+          /* container may have been destroyed */
+        }
+      }, 450);
+    },
+  };
+}

--- a/theia-panel/src/ui/Overlays.ts
+++ b/theia-panel/src/ui/Overlays.ts
@@ -108,7 +108,7 @@ export function createOnboardingOverlay(element: HTMLElement): {
   return {
     update(progress) {
       const pct = Math.max(0, Math.min(100, Math.round(progress * 100)));
-      el.textContent = `CREATING THE UNIVERSE - ${pct}%`;
+      el.textContent = `CREATING YOUR CONSTELLATION - ${pct}%`;
     },
     remove() {
       el.style.opacity = "0";

--- a/theia-panel/src/ui/SearchBar.ts
+++ b/theia-panel/src/ui/SearchBar.ts
@@ -48,6 +48,31 @@ export function createSearchBar(
   let matchedCacheQuery = "";
   let matchedCacheIds: Set<string> | null = null;
 
+  // Pre-lowercase every searchable field once at construction. The hot
+  // path used to call .toLowerCase() five times per node per keystroke
+  // (~8k allocations + GC churn at 1.6k nodes); now it does a single
+  // lowercased query + plain `.includes()` against the cache.
+  const lcTitle = new Array<string>(graph.nodes.length);
+  const lcId = new Array<string>(graph.nodes.length);
+  const lcPreview = new Array<string>(graph.nodes.length);
+  const lcSummary = new Array<string>(graph.nodes.length);
+  const lcInitialPrompt = new Array<string>(graph.nodes.length);
+  for (let i = 0; i < graph.nodes.length; i++) {
+    const node = graph.nodes[i]!;
+    lcTitle[i] = (node.title ?? "").toLowerCase();
+    lcId[i] = node.id.toLowerCase();
+    lcPreview[i] = (node.preview ?? "").toLowerCase();
+    lcSummary[i] = (node.summary ?? "").toLowerCase();
+    lcInitialPrompt[i] = (node.initial_prompt ?? "").toLowerCase();
+  }
+
+  // Cap the rendered dropdown — short queries can match hundreds of
+  // nodes, and rendering them all (with per-item event listeners and
+  // innerHTML rewrites) is what the user perceives as input lag. The
+  // matchedCacheIds set still tracks the FULL match list for the
+  // search-focus filter; only the visible UI is capped.
+  const MAX_VISIBLE_RESULTS = 50;
+
   function applyWrapperStyle() {
     wrapper.style.cssText = `
       position: absolute; top: 12px; right: calc((100% - min(320px, 50vw)) / 2); transform: none;
@@ -129,18 +154,13 @@ export function createSearchBar(
     selectedIndex = -1;
   }
 
-  function normalize(s: string) {
-    return s.toLowerCase();
-  }
-
-  function matches(node: TheiaGraph["nodes"][number], query: string) {
-    const q = normalize(query);
+  function matchesIndex(i: number, lcQuery: string): boolean {
     return (
-      normalize(node.title || "").includes(q) ||
-      normalize(node.id).includes(q) ||
-      (node.preview && normalize(node.preview).includes(q)) ||
-      (node.summary && normalize(node.summary).includes(q)) ||
-      (node.initial_prompt && normalize(node.initial_prompt).includes(q))
+      lcTitle[i]!.includes(lcQuery) ||
+      lcId[i]!.includes(lcQuery) ||
+      lcPreview[i]!.includes(lcQuery) ||
+      lcSummary[i]!.includes(lcQuery) ||
+      lcInitialPrompt[i]!.includes(lcQuery)
     );
   }
 
@@ -156,20 +176,22 @@ export function createSearchBar(
       matchedCacheIds = new Set();
       return;
     }
-    const resultByIndex = new Map<number, SearchResult>();
+    const lcQuery = query.toLowerCase();
     const matchedIds = new Set<string>();
+    const visibleResults: SearchResult[] = [];
     for (let i = 0; i < graph.nodes.length; i++) {
+      if (!matchesIndex(i, lcQuery)) continue;
       const node = graph.nodes[i]!;
-      if (matches(node, query)) {
-        matchedIds.add(node.id);
+      matchedIds.add(node.id);
+      if (visibleResults.length < MAX_VISIBLE_RESULTS) {
         if (!isVisible || isVisible(node)) {
-          resultByIndex.set(i, { node, index: i });
+          visibleResults.push({ node, index: i });
         }
       }
     }
     matchedCacheQuery = query.trim();
     matchedCacheIds = matchedIds;
-    currentResults = Array.from(resultByIndex.values());
+    currentResults = visibleResults;
     if (currentResults.length === 0) {
       dropdown.innerHTML = `<div style="padding:12px;opacity:0.4;font-size:12px;text-align:center;color:#${theme.fg2}">No results found</div>`;
       dropdown.style.display = "block";
@@ -195,22 +217,33 @@ export function createSearchBar(
         .join("");
     dropdown.style.display = "block";
     selectedIndex = -1;
-
-    for (const el of dropdown.querySelectorAll<HTMLElement>(".search-item")) {
-      el.addEventListener("mouseenter", () => {
-        const ri = Number(el.dataset.resultIndex);
-        select(ri);
-      });
-      el.addEventListener("mouseleave", () => {
-        el.style.background = "transparent";
-      });
-      el.addEventListener("mousedown", (e) => {
-        e.preventDefault();
-        const ri = Number(el.dataset.resultIndex);
-        commit(ri);
-      });
-    }
+    // Per-item listeners are attached once at construction via event
+    // delegation (see below) — re-rendering the dropdown HTML on every
+    // keystroke used to attach 3 listeners per result, which was a
+    // measurable chunk of input-lag time at 50+ results.
   }
+
+  function findItemRowFromEvent(e: Event): HTMLElement | null {
+    let el = e.target as HTMLElement | null;
+    while (el && el !== dropdown) {
+      if (el.classList?.contains("search-item")) return el;
+      el = el.parentElement;
+    }
+    return null;
+  }
+  dropdown.addEventListener("mouseover", (e) => {
+    const el = findItemRowFromEvent(e);
+    if (!el) return;
+    const ri = Number(el.dataset.resultIndex);
+    if (Number.isFinite(ri)) select(ri);
+  });
+  dropdown.addEventListener("mousedown", (e) => {
+    const el = findItemRowFromEvent(e);
+    if (!el) return;
+    e.preventDefault();
+    const ri = Number(el.dataset.resultIndex);
+    if (Number.isFinite(ri)) commit(ri);
+  });
 
   input.addEventListener("input", () => {
     selectedIndex = -1;
@@ -262,10 +295,10 @@ export function createSearchBar(
       return new Set(matchedCacheIds);
     }
     const ids = new Set<string>();
+    const lcQuery = normalizedQuery.toLowerCase();
     for (let i = 0; i < graph.nodes.length; i++) {
-      const node = graph.nodes[i]!;
-      if (matches(node, normalizedQuery)) {
-        ids.add(node.id);
+      if (matchesIndex(i, lcQuery)) {
+        ids.add(graph.nodes[i]!.id);
       }
     }
     matchedCacheQuery = normalizedQuery;

--- a/theia-panel/tsconfig.json
+++ b/theia-panel/tsconfig.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "vite/client"],
     "isolatedModules": true,
     "noEmit": true
   },

--- a/theia-panel/vite.config.embed.ts
+++ b/theia-panel/vite.config.embed.ts
@@ -16,10 +16,13 @@ export default defineConfig({
       // Split heavy deps into separate chunks so each stays <500 kB.
       // The browser fetches them in parallel on first load and caches
       // them independently — three.js rarely changes between releases.
+      // d3-force-3d is intentionally NOT chunked here — it's only
+      // imported by the physics worker (src/physics/Simulation.ts via
+      // SimulationWorker.ts), which Vite emits as its own chunk
+      // automatically.
       output: {
         manualChunks: {
           three: ["three"],
-          "d3-force": ["d3-force-3d"],
         },
       },
     },

--- a/theia-panel/vite.config.ts
+++ b/theia-panel/vite.config.ts
@@ -53,4 +53,15 @@ export default defineConfig(({ command }) => ({
     },
     rollupOptions: { external: ["three", "d3-force-3d"] },
   },
+  // The lib build externalizes d3-force-3d so the host can dedupe it,
+  // but the physics worker has no access to the host's import map and
+  // would fail on a bare module specifier. Bundle d3-force-3d into the
+  // worker chunk; three isn't used in the worker so we still externalize
+  // it (size hygiene only).
+  worker: {
+    format: "es",
+    rollupOptions: {
+      external: ["three"],
+    },
+  },
 }));


### PR DESCRIPTION
## Summary

Rolls 57 commits from \`dev\` up to \`main\`. Highlights:

**Layout & view controls**
- New **Optimize layout** button — re-tunes force simulation (charge / cluster / anchor) and re-converges in place, scaled by node count.
- New **Home** button — animates camera back to fitted view (origin target, default zoom, front-on rotation).
- New **Jump-to-node** toggle — gates camera focus on every selection path (search, side panel, direct click).

**Onboarding**
- Per-node ease-in on wall-clock, replacing group warmup + supernova burst.
- Adaptive pop duration from spawn interval.
- Piecewise reveal cadence (linear for first ~16 nodes, then t²).
- Worker rebuild throttling + skip-settled to cut stutter.
- Slow easeQuadInOut warmup before main reveal.
- Progressive zoom-out during reveal.

**Camera**
- Adapt near/far clip planes to orbit radius (fixes far-side clipping).
- Fix pan/rotate clipping, slow-pan tuning, invert W/S keys.

**Aesthetic**
- OFGKM stellar-classification node color gradient.
- Supernova: 10% nodes pop in one burst, rest easeInOutCubic.
- Chain overlay moved to bottom, styled to match search bar.

## Test plan
- [x] Smoke test: load default graph, verify nodes/edges render and forces settle.
- [x] Optimize layout: click button, layout reorganizes without blow-out at small + large node counts.
- [x] Home button: pan/rotate/zoom around, click ⌂, camera eases back to origin/front-on.
- [ ] Jump-to-node: toggle off, click a node — selection happens, camera stays put. Toggle on — camera animates onto node.
- [ ] Onboarding (clear localStorage first): reveal animation completes smoothly, no stutter spikes.
- [x] Filter bar / chain selection / side panel still work.
- [x] Pan/rotate with mouse + WASD keys behaves correctly, no clipping at extreme zoom.