### PR TITLE
style(core): ruff format topology.py

### DIFF
--- a/theia-core/theia_core/detect/topology.py
+++ b/theia-core/theia_core/detect/topology.py
@@ -154,9 +154,7 @@ def _subagent_tree_metrics(
     return depth, desc
 
 
-def _cron_sequence_ids(
-    node_ids: set[str], edges: list[Edge]
-) -> dict[str, int | None]:
+def _cron_sequence_ids(node_ids: set[str], edges: list[Edge]) -> dict[str, int | None]:
     """Group cron-chain edges with gap ≤ 48h into connected sequences."""
     cron_adj: dict[str, set[str]] = {nid: set() for nid in node_ids}
     for e in edges:
@@ -197,9 +195,7 @@ def _cron_sequence_ids(
     return out
 
 
-def detect_topology(
-    sessions: list[Session], edges: list[Edge]
-) -> dict[str, dict[str, Any]]:
+def detect_topology(sessions: list[Session], edges: list[Edge]) -> dict[str, dict[str, Any]]:
     """Compute per-node topology metadata.
 
     Returns a mapping ``{node_id: metadata_dict}`` where every value contains

--- a/theia-core/uv.lock
+++ b/theia-core/uv.lock
@@ -678,7 +678,7 @@ wheels = [
 
 [[package]]
 name = "theia-core"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Summary
- Fixes the dev→main CI failure: \`ruff format --check\` flagged \`theia_core/detect/topology.py\` (PR #102 was failing on this).
- Drive-by sync of \`theia-core/uv.lock\` (was at 0.0.1, pyproject is 0.1.0) — uv re-resolved when running ruff under uvx.

## Test plan
- [x] \`uvx ruff format --check .\` from \`theia-core/\` reports "28 files already formatted".