### PR TITLE
docs: changelog for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,115 @@ Dates use ISO 8601.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-04
+
+Layout, view-control, and onboarding-polish window. Adds three
+bottom-right controls (Optimize layout, Home, Jump-to-node), reworks
+the onboarding reveal so it no longer stutters, retunes node colors
+to a stellar classification ramp, and fixes several camera issues.
+
+### Added
+- **Optimize layout button.** Bottom-right control that re-converges
+  the force simulation in place. The worker handler (`relayout`) tunes
+  the existing forces — boosts cluster pull, mildly lifts many-body
+  repulsion (scaled by active node count: ~-0.046 at N=100, ~-0.07 at
+  N=1000, capped at -0.075), and softens the anchor pull from 0.14 to
+  0.06 — then bumps alpha to 1.0. Nodes redistribute toward better
+  spacing and tighter neighbor groups without re-randomizing.
+  *(`physics/SimulationWorker.ts` `applyRelayout`, `physics/Simulation.ts`
+  strength setters on `forceAnchor`/`forceCluster`,
+  `state/simulation.ts` `optimize()`, `ui/Overlays.ts`
+  `createControlsOverlay`.)*
+- **Home button (⌂).** Animates the camera back to the initial fitted
+  view — origin target, default zoom 0.5, front-on rotation — over
+  700 ms with the same cubic easing as `focusOn`. Backed by a new
+  `ctx.resetView()` on `SceneContext`. *(`scene/Scene.ts` `resetView`,
+  `ui/Overlays.ts`.)*
+- **Jump-to-node toggle (◎).** Default on. Gates camera focus on
+  every selection path: search-result picks, side-panel navigation,
+  and direct 3D clicks. Off keeps the camera put while still
+  selecting + opening the side panel. In-memory only (no
+  persistence). *(`index.ts` gating around the three `focusOn`
+  callsites; `ui/Overlays.ts` `applyJumpState`.)*
+- **OFGKM stellar-classification node color gradient.** Replaces the
+  prior B/A/F intermediate stops with the textbook OFGKM stops
+  (Blue / White / Yellow / Orange / Red) plus a dark-red final stop
+  for the oldest origin nodes. Date → spectral class mapping reads
+  more cleanly. *(`scene/Nodes.ts`.)*
+- **Progressive zoom-out during onboarding.** Camera widens as more
+  nodes appear so the constellation stays fully visible through the
+  reveal. Pairs with the slower onboarding cadence and reduced
+  supernova burst. *(`state/onboarding.ts`.)*
+- **Slow easeQuadInOut warmup before main onboarding reveal.** The
+  first dozen-or-so nodes ease in on a wider curve before the bulk
+  reveal kicks in, so the opening doesn't feel abrupt.
+  *(`state/onboarding.ts`.)*
+- **Adaptive pop duration from spawn interval.** The per-node pop
+  scales its duration to the current spawn interval, so cadence and
+  pop length stay coherent as group rates change.
+  *(`state/onboarding.ts`.)*
+
+### Changed
+- **Onboarding reveal rewritten around per-node wall-clock easing.**
+  Drops the group-warmup + supernova-burst layering in favor of a
+  single per-node ease-in driven by wall-clock time. Adds piecewise
+  reveal cadence — first ~16 nodes at the original pace, then t²
+  ramp — and a 24 s cap. The previous design scheduled large groups
+  per frame and stuttered on the heaviest reveals.
+  *(`state/onboarding.ts`.)*
+- **Chain overlay moved to bottom-center, restyled to match the
+  search bar.** Same border / background-alpha / blur tokens as the
+  search input, lower z-conflict with the filter dropdown.
+  *(`ui/Overlays.ts` `createChainOverlay`.)*
+- **Onboarding extracted to `state/onboarding.ts`.** Pulls the
+  reveal/zoom/burst logic out of `index.ts` into a focused module
+  with `createOnboarding`, `hasCompletedOnboarding`, and an
+  `OnboardingController` interface. Pure restructuring; no behavior
+  change in that commit. *(`state/onboarding.ts`, `index.ts`.)*
+- **Search dropdown perf: pre-lowercased fields, capped visible
+  results, delegated listeners.** Pre-lowercases title/id/preview/
+  summary/initial-prompt once at construction; the matching path now
+  does a single lowercased query + `.includes()` instead of five
+  `.toLowerCase()` calls per node per keystroke. Visible dropdown
+  capped at 50 entries — match cache still tracks the full set for
+  the search-focus filter. *(`ui/SearchBar.ts`.)*
+- **Optimize-layout-button styling for `createControlsOverlay`.**
+  The standalone optimize overlay was replaced by a unified flex bar
+  hosting all three controls, so they share alignment, gap, and
+  hover treatment. *(`ui/Overlays.ts`.)*
+
+### Fixed
+- **Camera near/far adapted to orbit radius.** Far-side nodes used
+  to clip when zoomed in; close ones clipped when zoomed out. Near
+  is now `radius * 0.01` (min 0.01) and far is `radius +
+  SCENE_EXTENT`, recomputed inside `updateCamera()`. *(`scene/Scene.ts`.)*
+- **Rotation clipping, slow pan, inverted W/S keys.** Several
+  camera-control issues bundled — rotation no longer clamps mid-
+  motion, pan speed is corrected, and the WASD bindings match
+  on-screen orientation. *(`scene/KeyboardNav.ts`, `scene/Scene.ts`.)*
+- **Jump-to-node toggle now affects direct 3D clicks.** The first
+  cut only gated `focusOn` on search results and side-panel
+  navigation; direct clicks never called `focusOn` at all, making
+  the toggle look broken from the user's most common interaction
+  path. *(`index.ts` `runTapSelection`.)*
+- **Onboarding stutter on heavy reveals.** Throttles the worker
+  rebuild on incremental reveals, skips no-op (already-settled)
+  nodes, marks newly added nodes visible immediately while only
+  deferring the heavy rebuild, and snaps `popScale` to 1 on the
+  reveal frame so the first frame doesn't hide the node behind a
+  zero-scale matrix. *(`state/onboarding.ts`.)*
+- **Visible first-node pop, quadratic group rate, 24 s cap.**
+  Resolves a regression where the very first reveal frame hid the
+  hero node, plus tunes the group rate to a quadratic curve and
+  caps total reveal time at 24 s on large graphs.
+  *(`state/onboarding.ts`.)*
+- **Supernova burst tuning.** 10 % of revealed nodes burst in one
+  frame, the remainder ease in on `easeInOutCubic`, balancing
+  visual punch against the stutter the all-burst version produced.
+  *(`state/onboarding.ts`.)*
+- **`ruff format` on `theia_core/detect/topology.py`.** Unblocks the
+  release workflow's lint step.
+
 ## [0.1.0] - 2026-05-03
 
 First tagged release. Pulls together the chain-isolation, keyboard-nav,
@@ -77,5 +186,6 @@ window.
   separately)* — these landed during the same window through other PRs and
   are listed here for completeness; see `git log` for primary authorship.
 
-[Unreleased]: https://github.com/arm64be/theia/compare/v0.1.0...dev
+[Unreleased]: https://github.com/arm64be/theia/compare/v0.2.0...dev
+[0.2.0]: https://github.com/arm64be/theia/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/arm64be/theia/compare/19b71cc...v0.1.0


### PR DESCRIPTION
## Summary
Populates \`CHANGELOG.md\` for the upcoming \`v0.2.0\` tag.

Window since \`v0.1.0\` (2026-05-03):
- **Added** — Optimize layout button, Home (⌂), Jump-to-node toggle (◎), OFGKM stellar color gradient, progressive zoom-out + slow easeQuadInOut warmup during onboarding, adaptive pop duration.
- **Changed** — onboarding reveal rewritten around per-node wall-clock easing, chain overlay restyled, search-dropdown perf, controls overlay refactor.
- **Fixed** — camera near/far adapted to orbit radius, rotation/pan/key bugs, jump-to-node toggle wired to direct clicks, onboarding stutter, supernova burst tuning, ruff format on \`topology.py\`.

Tag plan: once #102 (\`dev\` → \`main\`) lands and this CHANGELOG entry is merged, cut \`v0.2.0\` from \`main\` to fire \`release.yml\`.

## Test plan
- [x] \`grep "^## " CHANGELOG.md\` shows three sections: Unreleased / 0.2.0 / 0.1.0.
- [x] Reference links at the bottom resolve to compare URLs.
- [ ] Optional: glance through entries against \`git log v0.1.0..origin/dev\` to confirm coverage.